### PR TITLE
Refactor keyboard shortcuts to use @tanstack/react-hotkeys

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-hotkeys": "^0.3.1",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-router": "^1.133.28",
     "@types/mdx": "^2.0.13",

--- a/apps/www/src/components/cmd/HierarchicalCommand.tsx
+++ b/apps/www/src/components/cmd/HierarchicalCommand.tsx
@@ -33,6 +33,7 @@ export function HierarchicalCommand({
   )
   const [selectedIndex, setSelectedIndex] = useState(0)
   const containerRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<Array<HTMLElement | null>>([])
 
   // Filter items based on authentication and search
   const filteredItems = items
@@ -175,6 +176,13 @@ export function HierarchicalCommand({
     }
   }, [searchValue, isInSection])
 
+  // Scroll selected item into view when navigating with keyboard in list view
+  useEffect(() => {
+    if (isInSection) {
+      itemRefs.current[selectedIndex]?.scrollIntoView({ block: 'nearest' })
+    }
+  }, [selectedIndex, isInSection])
+
   // Render as grid when showing main tiles (both filtered and unfiltered)
   if (!isInSection) {
     return (
@@ -259,12 +267,15 @@ export function HierarchicalCommand({
         }>
         {currentItems.map((item, index) => {
           const Icon = 'icon' in item ? item.icon : undefined
+          const isSelected = index === selectedIndex
 
           return (
             <UICommandItem
               key={item.id}
+              ref={(el) => { itemRefs.current[index] = el }}
               onSelect={() => handleItemSelect(item)}
-              onMouseEnter={() => setSelectedIndex(index)}>
+              onMouseEnter={() => setSelectedIndex(index)}
+              className={isSelected ? 'bg-accent text-accent-foreground' : ''}>
               {Icon && <Icon className='w-4 h-4' />}
               <span>{item.label}</span>
               {'shortcut' in item && item.shortcut && (

--- a/apps/www/src/components/cmd/HierarchicalCommand.tsx
+++ b/apps/www/src/components/cmd/HierarchicalCommand.tsx
@@ -272,7 +272,9 @@ export function HierarchicalCommand({
           return (
             <UICommandItem
               key={item.id}
-              ref={(el) => { itemRefs.current[index] = el }}
+              ref={(el) => {
+                itemRefs.current[index] = el
+              }}
               onSelect={() => handleItemSelect(item)}
               onMouseEnter={() => setSelectedIndex(index)}
               className={isSelected ? 'bg-accent text-accent-foreground' : ''}>

--- a/apps/www/src/components/cmd/index.tsx
+++ b/apps/www/src/components/cmd/index.tsx
@@ -96,20 +96,15 @@ export function CommandDialogDemo() {
     ]
   )
 
-  const { setupKeyboardShortcuts } = useKeyboardShortcuts({
+  useKeyboardShortcuts({
     isOnMixesPage,
     toggleSortOrder: sortingActions.toggleSort,
     routeToMixes: navigationActions.routeToMixes,
     toggleCmd,
     closeCmd,
     audioSrc,
-    isCmdOpen: Cmd.isOpen,
-    whitelistedShortcuts: ['cmd+k']
+    isCmdOpen: Cmd.isOpen
   })
-
-  React.useEffect(() => {
-    return setupKeyboardShortcuts()
-  }, [setupKeyboardShortcuts])
 
   const handleItemSelect = (item: CommandItem | CommandAction) => {
     if ('onSelect' in item) {

--- a/apps/www/src/components/cmd/keyboard-shortcuts.tsx
+++ b/apps/www/src/components/cmd/keyboard-shortcuts.tsx
@@ -1,3 +1,4 @@
+import { useHotkey } from '@tanstack/react-hotkeys'
 import { useAudioPlayerCmdActions } from './audio/actions'
 
 interface KeyboardShortcutsProps {
@@ -8,81 +9,6 @@ interface KeyboardShortcutsProps {
   closeCmd: () => void
   audioSrc: string | null
   isCmdOpen: boolean
-  whitelistedShortcuts?: string[]
-}
-
-// Elements that should be ignored for keyboard shortcuts when focused
-const TYPING_ELEMENTS = [
-  'INPUT',
-  'TEXTAREA',
-  'SELECT',
-  'DETAILS',
-  'IFRAME' // For rich text editors and embedded content
-]
-
-// Roles that indicate typing elements
-const TYPING_ROLES = [
-  'textbox',
-  'combobox',
-  'searchbox',
-  'search',
-  'listbox',
-  'menuitem',
-  'option'
-]
-
-// Check if the current focused element is a typing element
-const isTypingElement = (element: Element | null): boolean => {
-  if (!element) return false
-
-  // Check if element is a typing element by tag name
-  if (TYPING_ELEMENTS.includes(element.tagName)) {
-    return true
-  }
-
-  // Check if element has contenteditable attribute
-  if (element.getAttribute('contenteditable') === 'true') {
-    return true
-  }
-
-  // Check if element has specific roles
-  const role = element.getAttribute('role')
-  if (role && TYPING_ROLES.includes(role)) {
-    return true
-  }
-
-  // Check if element is inside a typing element (using closest for more reliable checking)
-  const selector = [
-    ...TYPING_ELEMENTS.map((tag) => tag.toLowerCase()),
-    '[contenteditable="true"]',
-    '[contenteditable]',
-    ...TYPING_ROLES.map((role) => `[role="${role}"]`)
-  ].join(',')
-
-  const parentTypingElement = element.closest(selector)
-  if (parentTypingElement) {
-    return true
-  }
-
-  // Additional checks for common rich text editor classes and IDs
-  const isInRichTextEditor = element.closest(
-    [
-      '.ProseMirror',
-      '.ql-editor',
-      '.toastui-editor-contents',
-      '.wysiwyg-editor',
-      '.rich-text-editor',
-      '[data-gramm_editor]',
-      '[class*="editor"]',
-      '[class*="rich-text"]'
-    ].join(',')
-  )
-
-  if (isInRichTextEditor) {
-    return true
-  }
-
-  return false
 }
 
 export const useKeyboardShortcuts = ({
@@ -92,156 +18,80 @@ export const useKeyboardShortcuts = ({
   toggleCmd,
   closeCmd,
   audioSrc,
-  isCmdOpen,
-  whitelistedShortcuts = ['cmd+k']
+  isCmdOpen
 }: KeyboardShortcutsProps) => {
   const audioPlayerActions = useAudioPlayerCmdActions(closeCmd)
 
-  const setupKeyboardShortcuts = () => {
-    const down = (e: KeyboardEvent) => {
-      // Handle Escape key specially - always close command dialog if open, regardless of focus
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        if (isCmdOpen) {
-          closeCmd()
-          return
-        }
-        if (audioSrc && audioPlayerActions.isFullscreenVisible) {
-          audioPlayerActions.actions.closeFullscreen()
-          return
-        }
-        return
-      }
+  const hasAudio = Boolean(audioSrc)
 
-      // Check if user is focused on a typing element
-      const activeElement = document.activeElement
-      if (isTypingElement(activeElement)) {
-        return
-      }
+  // Cmd/Ctrl+K — toggle command dialog (ignoreInputs: false by default for Mod combos)
+  useHotkey('Mod+K', () => {
+    toggleCmd()
+  })
 
-      // Allow browser navigation shortcuts to pass through (only cmd/ctrl + key combinations)
-      const isBrowserNavigation =
-        (e.metaKey || e.ctrlKey) &&
-        [
-          'ArrowLeft', // cmd+left = back
-          'ArrowRight', // cmd+right = forward
-          'r', // cmd+r = reload
-          't', // cmd+t = new tab
-          'w', // cmd+w = close tab
-          'l', // cmd+l = focus address bar
-          'a', // cmd+a = select all
-          'c', // cmd+c = copy
-          'v', // cmd+v = paste
-          'z', // cmd+z = undo
-          'f', // cmd+f = find (conflicts with our fullscreen shortcut, but browser takes precedence)
-          'n', // cmd+n = new window
-          ',', // cmd+, = preferences
-          '1',
-          '2',
-          '3',
-          '4',
-          '5',
-          '6',
-          '7',
-          '8',
-          '9' // cmd+1-9 = switch tabs
-        ].includes(e.key)
-
-      if (isBrowserNavigation) {
-        return // Allow browser shortcuts to work normally
-      }
-
-      // Always allow cmd+k to toggle command dialog
-      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault()
-        toggleCmd()
-        return
-      }
-
-      // If command dialog is open, only allow whitelisted shortcuts
-      if (isCmdOpen && !whitelistedShortcuts.includes(e.key)) {
-        return
-      }
-
-      // Only process other shortcuts when command dialog is closed
-      if (e.key === '0') {
-        e.preventDefault()
-        routeToMixes()
-      }
-
-      if (e.key === 's' && e.altKey && isOnMixesPage) {
-        e.preventDefault()
-        toggleSortOrder()
-      }
-
-      // Audio player shortcuts
-      if (audioSrc) {
-        if (e.key === ' ') {
-          e.preventDefault()
-          audioPlayerActions.actions.togglePlayPause()
-        }
-
-        if (e.key === 'ArrowLeft' && e.altKey) {
-          e.preventDefault()
-          audioPlayerActions.actions.jumpBackward()
-        }
-
-        if (e.key === 'ArrowRight' && e.altKey) {
-          e.preventDefault()
-          audioPlayerActions.actions.jumpForward()
-        }
-
-        if (
-          e.key === 'ArrowLeft' &&
-          !e.altKey &&
-          audioPlayerActions.canPlayPrevious
-        ) {
-          e.preventDefault()
-          audioPlayerActions.actions.playPrevious()
-        }
-
-        if (
-          e.key === 'ArrowRight' &&
-          !e.altKey &&
-          audioPlayerActions.canPlayNext
-        ) {
-          e.preventDefault()
-          audioPlayerActions.actions.playNext()
-        }
-
-        if (e.key === 'm' || e.key === 'M') {
-          e.preventDefault()
-          audioPlayerActions.actions.toggleMute()
-        }
-
-        if (e.key === 'ArrowUp' && e.altKey) {
-          e.preventDefault()
-          audioPlayerActions.actions.volumeUp()
-        }
-
-        if (e.key === 'ArrowDown' && e.altKey) {
-          e.preventDefault()
-          audioPlayerActions.actions.volumeDown()
-        }
-
-        if (e.key === 'q' || e.key === 'Q') {
-          e.preventDefault()
-          audioPlayerActions.actions.toggleQueue()
-        }
-
-        if (e.key === 'f' || e.key === 'F') {
-          e.preventDefault()
-          audioPlayerActions.actions.toggleFullscreen()
-        }
-      }
+  // Escape — close command dialog or fullscreen player
+  useHotkey('Escape', () => {
+    if (isCmdOpen) {
+      closeCmd()
+    } else if (hasAudio && audioPlayerActions.isFullscreenVisible) {
+      audioPlayerActions.actions.closeFullscreen()
     }
+  })
 
-    document.addEventListener('keydown', down)
-    return () => document.removeEventListener('keydown', down)
-  }
+  // 0 — navigate to mixes
+  useHotkey('0', () => {
+    routeToMixes()
+  }, { enabled: !isCmdOpen })
 
-  return {
-    setupKeyboardShortcuts,
-    audioPlayerActions
-  }
+  // Alt+S — toggle sort order (mixes page only)
+  useHotkey('Alt+S', () => {
+    toggleSortOrder()
+  }, { enabled: !isCmdOpen && isOnMixesPage })
+
+  // Space — play/pause
+  useHotkey('Space', () => {
+    audioPlayerActions.actions.togglePlayPause()
+  }, { enabled: hasAudio && !isCmdOpen })
+
+  // ← / → — previous / next track
+  useHotkey('ArrowLeft', () => {
+    audioPlayerActions.actions.playPrevious()
+  }, { enabled: hasAudio && !isCmdOpen && audioPlayerActions.canPlayPrevious })
+
+  useHotkey('ArrowRight', () => {
+    audioPlayerActions.actions.playNext()
+  }, { enabled: hasAudio && !isCmdOpen && audioPlayerActions.canPlayNext })
+
+  // Alt+← / Alt+→ — seek backward / forward
+  useHotkey('Alt+ArrowLeft', () => {
+    audioPlayerActions.actions.jumpBackward()
+  }, { enabled: hasAudio && !isCmdOpen })
+
+  useHotkey('Alt+ArrowRight', () => {
+    audioPlayerActions.actions.jumpForward()
+  }, { enabled: hasAudio && !isCmdOpen })
+
+  // M — mute/unmute
+  useHotkey('M', () => {
+    audioPlayerActions.actions.toggleMute()
+  }, { enabled: hasAudio && !isCmdOpen })
+
+  // Alt+↑ / Alt+↓ — volume up/down
+  useHotkey('Alt+ArrowUp', () => {
+    audioPlayerActions.actions.volumeUp()
+  }, { enabled: hasAudio && !isCmdOpen })
+
+  useHotkey('Alt+ArrowDown', () => {
+    audioPlayerActions.actions.volumeDown()
+  }, { enabled: hasAudio && !isCmdOpen })
+
+  // Q — toggle queue
+  useHotkey('Q', () => {
+    audioPlayerActions.actions.toggleQueue()
+  }, { enabled: hasAudio && !isCmdOpen })
+
+  // F — toggle fullscreen
+  useHotkey('F', () => {
+    audioPlayerActions.actions.toggleFullscreen()
+  }, { enabled: hasAudio && !isCmdOpen })
 }

--- a/apps/www/src/components/cmd/keyboard-shortcuts.tsx
+++ b/apps/www/src/components/cmd/keyboard-shortcuts.tsx
@@ -39,59 +39,107 @@ export const useKeyboardShortcuts = ({
   })
 
   // 0 — navigate to mixes
-  useHotkey('0', () => {
-    routeToMixes()
-  }, { enabled: !isCmdOpen })
+  useHotkey(
+    '0',
+    () => {
+      routeToMixes()
+    },
+    { enabled: !isCmdOpen }
+  )
 
   // Alt+S — toggle sort order (mixes page only)
-  useHotkey('Alt+S', () => {
-    toggleSortOrder()
-  }, { enabled: !isCmdOpen && isOnMixesPage })
+  useHotkey(
+    'Alt+S',
+    () => {
+      toggleSortOrder()
+    },
+    { enabled: !isCmdOpen && isOnMixesPage }
+  )
 
   // Space — play/pause
-  useHotkey('Space', () => {
-    audioPlayerActions.actions.togglePlayPause()
-  }, { enabled: hasAudio && !isCmdOpen })
+  useHotkey(
+    'Space',
+    () => {
+      audioPlayerActions.actions.togglePlayPause()
+    },
+    { enabled: hasAudio && !isCmdOpen }
+  )
 
   // ← / → — previous / next track
-  useHotkey('ArrowLeft', () => {
-    audioPlayerActions.actions.playPrevious()
-  }, { enabled: hasAudio && !isCmdOpen && audioPlayerActions.canPlayPrevious })
+  useHotkey(
+    'ArrowLeft',
+    () => {
+      audioPlayerActions.actions.playPrevious()
+    },
+    { enabled: hasAudio && !isCmdOpen && audioPlayerActions.canPlayPrevious }
+  )
 
-  useHotkey('ArrowRight', () => {
-    audioPlayerActions.actions.playNext()
-  }, { enabled: hasAudio && !isCmdOpen && audioPlayerActions.canPlayNext })
+  useHotkey(
+    'ArrowRight',
+    () => {
+      audioPlayerActions.actions.playNext()
+    },
+    { enabled: hasAudio && !isCmdOpen && audioPlayerActions.canPlayNext }
+  )
 
   // Alt+← / Alt+→ — seek backward / forward
-  useHotkey('Alt+ArrowLeft', () => {
-    audioPlayerActions.actions.jumpBackward()
-  }, { enabled: hasAudio && !isCmdOpen })
+  useHotkey(
+    'Alt+ArrowLeft',
+    () => {
+      audioPlayerActions.actions.jumpBackward()
+    },
+    { enabled: hasAudio && !isCmdOpen }
+  )
 
-  useHotkey('Alt+ArrowRight', () => {
-    audioPlayerActions.actions.jumpForward()
-  }, { enabled: hasAudio && !isCmdOpen })
+  useHotkey(
+    'Alt+ArrowRight',
+    () => {
+      audioPlayerActions.actions.jumpForward()
+    },
+    { enabled: hasAudio && !isCmdOpen }
+  )
 
   // M — mute/unmute
-  useHotkey('M', () => {
-    audioPlayerActions.actions.toggleMute()
-  }, { enabled: hasAudio && !isCmdOpen })
+  useHotkey(
+    'M',
+    () => {
+      audioPlayerActions.actions.toggleMute()
+    },
+    { enabled: hasAudio && !isCmdOpen }
+  )
 
   // Alt+↑ / Alt+↓ — volume up/down
-  useHotkey('Alt+ArrowUp', () => {
-    audioPlayerActions.actions.volumeUp()
-  }, { enabled: hasAudio && !isCmdOpen })
+  useHotkey(
+    'Alt+ArrowUp',
+    () => {
+      audioPlayerActions.actions.volumeUp()
+    },
+    { enabled: hasAudio && !isCmdOpen }
+  )
 
-  useHotkey('Alt+ArrowDown', () => {
-    audioPlayerActions.actions.volumeDown()
-  }, { enabled: hasAudio && !isCmdOpen })
+  useHotkey(
+    'Alt+ArrowDown',
+    () => {
+      audioPlayerActions.actions.volumeDown()
+    },
+    { enabled: hasAudio && !isCmdOpen }
+  )
 
   // Q — toggle queue
-  useHotkey('Q', () => {
-    audioPlayerActions.actions.toggleQueue()
-  }, { enabled: hasAudio && !isCmdOpen })
+  useHotkey(
+    'Q',
+    () => {
+      audioPlayerActions.actions.toggleQueue()
+    },
+    { enabled: hasAudio && !isCmdOpen }
+  )
 
   // F — toggle fullscreen
-  useHotkey('F', () => {
-    audioPlayerActions.actions.toggleFullscreen()
-  }, { enabled: hasAudio && !isCmdOpen })
+  useHotkey(
+    'F',
+    () => {
+      audioPlayerActions.actions.toggleFullscreen()
+    },
+    { enabled: hasAudio && !isCmdOpen }
+  )
 }

--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toast": "^1.2.15",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@tanstack/react-hotkeys": "^0.3.1",
         "@tanstack/react-query": "^5.90.2",
         "@tanstack/react-router": "^1.133.28",
         "@types/mdx": "^2.0.13",
@@ -1446,7 +1447,11 @@
 
     "@tanstack/history": ["@tanstack/history@1.154.14", "", {}, "sha512-xyIfof8eHBuub1CkBnbKNKQXeRZC4dClhmzePHVOEel4G7lk/dW+TQ16da7CFdeNLv6u6Owf5VoBQxoo6DFTSA=="],
 
+    "@tanstack/hotkeys": ["@tanstack/hotkeys@0.3.1", "", { "dependencies": { "@tanstack/store": "^0.9.1" } }, "sha512-G+v+PUac8ff/jg752yhhfPqw7/0xr8RYKL69Jb4i7L1JCPKwwoO4aLqVSmI17WSDN6sh1+nNf8QzUOphuPLAuw=="],
+
     "@tanstack/query-core": ["@tanstack/query-core@5.90.2", "", {}, "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ=="],
+
+    "@tanstack/react-hotkeys": ["@tanstack/react-hotkeys@0.3.1", "", { "dependencies": { "@tanstack/hotkeys": "0.3.1", "@tanstack/react-store": "^0.9.1" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-QXTIwVy4mdLZD0Fz501hzw85aNEI9522kLnxF85Bgyr6iKSHYq5L6ChBsBVx28d4zbyEiDQ6HHf96/qzIcNtOg=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.2", "", { "dependencies": { "@tanstack/query-core": "5.90.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw=="],
 
@@ -1454,7 +1459,7 @@
 
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.157.4", "", { "dependencies": { "@tanstack/router-devtools-core": "1.157.4" }, "peerDependencies": { "@tanstack/react-router": "^1.157.4", "@tanstack/router-core": "^1.157.4", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-4vZ7BTT7PqFqYABueNU2k9AdIHR9ab98GhXa5bHTvQ2+8IJyzFxBJIsQ0XWkvSRCCKkEfhf1VpVUTI3YvZOW9A=="],
 
-    "@tanstack/react-store": ["@tanstack/react-store@0.8.0", "", { "dependencies": { "@tanstack/store": "0.8.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-1vG9beLIuB7q69skxK9r5xiLN3ztzIPfSQSs0GfeqWGO2tGIyInZx0x1COhpx97RKaONSoAb8C3dxacWksm1ow=="],
+    "@tanstack/react-store": ["@tanstack/react-store@0.9.1", "", { "dependencies": { "@tanstack/store": "0.9.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-YzJLnRvy5lIEFTLWBAZmcOjK3+2AepnBv/sr6NZmiqJvq7zTQggyK99Gw8fqYdMdHPQWXjz0epFKJXC+9V2xDA=="],
 
     "@tanstack/router-core": ["@tanstack/router-core@1.157.4", "", { "dependencies": { "@tanstack/history": "1.154.14", "@tanstack/store": "^0.8.0", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" } }, "sha512-hoFTp19e65/jItOjDNnEubwtb2kFDBHu7WRJTxklisSqKOVjRv3NvT4azZNXa0qlIkWmldzLlzhOsE1y9KQT2A=="],
 
@@ -3891,6 +3896,12 @@
     "@semantic-release/release-notes-generator/read-package-up": ["read-package-up@11.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0", "read-pkg": "^9.0.0", "type-fest": "^4.6.0" } }, "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ=="],
 
     "@tailwindcss/typography/postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
+
+    "@tanstack/hotkeys/@tanstack/store": ["@tanstack/store@0.9.1", "", {}, "sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg=="],
+
+    "@tanstack/react-router/@tanstack/react-store": ["@tanstack/react-store@0.8.0", "", { "dependencies": { "@tanstack/store": "0.8.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-1vG9beLIuB7q69skxK9r5xiLN3ztzIPfSQSs0GfeqWGO2tGIyInZx0x1COhpx97RKaONSoAb8C3dxacWksm1ow=="],
+
+    "@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.9.1", "", {}, "sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg=="],
 
     "@tanstack/router-generator/zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 


### PR DESCRIPTION
## Summary
Migrated keyboard shortcut handling from a custom manual event listener implementation to the `@tanstack/react-hotkeys` library, improving maintainability and reducing code complexity.

## Key Changes
- **Replaced custom keyboard event handler** with `useHotkey` hook from `@tanstack/react-hotkeys`
  - Removed ~80 lines of custom logic for detecting typing elements and managing keyboard events
  - Removed `whitelistedShortcuts` prop and related filtering logic
  - Simplified the `useKeyboardShortcuts` hook to use individual `useHotkey` calls for each shortcut

- **Refactored keyboard shortcut definitions** to be more declarative
  - Each shortcut is now defined as a separate `useHotkey` call with clear intent
  - Added `enabled` conditions to control when shortcuts are active (e.g., disabled when command dialog is open)
  - Improved readability with inline comments describing each shortcut

- **Enhanced command dialog list navigation**
  - Added `itemRefs` to track DOM references for list items
  - Implemented auto-scroll behavior to keep selected items in view during keyboard navigation
  - Added visual feedback with `bg-accent` styling for selected items

- **Simplified component integration**
  - Removed manual `useEffect` setup/cleanup for keyboard event listeners
  - The `useHotkey` hook handles all lifecycle management automatically

## Implementation Details
- The library automatically handles focus detection and prevents shortcuts from firing when typing in input fields
- Modifier keys use the `Mod` prefix (automatically resolves to `Cmd` on Mac, `Ctrl` on other platforms)
- Each shortcut can be individually enabled/disabled via the `enabled` option, replacing the previous whitelist approach
- The command dialog's list view now properly scrolls selected items into view with `scrollIntoView({ block: 'nearest' })`

https://claude.ai/code/session_019BYkoBncZevUhm8p3mt34n