### PR TITLE
Add S3 audio file picker to mix upload flow

### DIFF
--- a/apps/vps/src/routes/file-manager/file-manager.handlers.ts
+++ b/apps/vps/src/routes/file-manager/file-manager.handlers.ts
@@ -44,6 +44,7 @@ export const getConfig: AppRouteHandler<GetConfigRoute> = async (c) => {
 
     return {
       stage: config.app.stage,
+      routerUrl: config.urls.router,
       buckets: {
         userContent: config.buckets.userContent,
         mixes: config.buckets.mixes

--- a/apps/vps/src/routes/file-manager/file-manager.routes.ts
+++ b/apps/vps/src/routes/file-manager/file-manager.routes.ts
@@ -20,6 +20,7 @@ export const getConfig = createRoute({
     [HttpStatusCodes.OK]: jsonContent(
       z.object({
         stage: z.string(),
+        routerUrl: z.string(),
         buckets: z.object({
           userContent: z.string(),
           mixes: z.string()

--- a/apps/www/src/components/mix-uploader/AudioDropZone.tsx
+++ b/apps/www/src/components/mix-uploader/AudioDropZone.tsx
@@ -6,7 +6,10 @@ interface AudioDropZoneProps {
   onPickFromS3?: () => void
 }
 
-export function AudioDropZone({ onFileSelect, onPickFromS3 }: AudioDropZoneProps) {
+export function AudioDropZone({
+  onFileSelect,
+  onPickFromS3
+}: AudioDropZoneProps) {
   return (
     <div className='space-y-3'>
       <div className='relative p-12 text-center transition-colors border-2 border-dashed cursor-pointer group rounded-sm bg-gb-darker-bg border-gb-pastel-green-2/30 hover:border-gb-highlight/50'>

--- a/apps/www/src/components/mix-uploader/AudioDropZone.tsx
+++ b/apps/www/src/components/mix-uploader/AudioDropZone.tsx
@@ -1,27 +1,50 @@
-import { Upload } from 'lucide-react'
+import { FolderOpen, Upload } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 
 interface AudioDropZoneProps {
   onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onPickFromS3?: () => void
 }
 
-export function AudioDropZone({ onFileSelect }: AudioDropZoneProps) {
+export function AudioDropZone({ onFileSelect, onPickFromS3 }: AudioDropZoneProps) {
   return (
-    <div className='relative p-12 text-center transition-colors border-2 border-dashed cursor-pointer group rounded-sm bg-gb-darker-bg border-gb-pastel-green-2/30 hover:border-gb-highlight/50'>
-      <input
-        type='file'
-        accept='audio/*'
-        onChange={onFileSelect}
-        className='absolute inset-0 opacity-0 cursor-pointer'
-      />
-      <div className='flex items-center justify-center w-16 h-16 mx-auto mb-4 transition-transform rounded-sm bg-gb-pastel-green-2/20 group-hover:scale-110'>
-        <Upload className='w-8 h-8 text-gb-highlight' />
+    <div className='space-y-3'>
+      <div className='relative p-12 text-center transition-colors border-2 border-dashed cursor-pointer group rounded-sm bg-gb-darker-bg border-gb-pastel-green-2/30 hover:border-gb-highlight/50'>
+        <input
+          type='file'
+          accept='audio/*'
+          onChange={onFileSelect}
+          className='absolute inset-0 opacity-0 cursor-pointer'
+        />
+        <div className='flex items-center justify-center w-16 h-16 mx-auto mb-4 transition-transform rounded-sm bg-gb-pastel-green-2/20 group-hover:scale-110'>
+          <Upload className='w-8 h-8 text-gb-highlight' />
+        </div>
+        <h2 className='mb-2 text-xl font-semibold text-gb-pastel-green-1'>
+          Select your mix file
+        </h2>
+        <p className='text-muted-foreground'>
+          MP3, WAV, or AIFF supported. Title will be inferred automatically.
+        </p>
       </div>
-      <h2 className='mb-2 text-xl font-semibold text-gb-pastel-green-1'>
-        Select your mix file
-      </h2>
-      <p className='text-muted-foreground'>
-        MP3, WAV, or AIFF supported. Title will be inferred automatically.
-      </p>
+
+      {onPickFromS3 && (
+        <div className='flex items-center gap-3'>
+          <div className='flex-1 h-px bg-gb-pastel-green-2/20' />
+          <span className='text-xs text-muted-foreground'>or</span>
+          <div className='flex-1 h-px bg-gb-pastel-green-2/20' />
+        </div>
+      )}
+
+      {onPickFromS3 && (
+        <Button
+          type='button'
+          variant='outline'
+          className='w-full border-gb-pastel-green-2/30 text-gb-pastel-green-1 hover:border-gb-highlight/50 hover:text-gb-highlight'
+          onClick={onPickFromS3}>
+          <FolderOpen className='w-4 h-4 mr-2' />
+          Pick from S3 bucket
+        </Button>
+      )}
     </div>
   )
 }

--- a/apps/www/src/components/mix-uploader/S3AudioFilePicker.tsx
+++ b/apps/www/src/components/mix-uploader/S3AudioFilePicker.tsx
@@ -229,6 +229,21 @@ export function S3AudioFilePicker({
             )}
           </div>
 
+          {selectedKey && configData && (
+            <div className='rounded-sm border border-gb-pastel-green-2/20 p-3'>
+              {/* biome-ignore lint/a11y/useMediaCaption: internal preview player, no captions needed */}
+              <audio
+                key={selectedKey}
+                controls
+                className='w-full h-8'
+                src={
+                  getPublicUrl(configData, effectiveBucket, selectedKey) ??
+                  undefined
+                }
+              />
+            </div>
+          )}
+
           <div className='flex justify-end gap-2'>
             <Button
               variant='outline'

--- a/apps/www/src/components/mix-uploader/S3AudioFilePicker.tsx
+++ b/apps/www/src/components/mix-uploader/S3AudioFilePicker.tsx
@@ -146,14 +146,14 @@ export function S3AudioFilePicker({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className='max-w-2xl bg-gb-darker-bg border-gb-pastel-green-2/20'>
+      <DialogContent className='max-w-2xl bg-gb-darker-bg border-gb-pastel-green-2/20 overflow-hidden'>
         <DialogHeader>
           <DialogTitle className='text-gb-pastel-green-1'>
             Pick audio file from S3
           </DialogTitle>
         </DialogHeader>
 
-        <div className='space-y-4'>
+        <div className='space-y-4 min-w-0 w-full'>
           <div className='flex items-center gap-2'>
             <Select
               value={effectiveBucket}
@@ -181,7 +181,7 @@ export function S3AudioFilePicker({
             </Button>
           </div>
 
-          <div className='rounded-sm border border-gb-pastel-green-2/20 overflow-hidden'>
+          <div className='rounded-sm border border-gb-pastel-green-2/20 overflow-hidden w-full max-w-full'>
             {isListLoading ? (
               <div className='flex items-center justify-center py-12'>
                 <Loader2 className='h-6 w-6 animate-spin text-gb-highlight' />
@@ -193,7 +193,7 @@ export function S3AudioFilePicker({
                   : 'Select a bucket to browse files'}
               </div>
             ) : (
-              <div className='max-h-80 overflow-y-auto'>
+              <div className='max-h-80 overflow-y-auto overflow-x-hidden'>
                 {audioFiles.map((obj) => {
                   const isSelected = selectedKey === obj.key
                   return (
@@ -201,30 +201,25 @@ export function S3AudioFilePicker({
                       key={obj.key}
                       type='button'
                       onClick={() => setSelectedKey(obj.key)}
-                      className={`w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-gb-pastel-green-2/10 transition-colors border-b border-gb-pastel-green-2/10 last:border-b-0 ${
+                      className={`w-full flex items-center gap-3 pl-4 pr-3 py-2.5 text-left hover:bg-gb-pastel-green-2/10 transition-colors border-b border-gb-pastel-green-2/10 last:border-b-0 ${
                         isSelected ? 'bg-gb-pastel-green-2/15' : ''
                       }`}>
                       <div
-                        className={`flex-shrink-0 w-8 h-8 rounded-sm flex items-center justify-center ${
+                        className={`flex-none w-7 h-7 rounded-sm flex items-center justify-center ${
                           isSelected
                             ? 'bg-gb-highlight text-gb-darker-bg'
                             : 'bg-gb-pastel-green-2/20 text-gb-highlight'
                         }`}>
                         {isSelected ? (
-                          <Check className='h-4 w-4' />
+                          <Check className='h-3.5 w-3.5' />
                         ) : (
-                          <Music className='h-4 w-4' />
+                          <Music className='h-3.5 w-3.5' />
                         )}
                       </div>
-                      <div className='flex-1 min-w-0'>
-                        <p className='text-sm font-mono text-gb-default-text truncate'>
-                          {obj.key.split('/').pop() ?? obj.key}
-                        </p>
-                        <p className='text-xs text-muted-foreground truncate'>
-                          {obj.key}
-                        </p>
-                      </div>
-                      <span className='flex-shrink-0 text-xs text-muted-foreground'>
+                      <p className='flex-1 min-w-0 text-sm font-mono text-gb-default-text truncate'>
+                        {obj.key.split('/').pop() ?? obj.key}
+                      </p>
+                      <span className='flex-none text-xs tabular-nums text-muted-foreground ml-3'>
                         {formatBytes(obj.size)}
                       </span>
                     </button>

--- a/apps/www/src/components/mix-uploader/S3AudioFilePicker.tsx
+++ b/apps/www/src/components/mix-uploader/S3AudioFilePicker.tsx
@@ -1,0 +1,260 @@
+import { useQuery } from '@tanstack/react-query'
+import { Check, Loader2, Music, RefreshCw } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { fetcher, VPS_BASE_URL } from '@/lib/http'
+
+interface S3Object {
+  key: string
+  lastModified: string
+  size: number
+}
+
+interface BucketConfig {
+  stage: string
+  routerUrl: string
+  buckets: {
+    userContent: string
+    mixes: string
+  }
+  availableBuckets: string[]
+}
+
+interface S3AudioFilePickerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (url: string, filename: string) => void
+}
+
+const AUDIO_EXTENSIONS = new Set([
+  'mp3',
+  'wav',
+  'aiff',
+  'aif',
+  'flac',
+  'ogg',
+  'm4a',
+  'opus',
+  'wma'
+])
+
+function isAudioFile(key: string) {
+  const ext = key.split('.').pop()?.toLowerCase()
+  return ext ? AUDIO_EXTENSIONS.has(ext) : false
+}
+
+function formatBytes(bytes: number) {
+  if (bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${parseFloat((bytes / k ** i).toFixed(1))} ${sizes[i]}`
+}
+
+function getPublicUrl(
+  config: BucketConfig,
+  bucketName: string,
+  key: string
+): string | null {
+  if (bucketName === config.buckets.userContent) {
+    return `${config.routerUrl}/user-content/${key}`
+  }
+  if (bucketName === config.buckets.mixes) {
+    return `${config.routerUrl}/mixes/${key}`
+  }
+  return null
+}
+
+export function S3AudioFilePicker({
+  open,
+  onOpenChange,
+  onSelect
+}: S3AudioFilePickerProps) {
+  const [selectedBucket, setSelectedBucket] = useState<string>('')
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+
+  const { data: configData } = useQuery<BucketConfig>({
+    queryKey: ['file-manager', 'config'],
+    queryFn: () => fetcher<BucketConfig>(`${VPS_BASE_URL}/file-manager/config`),
+    staleTime: Infinity,
+    enabled: open
+  })
+
+  // Auto-select first bucket once config loads
+  const effectiveBucket =
+    selectedBucket ||
+    configData?.buckets.userContent ||
+    configData?.availableBuckets[0] ||
+    ''
+
+  const {
+    data: listData,
+    isLoading: isListLoading,
+    refetch
+  } = useQuery<{ objects: S3Object[] }>({
+    queryKey: ['file-manager', 'list', effectiveBucket],
+    queryFn: () =>
+      fetcher<{ objects: S3Object[] }>(
+        `${VPS_BASE_URL}/file-manager/list?bucketName=${encodeURIComponent(effectiveBucket)}`
+      ),
+    enabled: Boolean(effectiveBucket) && open,
+    staleTime: 30_000
+  })
+
+  const audioFiles =
+    listData?.objects.filter((obj) => isAudioFile(obj.key)) ?? []
+
+  const handleConfirm = () => {
+    if (!selectedKey || !configData) return
+    const url = getPublicUrl(configData, effectiveBucket, selectedKey)
+    if (!url) return
+    const filename = selectedKey.split('/').pop() ?? selectedKey
+    onSelect(url, filename)
+    onOpenChange(false)
+    setSelectedKey(null)
+  }
+
+  const bucketOptions = configData
+    ? Array.from(
+        new Set([
+          configData.buckets.userContent,
+          configData.buckets.mixes,
+          ...configData.availableBuckets
+        ])
+      ).filter(Boolean)
+    : []
+
+  const getBucketLabel = (bucket: string) => {
+    if (!configData) return bucket
+    if (bucket === configData.buckets.userContent) return `uploads · ${bucket}`
+    if (bucket === configData.buckets.mixes) return `mixes · ${bucket}`
+    return bucket
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-2xl bg-gb-darker-bg border-gb-pastel-green-2/20'>
+        <DialogHeader>
+          <DialogTitle className='text-gb-pastel-green-1'>
+            Pick audio file from S3
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className='space-y-4'>
+          <div className='flex items-center gap-2'>
+            <Select
+              value={effectiveBucket}
+              onValueChange={(v) => {
+                setSelectedBucket(v)
+                setSelectedKey(null)
+              }}>
+              <SelectTrigger className='flex-1 h-9 text-sm'>
+                <SelectValue placeholder='Select bucket' />
+              </SelectTrigger>
+              <SelectContent>
+                {bucketOptions.map((bucket) => (
+                  <SelectItem key={bucket} value={bucket} className='text-xs'>
+                    {getBucketLabel(bucket)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              variant='outline'
+              size='sm'
+              className='h-9'
+              onClick={() => refetch()}>
+              <RefreshCw className='h-3.5 w-3.5' />
+            </Button>
+          </div>
+
+          <div className='rounded-sm border border-gb-pastel-green-2/20 overflow-hidden'>
+            {isListLoading ? (
+              <div className='flex items-center justify-center py-12'>
+                <Loader2 className='h-6 w-6 animate-spin text-gb-highlight' />
+              </div>
+            ) : audioFiles.length === 0 ? (
+              <div className='py-12 text-center text-sm text-muted-foreground'>
+                {effectiveBucket
+                  ? 'No audio files found in this bucket'
+                  : 'Select a bucket to browse files'}
+              </div>
+            ) : (
+              <div className='max-h-80 overflow-y-auto'>
+                {audioFiles.map((obj) => {
+                  const isSelected = selectedKey === obj.key
+                  return (
+                    <button
+                      key={obj.key}
+                      type='button'
+                      onClick={() => setSelectedKey(obj.key)}
+                      className={`w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-gb-pastel-green-2/10 transition-colors border-b border-gb-pastel-green-2/10 last:border-b-0 ${
+                        isSelected ? 'bg-gb-pastel-green-2/15' : ''
+                      }`}>
+                      <div
+                        className={`flex-shrink-0 w-8 h-8 rounded-sm flex items-center justify-center ${
+                          isSelected
+                            ? 'bg-gb-highlight text-gb-darker-bg'
+                            : 'bg-gb-pastel-green-2/20 text-gb-highlight'
+                        }`}>
+                        {isSelected ? (
+                          <Check className='h-4 w-4' />
+                        ) : (
+                          <Music className='h-4 w-4' />
+                        )}
+                      </div>
+                      <div className='flex-1 min-w-0'>
+                        <p className='text-sm font-mono text-gb-default-text truncate'>
+                          {obj.key.split('/').pop() ?? obj.key}
+                        </p>
+                        <p className='text-xs text-muted-foreground truncate'>
+                          {obj.key}
+                        </p>
+                      </div>
+                      <span className='flex-shrink-0 text-xs text-muted-foreground'>
+                        {formatBytes(obj.size)}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className='flex justify-end gap-2'>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              size='sm'
+              disabled={
+                !selectedKey ||
+                !configData ||
+                !getPublicUrl(configData, effectiveBucket, selectedKey ?? '')
+              }
+              onClick={handleConfirm}
+              className='bg-gb-highlight text-gb-darker-bg hover:bg-gb-highlight/90'>
+              Use this file
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -18,24 +18,24 @@ import { Route as RemindersRouteImport } from './routes/reminders'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as ChangelogRouteImport } from './routes/changelog'
 import { Route as SlugRouteImport } from './routes/$slug'
-import { Route as TracksRouteRouteImport } from './routes/tracks/route'
 import { Route as TweetRouteRouteImport } from './routes/tweet/route'
+import { Route as TracksRouteRouteImport } from './routes/tracks/route'
 import { Route as MixesRouteRouteImport } from './routes/mixes/route'
 import { Route as LabelsRouteRouteImport } from './routes/labels/route'
 import { Route as EditorialRouteRouteImport } from './routes/editorial/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as TweetIndexRouteImport } from './routes/tweet/index'
 import { Route as TracksIndexRouteImport } from './routes/tracks/index'
 import { Route as ShowsIndexRouteImport } from './routes/shows/index'
-import { Route as TweetIndexRouteImport } from './routes/tweet/index'
 import { Route as MixesIndexRouteImport } from './routes/mixes/index'
 import { Route as LabelsIndexRouteImport } from './routes/labels/index'
 import { Route as EditorialIndexRouteImport } from './routes/editorial/index'
 import { Route as AdminIndexRouteImport } from './routes/admin/index'
+import { Route as TweetSlugRouteImport } from './routes/tweet/$slug'
 import { Route as TracksTrackIdRouteImport } from './routes/tracks/$trackId'
 import { Route as ShowsShowSlugRouteImport } from './routes/shows/$showSlug'
 import { Route as ReleasesSlugRouteImport } from './routes/releases/$slug'
 import { Route as ProfileUsernameRouteImport } from './routes/profile/$username'
-import { Route as TweetSlugRouteImport } from './routes/tweet/$slug'
 import { Route as MixesMixIdRouteImport } from './routes/mixes/$mixId'
 import { Route as LabelsLabelSlugRouteImport } from './routes/labels/$labelSlug'
 import { Route as EditorialSlugRouteImport } from './routes/editorial/$slug'
@@ -104,14 +104,14 @@ const SlugRoute = SlugRouteImport.update({
   path: '/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
-const TracksRouteRoute = TracksRouteRouteImport.update({
-  id: '/tracks',
-  path: '/tracks',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const TweetRouteRoute = TweetRouteRouteImport.update({
   id: '/tweet',
   path: '/tweet',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TracksRouteRoute = TracksRouteRouteImport.update({
+  id: '/tracks',
+  path: '/tracks',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MixesRouteRoute = MixesRouteRouteImport.update({
@@ -134,6 +134,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TweetIndexRoute = TweetIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => TweetRouteRoute,
+} as any)
 const TracksIndexRoute = TracksIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -141,13 +146,8 @@ const TracksIndexRoute = TracksIndexRouteImport.update({
 } as any)
 const ShowsIndexRoute = ShowsIndexRouteImport.update({
   id: '/shows/',
-  path: '/shows',
+  path: '/shows/',
   getParentRoute: () => rootRouteImport,
-} as any)
-const TweetIndexRoute = TweetIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => TweetRouteRoute,
 } as any)
 const MixesIndexRoute = MixesIndexRouteImport.update({
   id: '/',
@@ -166,8 +166,13 @@ const EditorialIndexRoute = EditorialIndexRouteImport.update({
 } as any)
 const AdminIndexRoute = AdminIndexRouteImport.update({
   id: '/admin/',
-  path: '/admin',
+  path: '/admin/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const TweetSlugRoute = TweetSlugRouteImport.update({
+  id: '/$slug',
+  path: '/$slug',
+  getParentRoute: () => TweetRouteRoute,
 } as any)
 const TracksTrackIdRoute = TracksTrackIdRouteImport.update({
   id: '/$trackId',
@@ -188,11 +193,6 @@ const ProfileUsernameRoute = ProfileUsernameRouteImport.update({
   id: '/profile/$username',
   path: '/profile/$username',
   getParentRoute: () => rootRouteImport,
-} as any)
-const TweetSlugRoute = TweetSlugRouteImport.update({
-  id: '/$slug',
-  path: '/$slug',
-  getParentRoute: () => TweetRouteRoute,
 } as any)
 const MixesMixIdRoute = MixesMixIdRouteImport.update({
   id: '/$mixId',
@@ -235,8 +235,8 @@ export interface FileRoutesByFullPath {
   '/editorial': typeof EditorialRouteRouteWithChildren
   '/labels': typeof LabelsRouteRouteWithChildren
   '/mixes': typeof MixesRouteRouteWithChildren
-  '/tweet': typeof TweetRouteRouteWithChildren
   '/tracks': typeof TracksRouteRouteWithChildren
+  '/tweet': typeof TweetRouteRouteWithChildren
   '/$slug': typeof SlugRoute
   '/changelog': typeof ChangelogRoute
   '/dashboard': typeof DashboardRoute
@@ -255,18 +255,18 @@ export interface FileRoutesByFullPath {
   '/editorial/$slug': typeof EditorialSlugRoute
   '/labels/$labelSlug': typeof LabelsLabelSlugRoute
   '/mixes/$mixId': typeof MixesMixIdRoute
-  '/tweet/$slug': typeof TweetSlugRoute
   '/profile/$username': typeof ProfileUsernameRoute
   '/releases/$slug': typeof ReleasesSlugRoute
   '/shows/$showSlug': typeof ShowsShowSlugRoute
   '/tracks/$trackId': typeof TracksTrackIdRoute
+  '/tweet/$slug': typeof TweetSlugRoute
   '/admin/': typeof AdminIndexRoute
   '/editorial/': typeof EditorialIndexRoute
   '/labels/': typeof LabelsIndexRoute
   '/mixes/': typeof MixesIndexRoute
-  '/tweet/': typeof TweetIndexRoute
   '/shows/': typeof ShowsIndexRoute
   '/tracks/': typeof TracksIndexRoute
+  '/tweet/': typeof TweetIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -288,18 +288,18 @@ export interface FileRoutesByTo {
   '/editorial/$slug': typeof EditorialSlugRoute
   '/labels/$labelSlug': typeof LabelsLabelSlugRoute
   '/mixes/$mixId': typeof MixesMixIdRoute
-  '/tweet/$slug': typeof TweetSlugRoute
   '/profile/$username': typeof ProfileUsernameRoute
   '/releases/$slug': typeof ReleasesSlugRoute
   '/shows/$showSlug': typeof ShowsShowSlugRoute
   '/tracks/$trackId': typeof TracksTrackIdRoute
+  '/tweet/$slug': typeof TweetSlugRoute
   '/admin': typeof AdminIndexRoute
   '/editorial': typeof EditorialIndexRoute
   '/labels': typeof LabelsIndexRoute
   '/mixes': typeof MixesIndexRoute
-  '/tweet': typeof TweetIndexRoute
   '/shows': typeof ShowsIndexRoute
   '/tracks': typeof TracksIndexRoute
+  '/tweet': typeof TweetIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -307,8 +307,8 @@ export interface FileRoutesById {
   '/editorial': typeof EditorialRouteRouteWithChildren
   '/labels': typeof LabelsRouteRouteWithChildren
   '/mixes': typeof MixesRouteRouteWithChildren
-  '/tweet': typeof TweetRouteRouteWithChildren
   '/tracks': typeof TracksRouteRouteWithChildren
+  '/tweet': typeof TweetRouteRouteWithChildren
   '/$slug': typeof SlugRoute
   '/changelog': typeof ChangelogRoute
   '/dashboard': typeof DashboardRoute
@@ -327,18 +327,18 @@ export interface FileRoutesById {
   '/editorial/$slug': typeof EditorialSlugRoute
   '/labels/$labelSlug': typeof LabelsLabelSlugRoute
   '/mixes/$mixId': typeof MixesMixIdRoute
-  '/tweet/$slug': typeof TweetSlugRoute
   '/profile/$username': typeof ProfileUsernameRoute
   '/releases/$slug': typeof ReleasesSlugRoute
   '/shows/$showSlug': typeof ShowsShowSlugRoute
   '/tracks/$trackId': typeof TracksTrackIdRoute
+  '/tweet/$slug': typeof TweetSlugRoute
   '/admin/': typeof AdminIndexRoute
   '/editorial/': typeof EditorialIndexRoute
   '/labels/': typeof LabelsIndexRoute
   '/mixes/': typeof MixesIndexRoute
-  '/tweet/': typeof TweetIndexRoute
   '/shows/': typeof ShowsIndexRoute
   '/tracks/': typeof TracksIndexRoute
+  '/tweet/': typeof TweetIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -347,8 +347,8 @@ export interface FileRouteTypes {
     | '/editorial'
     | '/labels'
     | '/mixes'
-    | '/tweet'
     | '/tracks'
+    | '/tweet'
     | '/$slug'
     | '/changelog'
     | '/dashboard'
@@ -367,18 +367,18 @@ export interface FileRouteTypes {
     | '/editorial/$slug'
     | '/labels/$labelSlug'
     | '/mixes/$mixId'
-    | '/tweet/$slug'
     | '/profile/$username'
     | '/releases/$slug'
     | '/shows/$showSlug'
     | '/tracks/$trackId'
+    | '/tweet/$slug'
     | '/admin/'
     | '/editorial/'
     | '/labels/'
     | '/mixes/'
-    | '/tweet/'
     | '/shows/'
     | '/tracks/'
+    | '/tweet/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -400,26 +400,26 @@ export interface FileRouteTypes {
     | '/editorial/$slug'
     | '/labels/$labelSlug'
     | '/mixes/$mixId'
-    | '/tweet/$slug'
     | '/profile/$username'
     | '/releases/$slug'
     | '/shows/$showSlug'
     | '/tracks/$trackId'
+    | '/tweet/$slug'
     | '/admin'
     | '/editorial'
     | '/labels'
     | '/mixes'
-    | '/tweet'
     | '/shows'
     | '/tracks'
+    | '/tweet'
   id:
     | '__root__'
     | '/'
     | '/editorial'
     | '/labels'
     | '/mixes'
-    | '/tweet'
     | '/tracks'
+    | '/tweet'
     | '/$slug'
     | '/changelog'
     | '/dashboard'
@@ -438,18 +438,18 @@ export interface FileRouteTypes {
     | '/editorial/$slug'
     | '/labels/$labelSlug'
     | '/mixes/$mixId'
-    | '/tweet/$slug'
     | '/profile/$username'
     | '/releases/$slug'
     | '/shows/$showSlug'
     | '/tracks/$trackId'
+    | '/tweet/$slug'
     | '/admin/'
     | '/editorial/'
     | '/labels/'
     | '/mixes/'
-    | '/tweet/'
     | '/shows/'
     | '/tracks/'
+    | '/tweet/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -457,8 +457,8 @@ export interface RootRouteChildren {
   EditorialRouteRoute: typeof EditorialRouteRouteWithChildren
   LabelsRouteRoute: typeof LabelsRouteRouteWithChildren
   MixesRouteRoute: typeof MixesRouteRouteWithChildren
-  TweetRouteRoute: typeof TweetRouteRouteWithChildren
   TracksRouteRoute: typeof TracksRouteRouteWithChildren
+  TweetRouteRoute: typeof TweetRouteRouteWithChildren
   SlugRoute: typeof SlugRoute
   ChangelogRoute: typeof ChangelogRoute
   DashboardRoute: typeof DashboardRoute
@@ -560,18 +560,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SlugRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/tracks': {
-      id: '/tracks'
-      path: '/tracks'
-      fullPath: '/tracks'
-      preLoaderRoute: typeof TracksRouteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/tweet': {
       id: '/tweet'
       path: '/tweet'
       fullPath: '/tweet'
       preLoaderRoute: typeof TweetRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tracks': {
+      id: '/tracks'
+      path: '/tracks'
+      fullPath: '/tracks'
+      preLoaderRoute: typeof TracksRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/mixes': {
@@ -602,6 +602,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/tweet/': {
+      id: '/tweet/'
+      path: '/'
+      fullPath: '/tweet/'
+      preLoaderRoute: typeof TweetIndexRouteImport
+      parentRoute: typeof TweetRouteRoute
+    }
     '/tracks/': {
       id: '/tracks/'
       path: '/'
@@ -615,13 +622,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/shows/'
       preLoaderRoute: typeof ShowsIndexRouteImport
       parentRoute: typeof rootRouteImport
-    }
-    '/tweet/': {
-      id: '/tweet/'
-      path: '/'
-      fullPath: '/tweet/'
-      preLoaderRoute: typeof TweetIndexRouteImport
-      parentRoute: typeof TweetRouteRoute
     }
     '/mixes/': {
       id: '/mixes/'
@@ -651,6 +651,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/tweet/$slug': {
+      id: '/tweet/$slug'
+      path: '/$slug'
+      fullPath: '/tweet/$slug'
+      preLoaderRoute: typeof TweetSlugRouteImport
+      parentRoute: typeof TweetRouteRoute
+    }
     '/tracks/$trackId': {
       id: '/tracks/$trackId'
       path: '/$trackId'
@@ -678,13 +685,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/profile/$username'
       preLoaderRoute: typeof ProfileUsernameRouteImport
       parentRoute: typeof rootRouteImport
-    }
-    '/tweet/$slug': {
-      id: '/tweet/$slug'
-      path: '/$slug'
-      fullPath: '/tweet/$slug'
-      preLoaderRoute: typeof TweetSlugRouteImport
-      parentRoute: typeof TweetRouteRoute
     }
     '/mixes/$mixId': {
       id: '/mixes/$mixId'
@@ -780,20 +780,6 @@ const MixesRouteRouteWithChildren = MixesRouteRoute._addFileChildren(
   MixesRouteRouteChildren,
 )
 
-interface TweetRouteRouteChildren {
-  TweetSlugRoute: typeof TweetSlugRoute
-  TweetIndexRoute: typeof TweetIndexRoute
-}
-
-const TweetRouteRouteChildren: TweetRouteRouteChildren = {
-  TweetSlugRoute: TweetSlugRoute,
-  TweetIndexRoute: TweetIndexRoute,
-}
-
-const TweetRouteRouteWithChildren = TweetRouteRoute._addFileChildren(
-  TweetRouteRouteChildren,
-)
-
 interface TracksRouteRouteChildren {
   TracksTrackIdRoute: typeof TracksTrackIdRoute
   TracksIndexRoute: typeof TracksIndexRoute
@@ -808,13 +794,27 @@ const TracksRouteRouteWithChildren = TracksRouteRoute._addFileChildren(
   TracksRouteRouteChildren,
 )
 
+interface TweetRouteRouteChildren {
+  TweetSlugRoute: typeof TweetSlugRoute
+  TweetIndexRoute: typeof TweetIndexRoute
+}
+
+const TweetRouteRouteChildren: TweetRouteRouteChildren = {
+  TweetSlugRoute: TweetSlugRoute,
+  TweetIndexRoute: TweetIndexRoute,
+}
+
+const TweetRouteRouteWithChildren = TweetRouteRoute._addFileChildren(
+  TweetRouteRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   EditorialRouteRoute: EditorialRouteRouteWithChildren,
   LabelsRouteRoute: LabelsRouteRouteWithChildren,
   MixesRouteRoute: MixesRouteRouteWithChildren,
-  TweetRouteRoute: TweetRouteRouteWithChildren,
   TracksRouteRoute: TracksRouteRouteWithChildren,
+  TweetRouteRoute: TweetRouteRouteWithChildren,
   SlugRoute: SlugRoute,
   ChangelogRoute: ChangelogRoute,
   DashboardRoute: DashboardRoute,

--- a/apps/www/src/routes/mix-upload.lazy.tsx
+++ b/apps/www/src/routes/mix-upload.lazy.tsx
@@ -5,6 +5,7 @@ import { createLazyFileRoute, useRouter } from '@tanstack/react-router'
 import { FileText, List, Loader2, Music } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { AudioDropZone } from '@/components/mix-uploader/AudioDropZone'
+import { S3AudioFilePicker } from '@/components/mix-uploader/S3AudioFilePicker'
 import { AudioFileCard } from '@/components/mix-uploader/AudioFileCard'
 import { MixDetailsForm } from '@/components/mix-uploader/MixDetailsForm'
 import {
@@ -103,6 +104,7 @@ function MixUploadPage() {
   const [audioPreview, setAudioPreview] = useState<string | null>(null)
   const [artworkPreview, setArtworkPreview] = useState<string | null>(null)
   const [currentTime, setCurrentTime] = useState(0)
+  const [s3PickerOpen, setS3PickerOpen] = useState(false)
 
   const audioRef = useRef<HTMLAudioElement>(null)
   const router = useRouter()
@@ -300,6 +302,22 @@ function MixUploadPage() {
     }
   }
 
+  const handleS3FileSelect = (url: string, filename: string) => {
+    setAudioPreview(url)
+    setFormData((prev) => {
+      const updated = { ...prev, url }
+      if (!prev.title) {
+        const cleanTitle = filename
+          .replace(/\.[^/.]+$/, '')
+          .replace(/[-_]/g, ' ')
+          .replace(/\b\w/g, (l) => l.toUpperCase())
+        updated.title = cleanTitle
+        if (!prev.slug) updated.slug = generateSlug(cleanTitle)
+      }
+      return updated
+    })
+  }
+
   const handleArtworkFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
@@ -385,10 +403,10 @@ function MixUploadPage() {
   }
 
   const handleSubmit = (isDraft: boolean) => {
-    if (!isEditMode && !audioFile) {
+    if (!isEditMode && !audioFile && !formData.url) {
       toast({
         title: 'Audio file required',
-        description: 'Please select an audio file to upload.',
+        description: 'Please select an audio file to upload or pick one from S3.',
         variant: 'destructive'
       })
       return
@@ -453,8 +471,17 @@ function MixUploadPage() {
         </div>
       </header>
 
+      <S3AudioFilePicker
+        open={s3PickerOpen}
+        onOpenChange={setS3PickerOpen}
+        onSelect={handleS3FileSelect}
+      />
+
       {!audioPreview && !isEditMode ? (
-        <AudioDropZone onFileSelect={handleAudioFileChange} />
+        <AudioDropZone
+          onFileSelect={handleAudioFileChange}
+          onPickFromS3={() => setS3PickerOpen(true)}
+        />
       ) : (
         <div className='grid grid-cols-1 gap-8 lg:grid-cols-12'>
           <div className='space-y-6 lg:col-span-7'>

--- a/apps/www/src/routes/mix-upload.lazy.tsx
+++ b/apps/www/src/routes/mix-upload.lazy.tsx
@@ -5,9 +5,9 @@ import { createLazyFileRoute, useRouter } from '@tanstack/react-router'
 import { FileText, List, Loader2, Music } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { AudioDropZone } from '@/components/mix-uploader/AudioDropZone'
-import { S3AudioFilePicker } from '@/components/mix-uploader/S3AudioFilePicker'
 import { AudioFileCard } from '@/components/mix-uploader/AudioFileCard'
 import { MixDetailsForm } from '@/components/mix-uploader/MixDetailsForm'
+import { S3AudioFilePicker } from '@/components/mix-uploader/S3AudioFilePicker'
 import {
   type TrackEntry,
   TracklistEditor
@@ -406,7 +406,8 @@ function MixUploadPage() {
     if (!isEditMode && !audioFile && !formData.url) {
       toast({
         title: 'Audio file required',
-        description: 'Please select an audio file to upload or pick one from S3.',
+        description:
+          'Please select an audio file to upload or pick one from S3.',
         variant: 'destructive'
       })
       return


### PR DESCRIPTION
## Summary
This PR adds the ability to pick audio files directly from S3 buckets during the mix upload process, providing an alternative to local file uploads.

## Key Changes

- **New S3AudioFilePicker component** (`S3AudioFilePicker.tsx`):
  - Dialog-based UI for browsing and selecting audio files from S3 buckets
  - Filters files by audio extensions (mp3, wav, aiff, aif, flac, ogg, m4a, opus, wma)
  - Displays file metadata (size, full path) with a scrollable list
  - Auto-selects the user content bucket by default
  - Generates public URLs based on bucket configuration
  - Includes refresh functionality to reload file listings

- **Enhanced AudioDropZone component**:
  - Added "Pick from S3 bucket" button as an alternative upload method
  - Visual separator between local upload and S3 picker options
  - Conditional rendering based on S3 picker availability

- **Updated mix-upload page**:
  - Integrated S3AudioFilePicker dialog state management
  - Added `handleS3FileSelect` handler that:
    - Sets audio preview from S3 URL
    - Auto-populates title from filename (with formatting)
    - Auto-generates slug if not already set
  - Updated validation to accept either local file or S3 URL
  - Updated error messaging to reflect both upload options

- **Backend updates** (file-manager):
  - Extended config endpoint to include `routerUrl` for generating public S3 URLs
  - Updated route schema to include the new `routerUrl` field

## Implementation Details

- Uses React Query for efficient data fetching and caching of bucket listings
- Supports multiple bucket types (user content, mixes, and custom buckets)
- Provides user-friendly bucket labels (e.g., "uploads · bucket-name")
- File selection state is properly reset when changing buckets
- Disabled state on confirm button prevents invalid selections

https://claude.ai/code/session_0175X7YiZ96ivHJTBY28c31Q