### PR TITLE
Refactor analytics to use Effect-based service layer

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -50,6 +50,7 @@
     "lucide-react": "^0.544.0",
     "motion": "^12.23.22",
     "posthog-js": "^1.297.2",
+    "effect": "^3.19.15",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-hook-form": "^7.64.0",

--- a/apps/www/src/hooks/useAnalytics.ts
+++ b/apps/www/src/hooks/useAnalytics.ts
@@ -1,0 +1,156 @@
+import { useCallback, useEffect } from 'react'
+import { Effect } from 'effect'
+import {
+  AnalyticsService,
+  runAnalytics,
+  type EventProperties,
+  type UserProperties
+} from '@/services/analytics'
+
+/**
+ * Hook for tracking analytics events in React components
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { track, identify } = useAnalytics()
+ *
+ *   const handleClick = () => {
+ *     track('button_clicked', { button_name: 'submit' })
+ *   }
+ *
+ *   return <button onClick={handleClick}>Submit</button>
+ * }
+ * ```
+ */
+export function useAnalytics() {
+  const track = useCallback(
+    (eventName: string, properties?: EventProperties) => {
+      runAnalytics(
+        Effect.gen(function* () {
+          const analytics = yield* AnalyticsService
+          yield* analytics.track(eventName, properties)
+        })
+      )
+    },
+    []
+  )
+
+  const identify = useCallback(
+    (userId: string, properties?: UserProperties) => {
+      runAnalytics(
+        Effect.gen(function* () {
+          const analytics = yield* AnalyticsService
+          yield* analytics.identify(userId, properties)
+        })
+      )
+    },
+    []
+  )
+
+  const reset = useCallback(() => {
+    runAnalytics(
+      Effect.gen(function* () {
+        const analytics = yield* AnalyticsService
+        yield* analytics.reset()
+      })
+    )
+  }, [])
+
+  const pageView = useCallback(
+    (pageName?: string, properties?: EventProperties) => {
+      runAnalytics(
+        Effect.gen(function* () {
+          const analytics = yield* AnalyticsService
+          yield* analytics.pageView(pageName, properties)
+        })
+      )
+    },
+    []
+  )
+
+  const setUserProperties = useCallback((properties: UserProperties) => {
+    runAnalytics(
+      Effect.gen(function* () {
+        const analytics = yield* AnalyticsService
+        yield* analytics.setUserProperties(properties)
+      })
+    )
+  }, [])
+
+  const optOut = useCallback(() => {
+    runAnalytics(
+      Effect.gen(function* () {
+        const analytics = yield* AnalyticsService
+        yield* analytics.optOut()
+      })
+    )
+  }, [])
+
+  const optIn = useCallback(() => {
+    runAnalytics(
+      Effect.gen(function* () {
+        const analytics = yield* AnalyticsService
+        yield* analytics.optIn()
+      })
+    )
+  }, [])
+
+  return {
+    track,
+    identify,
+    reset,
+    pageView,
+    setUserProperties,
+    optOut,
+    optIn
+  }
+}
+
+/**
+ * Hook for tracking page views on route changes
+ * Use this in your root layout or router component
+ *
+ * @example
+ * ```tsx
+ * function RootLayout() {
+ *   usePageViewTracking()
+ *   return <Outlet />
+ * }
+ * ```
+ */
+export function usePageViewTracking(pageName?: string) {
+  const { pageView } = useAnalytics()
+
+  useEffect(() => {
+    pageView(pageName)
+  }, [pageName, pageView])
+}
+
+/**
+ * Hook to identify user when they log in
+ * Automatically resets analytics when user logs out
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   const user = useAuthStore((s) => s.user)
+ *   useIdentifyUser(user?.id, { email: user?.email, name: user?.name })
+ *   return <Router />
+ * }
+ * ```
+ */
+export function useIdentifyUser(
+  userId: string | null | undefined,
+  properties?: UserProperties
+) {
+  const { identify, reset } = useAnalytics()
+
+  useEffect(() => {
+    if (userId) {
+      identify(userId, properties)
+    } else {
+      reset()
+    }
+  }, [userId, identify, reset, properties])
+}

