### PR TITLE
Add Media Session API for OS-level music player metadata

### DIFF
--- a/apps/www/e2e/media-session.spec.ts
+++ b/apps/www/e2e/media-session.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test'
+
+const MOCK_MIX_1 = {
+  id: 'mix-001',
+  title: 'Goosebumps Vol. 1',
+  slug: 'goosebumps-vol-1',
+  description: 'A test mix',
+  thumbnailUrl: 'https://example.com/thumb1.jpg',
+  url: 'https://example.com/mix1.mp3',
+  type: 'mix',
+  tags: ['house'],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  creators: [{ id: 'c1', name: 'DJ Test', username: 'djtest' }],
+  playCount: 0,
+  draft: false,
+  content: ''
+}
+
+const MOCK_MIX_2 = {
+  ...MOCK_MIX_1,
+  id: 'mix-002',
+  title: 'Late Night Frequencies',
+  slug: 'late-night-frequencies',
+  thumbnailUrl: 'https://example.com/thumb2.jpg',
+  url: 'https://example.com/mix2.mp3',
+  creators: [
+    { id: 'c2', name: 'DJ One', username: 'djone' },
+    { id: 'c3', name: 'DJ Two', username: 'djtwo' }
+  ]
+}
+
+test.describe('Media Session API', () => {
+  test.beforeEach(async ({ page }) => {
+    // Prevent real audio network requests and autoplay errors
+    await page.addInitScript(() => {
+      HTMLMediaElement.prototype.load = function () {}
+      HTMLMediaElement.prototype.play = function () {
+        this.dispatchEvent(new Event('play'))
+        return Promise.resolve()
+      }
+      HTMLMediaElement.prototype.pause = function () {
+        this.dispatchEvent(new Event('pause'))
+      }
+    })
+
+    await page.route('**/*', async (route) => {
+      const url = route.request().url()
+      if (url.includes('/content/audio/mix')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [MOCK_MIX_1, MOCK_MIX_2],
+            pagination: { total: 2, limit: 20, offset: 0, hasMore: false }
+          })
+        })
+      } else if (url.endsWith('.mp3')) {
+        await route.fulfill({ status: 200, contentType: 'audio/mpeg', body: '' })
+      } else {
+        await route.continue()
+      }
+    })
+  })
+
+  test('sets title and artist metadata when a mix starts playing', async ({
+    page
+  }) => {
+    await page.goto('/mixes')
+    await page.waitForSelector('[data-testid="mix-item"]')
+
+    await page.getByRole('button', { name: /^PLAY/i }).first().click()
+
+    const metadata = await page.evaluate(() => {
+      const m = navigator.mediaSession.metadata
+      if (!m) return null
+      return { title: m.title, artist: m.artist }
+    })
+
+    expect(metadata?.title).toBe('Goosebumps Vol. 1')
+    expect(metadata?.artist).toBe('DJ Test')
+  })
+
+  test('includes artwork url in metadata', async ({ page }) => {
+    await page.goto('/mixes')
+    await page.waitForSelector('[data-testid="mix-item"]')
+
+    await page.getByRole('button', { name: /^PLAY/i }).first().click()
+
+    const artworkSrcs = await page.evaluate(() =>
+      navigator.mediaSession.metadata?.artwork?.map((a) => a.src) ?? []
+    )
+
+    expect(artworkSrcs).toContain('https://example.com/thumb1.jpg')
+  })
+
+  test('joins multiple creators into artist string', async ({ page }) => {
+    await page.goto('/mixes')
+    await page.waitForSelector('[data-testid="mix-item"]')
+
+    // Click the second mix (Late Night Frequencies — 2 creators)
+    await page.getByRole('button', { name: /^PLAY/i }).nth(1).click()
+
+    const artist = await page.evaluate(
+      () => navigator.mediaSession.metadata?.artist
+    )
+
+    expect(artist).toBe('DJ One, DJ Two')
+  })
+
+  test('sets playbackState to playing after play', async ({ page }) => {
+    await page.goto('/mixes')
+    await page.waitForSelector('[data-testid="mix-item"]')
+
+    await page.getByRole('button', { name: /^PLAY/i }).first().click()
+
+    const state = await page.evaluate(
+      () => navigator.mediaSession.playbackState
+    )
+
+    expect(state).toBe('playing')
+  })
+
+  test('sets playbackState to paused after pause', async ({ page }) => {
+    await page.goto('/mixes')
+    await page.waitForSelector('[data-testid="mix-item"]')
+
+    await page.getByRole('button', { name: /^PLAY/i }).first().click()
+    // Button text changes to PLAYING when active — clicking it pauses
+    await page.getByRole('button', { name: /PLAYING/i }).click()
+
+    const state = await page.evaluate(
+      () => navigator.mediaSession.playbackState
+    )
+
+    expect(state).toBe('paused')
+  })
+
+  test('updates metadata when switching to a different mix', async ({
+    page
+  }) => {
+    await page.goto('/mixes')
+    await page.waitForSelector('[data-testid="mix-item"]')
+
+    await page.getByRole('button', { name: /^PLAY/i }).first().click()
+    await page.getByRole('button', { name: /^PLAY/i }).nth(1).click()
+
+    const metadata = await page.evaluate(() => ({
+      title: navigator.mediaSession.metadata?.title,
+      artist: navigator.mediaSession.metadata?.artist
+    }))
+
+    expect(metadata.title).toBe('Late Night Frequencies')
+    expect(metadata.artist).toBe('DJ One, DJ Two')
+  })
+
+  test('updates artwork when switching tracks', async ({ page }) => {
+    await page.goto('/mixes')
+    await page.waitForSelector('[data-testid="mix-item"]')
+
+    await page.getByRole('button', { name: /^PLAY/i }).first().click()
+    await page.getByRole('button', { name: /^PLAY/i }).nth(1).click()
+
+    const artworkSrcs = await page.evaluate(
+      () => navigator.mediaSession.metadata?.artwork?.map((a) => a.src) ?? []
+    )
+
+    expect(artworkSrcs).toContain('https://example.com/thumb2.jpg')
+    expect(artworkSrcs).not.toContain('https://example.com/thumb1.jpg')
+  })
+})

