### PR TITLE
Add JSON-LD structured data and posts to sitemap

### DIFF
--- a/apps/vps/src/routes/redirect/redirect.template.ts
+++ b/apps/vps/src/routes/redirect/redirect.template.ts
@@ -33,6 +33,8 @@ export interface OGData {
   creators?: string[]
   /** Optional alt text for the image */
   imageAlt?: string
+  /** Optional published/updated date for articles */
+  updatedAt?: Date | null
 }
 
 export interface ErrorPageData {
@@ -62,6 +64,9 @@ export const buildOGHtml = (data: OGData): string => {
   // Type-specific OG tags
   const typeSpecificTags = buildTypeSpecificTags(data, creatorNames)
 
+  // JSON-LD structured data
+  const jsonLd = buildJsonLd(data, canonicalUrl, image, siteUrl)
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -88,11 +93,15 @@ ${typeSpecificTags}
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@goosebumpsfm">
   <meta name="twitter:url" content="${canonicalUrl}">
   <meta name="twitter:title" content="${title} | goosebumps.fm">
   <meta name="twitter:description" content="${description}">
   <meta name="twitter:image" content="${image}">
   <meta name="twitter:image:alt" content="${escapeHtml(imageAlt)}">
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">${jsonLd}</script>
 
   <!-- Redirect to the actual page -->
   <meta http-equiv="refresh" content="0;url=${canonicalUrl}">
@@ -161,6 +170,73 @@ ${typeSpecificTags}
   </script>
 </body>
 </html>`
+}
+
+const buildJsonLd = (
+  data: OGData,
+  canonicalUrl: string,
+  image: string,
+  siteUrl: string
+): string => {
+  const base = {
+    '@context': 'https://schema.org',
+    name: data.title,
+    description: data.description,
+    image,
+    url: canonicalUrl
+  }
+
+  if (data.type === 'music.song' || data.type === 'music.album') {
+    const schema: Record<string, unknown> = {
+      ...base,
+      '@type': data.type === 'music.album' ? 'MusicAlbum' : 'MusicRecording'
+    }
+    if (data.creators?.length) {
+      schema.byArtist = data.creators.map((name) => ({
+        '@type': 'MusicGroup',
+        name
+      }))
+    }
+    if (data.audio) {
+      schema.audio = { '@type': 'AudioObject', contentUrl: data.audio }
+    }
+    return JSON.stringify(schema)
+  }
+
+  if (data.type === 'article') {
+    const schema: Record<string, unknown> = {
+      ...base,
+      '@type': 'Article',
+      publisher: {
+        '@type': 'Organization',
+        name: 'goosebumps.fm',
+        url: siteUrl
+      }
+    }
+    if (data.creators?.length) {
+      schema.author = data.creators.map((name) => ({
+        '@type': 'Person',
+        name
+      }))
+    }
+    if (data.updatedAt) {
+      schema.dateModified = data.updatedAt.toISOString()
+    }
+    return JSON.stringify(schema)
+  }
+
+  if (data.type === 'profile') {
+    return JSON.stringify({
+      ...base,
+      '@type': 'Person'
+    })
+  }
+
+  return JSON.stringify({
+    ...base,
+    '@type': 'WebPage',
+    isPartOf: { '@type': 'WebSite', name: 'goosebumps.fm', url: siteUrl }
+  })
 }
 
 const buildTypeSpecificTags = (

--- a/apps/vps/src/routes/redirect/seo/__snapshots__/sitemap.utils.test.ts.snap
+++ b/apps/vps/src/routes/redirect/seo/__snapshots__/sitemap.utils.test.ts.snap
@@ -29,6 +29,16 @@ exports[`sitemap.utils > buildSitemapXml > snapshot: full sitemap structure 1`] 
     <priority>0.7</priority>
   </url>
   <url>
+    <lastmod>2026-02-01</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <lastmod>2026-02-01</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://goosebumps.fm/mixes/test-mix</loc>
     <lastmod>2024-01-15</lastmod>
     <changefreq>weekly</changefreq>
@@ -57,6 +67,18 @@ exports[`sitemap.utils > buildSitemapXml > snapshot: full sitemap structure 1`] 
     <lastmod>2024-01-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://goosebumps.fm/editorial/test-post</loc>
+    <lastmod>2024-01-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://goosebumps.fm/tweet/test-tweet</loc>
+    <lastmod>2024-01-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
 </urlset>"
 `;

--- a/apps/vps/src/routes/redirect/seo/sitemap.service.ts
+++ b/apps/vps/src/routes/redirect/seo/sitemap.service.ts
@@ -137,15 +137,14 @@ const fetchPosts = () =>
 
 // Effect to fetch all sitemap data
 export const fetchSitemapData = Effect.gen(function* () {
-  const [mixes, shows, releases, labels, profiles, posts] =
-    yield* Effect.all([
-      fetchMixes(),
-      fetchShows(),
-      fetchReleases(),
-      fetchLabels(),
-      fetchProfiles(),
-      fetchPosts()
-    ])
+  const [mixes, shows, releases, labels, profiles, posts] = yield* Effect.all([
+    fetchMixes(),
+    fetchShows(),
+    fetchReleases(),
+    fetchLabels(),
+    fetchProfiles(),
+    fetchPosts()
+  ])
   return { mixes, shows, releases, labels, profiles, posts } as SitemapData
 })
 

--- a/apps/vps/src/routes/redirect/seo/sitemap.service.ts
+++ b/apps/vps/src/routes/redirect/seo/sitemap.service.ts
@@ -1,9 +1,10 @@
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { Effect } from 'effect'
 import { db } from '@/db'
 import { audioTable } from '@/db/audio.schema'
 import { user as usersTable } from '@/db/auth.schema'
 import { labelsTable } from '@/db/label.schema'
+import { postsTable } from '@/db/post.schema'
 import { releasesTable } from '@/db/release.schema'
 import { showsTable } from '@/db/show.schema'
 import { DatabaseError } from '@/errors'
@@ -11,7 +12,12 @@ import { config } from '@/services/config.service'
 import { buildSitemapXml, type SitemapData } from './sitemap.utils'
 
 // Re-export types and pure functions from utils
-export type { ProfileEntry, SitemapData, SitemapEntry } from './sitemap.utils'
+export type {
+  PostEntry,
+  ProfileEntry,
+  SitemapData,
+  SitemapEntry
+} from './sitemap.utils'
 export {
   buildSitemapIndexXml,
   buildSitemapXml,
@@ -35,7 +41,7 @@ const fetchMixes = () =>
       db
         .select({ slug: audioTable.slug, updatedAt: audioTable.updatedAt })
         .from(audioTable)
-        .where(eq(audioTable.draft, false)),
+        .where(and(eq(audioTable.draft, false), eq(audioTable.type, 'mix'))),
     catch: (error) =>
       new DatabaseError({
         message: String(error),
@@ -110,16 +116,37 @@ const fetchProfiles = () =>
       })
   })
 
+const fetchPosts = () =>
+  Effect.tryPromise({
+    try: () =>
+      db
+        .select({
+          slug: postsTable.slug,
+          updatedAt: postsTable.updatedAt,
+          type: postsTable.type
+        })
+        .from(postsTable)
+        .where(eq(postsTable.draft, false)),
+    catch: (error) =>
+      new DatabaseError({
+        message: String(error),
+        operation: 'select',
+        table: 'posts'
+      })
+  })
+
 // Effect to fetch all sitemap data
 export const fetchSitemapData = Effect.gen(function* () {
-  const [mixes, shows, releases, labels, profiles] = yield* Effect.all([
-    fetchMixes(),
-    fetchShows(),
-    fetchReleases(),
-    fetchLabels(),
-    fetchProfiles()
-  ])
-  return { mixes, shows, releases, labels, profiles } as SitemapData
+  const [mixes, shows, releases, labels, profiles, posts] =
+    yield* Effect.all([
+      fetchMixes(),
+      fetchShows(),
+      fetchReleases(),
+      fetchLabels(),
+      fetchProfiles(),
+      fetchPosts()
+    ])
+  return { mixes, shows, releases, labels, profiles, posts } as SitemapData
 })
 
 // Regenerate and cache the sitemap
@@ -134,7 +161,7 @@ export const regenerateSitemap = Effect.gen(function* () {
   }
 
   yield* Effect.log(
-    `✅ Sitemap regenerated with ${data.mixes.length} mixes, ${data.shows.length} shows, ${data.releases.length} releases, ${data.labels.length} labels, ${data.profiles.filter((p) => p.username).length} profiles`
+    `✅ Sitemap regenerated with ${data.mixes.length} mixes, ${data.shows.length} shows, ${data.releases.length} releases, ${data.labels.length} labels, ${data.profiles.filter((p) => p.username).length} profiles, ${data.posts.length} posts`
   )
 
   return sitemapCache

--- a/apps/vps/src/routes/redirect/seo/sitemap.utils.test.ts
+++ b/apps/vps/src/routes/redirect/seo/sitemap.utils.test.ts
@@ -58,6 +58,14 @@ describe('sitemap.utils', () => {
       profiles: [
         { username: 'dj-cool', updatedAt: new Date('2024-06-12') },
         { username: null, updatedAt: new Date('2024-06-12') } // Should be filtered out
+      ],
+      posts: [
+        {
+          slug: 'my-editorial',
+          updatedAt: new Date('2024-06-05'),
+          type: 'post'
+        },
+        { slug: 'my-tweet', updatedAt: new Date('2024-06-08'), type: 'micro' }
       ]
     }
 
@@ -87,6 +95,8 @@ describe('sitemap.utils', () => {
       expect(xml).toContain('<loc>https://goosebumps.fm/shows</loc>')
       expect(xml).toContain('<loc>https://goosebumps.fm/releases</loc>')
       expect(xml).toContain('<loc>https://goosebumps.fm/labels</loc>')
+      expect(xml).toContain('<loc>https://goosebumps.fm/editorial</loc>')
+      expect(xml).toContain('<loc>https://goosebumps.fm/tweet</loc>')
     })
 
     test('includes all mixes', () => {
@@ -142,9 +152,39 @@ describe('sitemap.utils', () => {
           !m.includes('/mixes') &&
           !m.includes('/shows') &&
           !m.includes('/releases') &&
-          !m.includes('/labels')
+          !m.includes('/labels') &&
+          !m.includes('/editorial') &&
+          !m.includes('/tweet')
       )
       expect(nonStaticProfiles).toHaveLength(1)
+    })
+
+    test('includes editorial posts at /editorial/:slug', () => {
+      const xml = buildSitemapXml(mockData, 'https://goosebumps.fm')
+
+      expect(xml).toContain(
+        '<loc>https://goosebumps.fm/editorial/my-editorial</loc>'
+      )
+    })
+
+    test('includes micro posts at /tweet/:slug', () => {
+      const xml = buildSitemapXml(mockData, 'https://goosebumps.fm')
+
+      expect(xml).toContain(
+        '<loc>https://goosebumps.fm/tweet/my-tweet</loc>'
+      )
+    })
+
+    test('null-type posts default to /editorial/:slug', () => {
+      const data: SitemapData = {
+        ...mockData,
+        posts: [{ slug: 'unknown-type', updatedAt: new Date(), type: null }]
+      }
+      const xml = buildSitemapXml(data, 'https://goosebumps.fm')
+
+      expect(xml).toContain(
+        '<loc>https://goosebumps.fm/editorial/unknown-type</loc>'
+      )
     })
 
     test('snapshot: full sitemap structure', () => {
@@ -162,6 +202,18 @@ describe('sitemap.utils', () => {
           labels: [{ slug: 'test-label', updatedAt: new Date('2024-01-01') }],
           profiles: [
             { username: 'testuser', updatedAt: new Date('2024-01-20') }
+          ],
+          posts: [
+            {
+              slug: 'test-post',
+              updatedAt: new Date('2024-01-25'),
+              type: 'post'
+            },
+            {
+              slug: 'test-tweet',
+              updatedAt: new Date('2024-01-26'),
+              type: 'micro'
+            }
           ]
         }
 
@@ -202,7 +254,7 @@ describe('sitemap.utils', () => {
       // This will have a dynamic date, so we just check structure
       const xml = buildSitemapIndexXml('https://goosebumps.fm')
 
-      // Replace date with placeholder for snapshot
+      // Replace date with placeholder for snapshot stability
       const normalized = xml.replace(
         /<lastmod>\d{4}-\d{2}-\d{2}<\/lastmod>/,
         '<lastmod>YYYY-MM-DD</lastmod>'
@@ -227,7 +279,8 @@ describe('sitemap.utils', () => {
         shows: [],
         releases: [],
         labels: [],
-        profiles: []
+        profiles: [],
+        posts: []
       }
 
       const xml = buildSitemapXml(emptyData, 'https://goosebumps.fm')

--- a/apps/vps/src/routes/redirect/seo/sitemap.utils.test.ts
+++ b/apps/vps/src/routes/redirect/seo/sitemap.utils.test.ts
@@ -170,9 +170,7 @@ describe('sitemap.utils', () => {
     test('includes micro posts at /tweet/:slug', () => {
       const xml = buildSitemapXml(mockData, 'https://goosebumps.fm')
 
-      expect(xml).toContain(
-        '<loc>https://goosebumps.fm/tweet/my-tweet</loc>'
-      )
+      expect(xml).toContain('<loc>https://goosebumps.fm/tweet/my-tweet</loc>')
     })
 
     test('null-type posts default to /editorial/:slug', () => {

--- a/apps/vps/src/routes/redirect/seo/sitemap.utils.ts
+++ b/apps/vps/src/routes/redirect/seo/sitemap.utils.ts
@@ -10,12 +10,19 @@ export interface ProfileEntry {
   updatedAt: Date
 }
 
+export interface PostEntry {
+  slug: string
+  updatedAt: Date
+  type: 'post' | 'micro' | null
+}
+
 export interface SitemapData {
   mixes: SitemapEntry[]
   shows: SitemapEntry[]
   releases: SitemapEntry[]
   labels: SitemapEntry[]
   profiles: ProfileEntry[]
+  posts: PostEntry[]
 }
 
 export const formatDate = (date: Date): string => {
@@ -48,6 +55,8 @@ export const buildSitemapXml = (data: SitemapData, siteUrl: string): string => {
   urls.push(buildUrlEntry(`${siteUrl}/shows`, now, 'daily', '0.9'))
   urls.push(buildUrlEntry(`${siteUrl}/releases`, now, 'weekly', '0.7'))
   urls.push(buildUrlEntry(`${siteUrl}/labels`, now, 'weekly', '0.7'))
+  urls.push(buildUrlEntry(`${siteUrl}/editorial`, now, 'daily', '0.8'))
+  urls.push(buildUrlEntry(`${siteUrl}/tweet`, now, 'daily', '0.8'))
 
   // Mixes
   for (const mix of data.mixes) {
@@ -99,6 +108,15 @@ export const buildSitemapXml = (data: SitemapData, siteUrl: string): string => {
         )
       )
     }
+  }
+
+  // Posts: 'post' type -> /editorial/:slug, 'micro' type -> /tweet/:slug
+  for (const post of data.posts) {
+    const path =
+      post.type === 'micro'
+        ? `${siteUrl}/tweet/${post.slug}`
+        : `${siteUrl}/editorial/${post.slug}`
+    urls.push(buildUrlEntry(path, post.updatedAt, 'weekly', '0.7'))
   }
 
   return `<?xml version="1.0" encoding="UTF-8"?>

--- a/infra/dns.ts
+++ b/infra/dns.ts
@@ -22,11 +22,11 @@ if ($app.stage === 'prod') {
     }
   })
 
-  new cloudflare.Ruleset('rss-redirect', {
+  new cloudflare.Ruleset('vps-redirects', {
     kind: 'zone',
     zoneId: zone.zoneId,
-    name: 'RSS Feed Redirects',
-    description: 'Redirect RSS requests to VPS',
+    name: 'VPS Route Redirects',
+    description: 'Redirect requests to VPS for dynamic content',
     phase: 'http_request_dynamic_redirect',
     rules: [
       {
@@ -41,6 +41,35 @@ if ($app.stage === 'prod') {
         },
         expression: `(http.request.uri.path eq "/rss.xml") or (http.request.uri.path eq "/rss")`,
         description: 'Redirect RSS feeds to VPS',
+        enabled: true
+      },
+      {
+        action: 'redirect',
+        actionParameters: {
+          fromValue: {
+            statusCode: 301,
+            targetUrl: {
+              value: `https://vps.${domain}/sitemap.xml`
+            }
+          }
+        },
+        expression: `http.request.uri.path eq "/sitemap.xml"`,
+        description: 'Redirect sitemap to VPS dynamic sitemap',
+        enabled: true
+      },
+      {
+        action: 'redirect',
+        actionParameters: {
+          fromValue: {
+            statusCode: 301,
+            targetUrl: {
+              expression: `concat("https://vps.${domain}", http.request.uri.path)`
+            },
+            preserveQueryString: true
+          }
+        },
+        expression: `starts_with(http.request.uri.path, "/s/")`,
+        description: 'Redirect share routes to VPS OG handlers',
         enabled: true
       }
     ]


### PR DESCRIPTION
- [ ] One thing still to do manually: Submit goosebumps.fm/sitemap.xml once via Google Search Console to seed discovery. After that, Google will find it automatically via robots.txt.

## Summary
This PR enhances SEO capabilities by adding JSON-LD structured data generation for Open Graph pages and extending sitemap support to include blog posts and micro-posts (tweets).

## Key Changes

### Open Graph & Structured Data
- Added `updatedAt` field to `OGData` interface for article metadata
- Implemented `buildJsonLd()` function to generate schema.org JSON-LD structured data with type-specific handling:
  - **Music content** (songs/albums): Generates `MusicRecording`/`MusicAlbum` schemas with artist information
  - **Articles**: Generates `Article` schemas with author and modification date
  - **Profiles**: Generates `Person` schemas
  - **Default**: Generates `WebPage` schemas
- Added Twitter site handle (`@goosebumpsfm`) to Twitter meta tags
- Embedded JSON-LD script tag in HTML head for search engine discovery

### Sitemap Enhancements
- Added `PostEntry` interface to support posts with slug, updatedAt, and type fields
- Extended `SitemapData` to include posts array
- Implemented `fetchPosts()` database query to retrieve non-draft posts
- Added post routing logic:
  - Posts with type `'micro'` route to `/tweet/:slug`
  - Posts with type `'post'` or null default to `/editorial/:slug`
- Added static route entries for `/editorial` and `/tweet` collections with daily change frequency
- Updated sitemap generation logging to include post count
- Fixed mixes query to explicitly filter by type `'mix'` (was previously fetching all audio)

### Infrastructure
- Renamed Cloudflare ruleset from `'rss-redirect'` to `'vps-redirects'` for clarity
- Added dynamic sitemap redirect rule (`/sitemap.xml` → VPS)
- Added share route redirect rule (`/s/*` → VPS OG handlers)

### Testing
- Updated sitemap tests to include post fixtures and validation
- Added specific test cases for editorial and micro-post routing
- Added null-type post default behavior test
- Updated snapshot tests to reflect new post entries

https://claude.ai/code/session_01Gu5rUUxLwtWztS6DrVRffo