--- a/apps/www/src/main.tsx
+++ b/apps/www/src/main.tsx
@@ -5,11 +5,12 @@ import { createRoot } from 'react-dom/client'
 import { MAIN_SCROLL_CONTAINER_ID } from './lib/constants'
 import { routeTree } from './routeTree.gen'
 import './styles/main.css'
-import { PostHogProvider } from 'posthog-js/react'
 import { ThemeProvider } from './components/ThemeProvider'
-import { env } from './env'
 import { useAuthSync } from './hooks/useAuthSync'
+import { useIdentifyUser } from './hooks/useAnalytics'
 import { useAuthStore } from './store/auth'
+// Initialize analytics runtime (side-effect import)
+import '@/services/analytics/runtime'
 
 const router = createRouter({
   routeTree,
@@ -44,6 +45,12 @@ function App() {
   const auth = useAuthStore()
   useAuthSync()
 
+  // Identify user for analytics when authenticated
+  useIdentifyUser(auth.user?.id, {
+    email: auth.user?.email,
+    name: auth.user?.name
+  })
+
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme='dark' storageKey='vite-ui-theme'>
@@ -60,16 +67,7 @@ if (container) {
 
   root.render(
     <React.StrictMode>
-      <PostHogProvider
-        apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_KEY}
-        options={{
-          api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
-          defaults: '2025-05-24',
-          capture_exceptions: true, // This enables capturing exceptions using Error Tracking, set to false if you don't want this
-          debug: env.isDev
-        }}>
-        <App />
-      </PostHogProvider>
+      <App />
     </React.StrictMode>
   )
 } else {

--- a/apps/www/src/services/analytics/analytics.service.ts
+++ b/apps/www/src/services/analytics/analytics.service.ts
@@ -1,0 +1,115 @@
+import { Context, Effect, Layer } from 'effect'
+
+/**
+ * Analytics event properties - flexible key-value pairs
+ */
+export type EventProperties = Record<string, unknown>
+
+/**
+ * User properties for identification
+ */
+export interface UserProperties {
+  email?: string
+  name?: string
+  [key: string]: unknown
+}
+
+/**
+ * Analytics service interface - provider-agnostic abstraction
+ *
+ * This interface defines the contract for analytics operations.
+ * Implementations can be swapped (PostHog, Sentry, Mixpanel, etc.)
+ * without changing the consuming code.
+ */
+export interface AnalyticsService {
+  /**
+   * Track a custom event
+   */
+  readonly track: (
+    eventName: string,
+    properties?: EventProperties
+  ) => Effect.Effect<void>
+
+  /**
+   * Identify a user with optional properties
+   */
+  readonly identify: (
+    userId: string,
+    properties?: UserProperties
+  ) => Effect.Effect<void>
+
+  /**
+   * Reset the current user (on logout)
+   */
+  readonly reset: () => Effect.Effect<void>
+
+  /**
+   * Track a page view
+   */
+  readonly pageView: (
+    pageName?: string,
+    properties?: EventProperties
+  ) => Effect.Effect<void>
+
+  /**
+   * Set user properties without identifying
+   */
+  readonly setUserProperties: (
+    properties: UserProperties
+  ) => Effect.Effect<void>
+
+  /**
+   * Register super properties (sent with every event)
+   */
+  readonly registerSuperProperties: (
+    properties: EventProperties
+  ) => Effect.Effect<void>
+
+  /**
+   * Opt user out of tracking
+   */
+  readonly optOut: () => Effect.Effect<void>
+
+  /**
+   * Opt user back into tracking
+   */
+  readonly optIn: () => Effect.Effect<void>
+
+  /**
+   * Check if user has opted out
+   */
+  readonly hasOptedOut: () => Effect.Effect<boolean>
+
+  /**
+   * Start a session recording (if supported)
+   */
+  readonly startSessionRecording: () => Effect.Effect<void>
+
+  /**
+   * Stop session recording (if supported)
+   */
+  readonly stopSessionRecording: () => Effect.Effect<void>
+}
+
+/**
+ * Analytics service tag for Effect dependency injection
+ */
+export const AnalyticsService =
+  Context.GenericTag<AnalyticsService>('AnalyticsService')
+
+/**
+ * No-op analytics implementation for testing or when analytics is disabled
+ */
+export const AnalyticsServiceNoop = Layer.succeed(AnalyticsService, {
+  track: () => Effect.void,
+  identify: () => Effect.void,
+  reset: () => Effect.void,
+  pageView: () => Effect.void,
+  setUserProperties: () => Effect.void,
+  registerSuperProperties: () => Effect.void,
+  optOut: () => Effect.void,
+  optIn: () => Effect.void,
+  hasOptedOut: () => Effect.succeed(false),
+  startSessionRecording: () => Effect.void,
+  stopSessionRecording: () => Effect.void
+})

--- a/apps/www/src/services/analytics/index.ts
+++ b/apps/www/src/services/analytics/index.ts
@@ -1,0 +1,19 @@
+export {
+  AnalyticsService,
+  AnalyticsServiceNoop,
+  type EventProperties,
+  type UserProperties
+} from './analytics.service'
+
+export {
+  PostHogAnalyticsLive,
+  makePostHogAnalyticsService,
+  type PostHogConfig
+} from './posthog.provider'
+
+export {
+  AnalyticsLive,
+  AnalyticsRuntime,
+  runAnalytics,
+  runAnalyticsAsync
+} from './runtime'

--- a/apps/www/src/services/analytics/posthog.provider.ts
+++ b/apps/www/src/services/analytics/posthog.provider.ts
@@ -1,0 +1,108 @@
+import { Effect, Layer } from 'effect'
+import posthog from 'posthog-js'
+import {
+  AnalyticsService,
+  type EventProperties,
+  type UserProperties
+} from './analytics.service'
+
+/**
+ * PostHog configuration options
+ */
+export interface PostHogConfig {
+  apiKey: string
+  apiHost?: string
+  debug?: boolean
+  captureExceptions?: boolean
+  autocapture?: boolean
+  disableSessionRecording?: boolean
+}
+
+/**
+ * Creates a PostHog implementation of the Analytics service
+ */
+export const makePostHogAnalyticsService = (
+  config: PostHogConfig
+): AnalyticsService => {
+  // Initialize PostHog if not already initialized
+  if (!posthog.__loaded) {
+    posthog.init(config.apiKey, {
+      api_host: config.apiHost ?? 'https://us.i.posthog.com',
+      capture_exceptions: config.captureExceptions ?? true,
+      autocapture: config.autocapture ?? true,
+      disable_session_recording: config.disableSessionRecording ?? false,
+      loaded: (ph) => {
+        if (config.debug) {
+          ph.debug()
+        }
+      }
+    })
+  }
+
+  return {
+    track: (eventName: string, properties?: EventProperties) =>
+      Effect.sync(() => {
+        posthog.capture(eventName, properties)
+      }),
+
+    identify: (userId: string, properties?: UserProperties) =>
+      Effect.sync(() => {
+        posthog.identify(userId, properties)
+      }),
+
+    reset: () =>
+      Effect.sync(() => {
+        posthog.reset()
+      }),
+
+    pageView: (pageName?: string, properties?: EventProperties) =>
+      Effect.sync(() => {
+        posthog.capture('$pageview', {
+          $current_url: window.location.href,
+          ...(pageName && { page_name: pageName }),
+          ...properties
+        })
+      }),
+
+    setUserProperties: (properties: UserProperties) =>
+      Effect.sync(() => {
+        posthog.setPersonProperties(properties)
+      }),
+
+    registerSuperProperties: (properties: EventProperties) =>
+      Effect.sync(() => {
+        posthog.register(properties)
+      }),
+
+    optOut: () =>
+      Effect.sync(() => {
+        posthog.opt_out_capturing()
+      }),
+
+    optIn: () =>
+      Effect.sync(() => {
+        posthog.opt_in_capturing()
+      }),
+
+    hasOptedOut: () =>
+      Effect.sync(() => {
+        return posthog.has_opted_out_capturing()
+      }),
+
+    startSessionRecording: () =>
+      Effect.sync(() => {
+        posthog.startSessionRecording()
+      }),
+
+    stopSessionRecording: () =>
+      Effect.sync(() => {
+        posthog.stopSessionRecording()
+      })
+  }
+}
+
+/**
+ * Creates a PostHog Analytics Layer from configuration
+ */
+export const PostHogAnalyticsLive = (config: PostHogConfig) =>
+  Layer.succeed(AnalyticsService, makePostHogAnalyticsService(config))

--- a/apps/www/src/services/analytics/runtime.ts
+++ b/apps/www/src/services/analytics/runtime.ts
@@ -1,0 +1,63 @@
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import { env } from '@/env'
+import { AnalyticsService, AnalyticsServiceNoop } from './analytics.service'
+import { PostHogAnalyticsLive } from './posthog.provider'
+
+/**
+ * Create the analytics layer based on environment configuration
+ */
+const createAnalyticsLayer = (): Layer.Layer<AnalyticsService> => {
+  const apiKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY
+  const apiHost = import.meta.env.VITE_PUBLIC_POSTHOG_HOST
+
+  // Use noop if PostHog is not configured
+  if (!apiKey) {
+    if (env.isDev) {
+      console.warn(
+        '[Analytics] PostHog API key not configured, using noop provider'
+      )
+    }
+    return AnalyticsServiceNoop
+  }
+
+  return PostHogAnalyticsLive({
+    apiKey,
+    apiHost,
+    debug: env.isDev,
+    captureExceptions: true
+  })
+}
+
+/**
+ * The main analytics layer for the application
+ */
+export const AnalyticsLive = createAnalyticsLayer()
+
+/**
+ * Managed runtime for running analytics effects
+ */
+export const AnalyticsRuntime = ManagedRuntime.make(AnalyticsLive)
+
+/**
+ * Run an analytics effect synchronously (fire-and-forget)
+ * Use this for non-critical analytics operations
+ */
+export const runAnalytics = <A>(
+  effect: Effect.Effect<A, never, AnalyticsService>
+): void => {
+  AnalyticsRuntime.runPromise(effect).catch((error) => {
+    if (env.isDev) {
+      console.error('[Analytics] Error:', error)
+    }
+  })
+}
+
+/**
+ * Run an analytics effect and return a promise
+ * Use this when you need to await the result
+ */
+export const runAnalyticsAsync = <A>(
+  effect: Effect.Effect<A, never, AnalyticsService>
+): Promise<A> => {
+  return AnalyticsRuntime.runPromise(effect)
+}


### PR DESCRIPTION
## Summary
Migrated analytics implementation from PostHog React provider to a custom Effect-based service layer, providing better abstraction, testability, and flexibility for swapping analytics providers.

## Key Changes

- **Added Effect library** (`^3.19.15`) as a dependency for functional effect management
- **Created analytics service layer** with provider-agnostic interface (`AnalyticsService`) that abstracts analytics operations
- **Implemented PostHog provider** (`posthog.provider.ts`) as a concrete implementation of the analytics service
- **Built Effect runtime** (`runtime.ts`) to manage analytics effects with automatic provider selection based on environment configuration
- **Created React hooks** (`useAnalytics.ts`) for easy integration in components:
  - `useAnalytics()` - Core hook for tracking events, identifying users, and managing opt-in/out
  - `usePageViewTracking()` - Automatic page view tracking on route changes
  - `useIdentifyUser()` - User identification with automatic reset on logout
- **Refactored main.tsx** to remove PostHog React provider and integrate new analytics hooks
- **Added noop implementation** for testing and when analytics is disabled

## Implementation Details

- The analytics service uses Effect's dependency injection system (`Context` and `Layer`) for clean, composable effect management
- Analytics operations are fire-and-forget by default via `runAnalytics()`, with optional async variant `runAnalyticsAsync()` for when results are needed
- Configuration is environment-driven - falls back to noop provider if PostHog API key is not configured
- The service layer is completely decoupled from PostHog, allowing easy swapping of providers (Sentry, Mixpanel, etc.) without changing consuming code
- All analytics operations are wrapped in `Effect.sync()` to maintain referential transparency and enable proper error handling

https://claude.ai/code/session_014WKM82GpP2CDCZj6WNHsPq