--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -15,7 +15,13 @@ export default defineConfig({
   projects: [
     {
       name: 'Mobile Chrome',
-      use: { ...devices['Pixel 5'], colorScheme: 'dark' }
+      use: {
+        ...devices['Pixel 5'],
+        colorScheme: 'dark',
+        launchOptions: {
+          executablePath: process.env.CHROMIUM_PATH || undefined
+        }
+      }
     }
   ],
   webServer: {

--- a/apps/www/src/store/audioPlayer.ts
+++ b/apps/www/src/store/audioPlayer.ts
@@ -24,7 +24,11 @@ const setMediaSessionMetadata = (
     ? [{ src: thumbnailUrl, sizes: '512x512', type: 'image/jpeg' }]
     : []
 
-  navigator.mediaSession.metadata = new MediaMetadata({ title, artist, artwork })
+  navigator.mediaSession.metadata = new MediaMetadata({
+    title,
+    artist,
+    artwork
+  })
 }
 
 const setMediaSessionPlaybackState = (playing: boolean) => {
@@ -36,7 +40,7 @@ const setMediaSessionPositionState = (
   duration: number,
   currentTime: number
 ) => {
-  if (!hasMediaSession() || !duration || !isFinite(duration)) return
+  if (!hasMediaSession() || !duration || !Number.isFinite(duration)) return
   try {
     navigator.mediaSession.setPositionState({
       duration,
@@ -242,13 +246,19 @@ export const useAudioPlayerStore = create<AudioPlayerStore>()(
             )
 
             if (hasMediaSession()) {
-              navigator.mediaSession.setActionHandler('play', () => get().play())
-              navigator.mediaSession.setActionHandler('pause', () => get().pause())
-              navigator.mediaSession.setActionHandler('seekbackward', (details) =>
-                get().jumpBackward(details.seekOffset ?? 15)
+              navigator.mediaSession.setActionHandler('play', () =>
+                get().play()
               )
-              navigator.mediaSession.setActionHandler('seekforward', (details) =>
-                get().jumpForward(details.seekOffset ?? 30)
+              navigator.mediaSession.setActionHandler('pause', () =>
+                get().pause()
+              )
+              navigator.mediaSession.setActionHandler(
+                'seekbackward',
+                (details) => get().jumpBackward(details.seekOffset ?? 15)
+              )
+              navigator.mediaSession.setActionHandler(
+                'seekforward',
+                (details) => get().jumpForward(details.seekOffset ?? 30)
               )
               navigator.mediaSession.setActionHandler('previoustrack', () =>
                 get().playPrevious()

--- a/apps/www/src/store/audioPlayer.ts
+++ b/apps/www/src/store/audioPlayer.ts
@@ -9,6 +9,45 @@ import { track } from '@/services/analytics'
 let lastPersistTime = 0
 const PERSIST_INTERVAL = 5000
 
+const hasMediaSession = () =>
+  typeof navigator !== 'undefined' && 'mediaSession' in navigator
+
+const setMediaSessionMetadata = (
+  title: string,
+  creators: Creator[] | undefined,
+  thumbnailUrl: string
+) => {
+  if (!hasMediaSession()) return
+
+  const artist = creators?.map((c) => c.name).join(', ') ?? ''
+  const artwork = thumbnailUrl
+    ? [{ src: thumbnailUrl, sizes: '512x512', type: 'image/jpeg' }]
+    : []
+
+  navigator.mediaSession.metadata = new MediaMetadata({ title, artist, artwork })
+}
+
+const setMediaSessionPlaybackState = (playing: boolean) => {
+  if (!hasMediaSession()) return
+  navigator.mediaSession.playbackState = playing ? 'playing' : 'paused'
+}
+
+const setMediaSessionPositionState = (
+  duration: number,
+  currentTime: number
+) => {
+  if (!hasMediaSession() || !duration || !isFinite(duration)) return
+  try {
+    navigator.mediaSession.setPositionState({
+      duration,
+      playbackRate: 1,
+      position: Math.min(currentTime, duration)
+    })
+  } catch {
+    // Ignore errors from invalid state
+  }
+}
+
 const persistTimeToStorage = (time: number) => {
   try {
     const stored = localStorage.getItem('audio-player-store')
@@ -184,6 +223,7 @@ export const useAudioPlayerStore = create<AudioPlayerStore>()(
                 false,
                 'audioPlayer/updateDuration'
               )
+              setMediaSessionPositionState(ref.duration || 0, ref.currentTime)
             }
 
             const handleVisibilityChange = () => {
@@ -201,6 +241,29 @@ export const useAudioPlayerStore = create<AudioPlayerStore>()(
               handleVisibilityChange
             )
 
+            if (hasMediaSession()) {
+              navigator.mediaSession.setActionHandler('play', () => get().play())
+              navigator.mediaSession.setActionHandler('pause', () => get().pause())
+              navigator.mediaSession.setActionHandler('seekbackward', (details) =>
+                get().jumpBackward(details.seekOffset ?? 15)
+              )
+              navigator.mediaSession.setActionHandler('seekforward', (details) =>
+                get().jumpForward(details.seekOffset ?? 30)
+              )
+              navigator.mediaSession.setActionHandler('previoustrack', () =>
+                get().playPrevious()
+              )
+              navigator.mediaSession.setActionHandler('nexttrack', () =>
+                get().playNext()
+              )
+              navigator.mediaSession.setActionHandler('seekto', (details) => {
+                const { audioRef: ar } = get()
+                if (ar && details.seekTime != null) {
+                  ar.currentTime = details.seekTime
+                }
+              })
+            }
+
             if (!get().isInitialized) {
               get().initialize()
             }
@@ -213,6 +276,7 @@ export const useAudioPlayerStore = create<AudioPlayerStore>()(
 
           audioRef.play()
           set({ isPlaying: true }, false, 'audioPlayer/play')
+          setMediaSessionPlaybackState(true)
 
           if (title) {
             set(
@@ -238,6 +302,7 @@ export const useAudioPlayerStore = create<AudioPlayerStore>()(
 
           audioRef.pause()
           set({ isPlaying: false }, false, 'audioPlayer/pause')
+          setMediaSessionPlaybackState(false)
           if (currentTime > 0) {
             persistTimeToStorage(currentTime)
             lastPersistTime = Date.now()
@@ -368,6 +433,8 @@ export const useAudioPlayerStore = create<AudioPlayerStore>()(
             'audioPlayer/loadTrack'
           )
 
+          setMediaSessionMetadata(title, creators, thumbnailUrl)
+
           void RuntimeClient.runPromise(
             track('audio_played', {
               trackId: trackId ?? null,
@@ -428,6 +495,10 @@ export const useAudioPlayerStore = create<AudioPlayerStore>()(
           if (now - lastPersistTime >= PERSIST_INTERVAL) {
             lastPersistTime = now
             persistTimeToStorage(audioRef.currentTime)
+            setMediaSessionPositionState(
+              audioRef.duration || 0,
+              audioRef.currentTime
+            )
           }
         },
 

--- a/apps/www/src/store/audioPlayer.ts
+++ b/apps/www/src/store/audioPlayer.ts
@@ -20,9 +20,7 @@ const setMediaSessionMetadata = (
   if (!hasMediaSession()) return
 
   const artist = creators?.map((c) => c.name).join(', ') ?? ''
-  const artwork = thumbnailUrl
-    ? [{ src: thumbnailUrl, sizes: '512x512', type: 'image/jpeg' }]
-    : []
+  const artwork = thumbnailUrl ? [{ src: thumbnailUrl }] : []
 
   navigator.mediaSession.metadata = new MediaMetadata({
     title,


### PR DESCRIPTION
Sets track title, artist (creators), and artwork on the device lock screen / notification center via the Media Session API. Also wires up action handlers for play, pause, seek, and next/previous track so hardware controls and OS media controls work correctly.

https://claude.ai/code/session_018Lcz9kAWx9ebUAmih5XrpV