### PR TITLE
Improve Sentry end-to-end performance tracing across www and vps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,6 +97,7 @@ jobs:
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
           CF_RULESET_IMPORT: ${{ inputs.cf_ruleset_import }}
+          SENTRY_RELEASE: ${{ steps.deployment-ref.outputs.ref }}
 
         run: |
           if [ "${{ inputs.refresh }}" = "true" ]; then

--- a/apps/vps/src/instrument.ts
+++ b/apps/vps/src/instrument.ts
@@ -9,6 +9,7 @@ if (dsn) {
   Sentry.init({
     dsn,
     environment,
+    release: process.env.SENTRY_RELEASE,
     tracesSampleRate: 1.0,
     sendDefaultPii: false,
     enableLogs: true,

--- a/apps/vps/src/middlewares/effect-logger.ts
+++ b/apps/vps/src/middlewares/effect-logger.ts
@@ -32,8 +32,15 @@ export function effectLogger(): MiddlewareHandler {
               })
               throw error
             } finally {
+              // Use matched route pattern (e.g. /content/posts/:slug) so
+              // transaction names aggregate by route rather than per-slug URL
+              const routePattern =
+                (c.req as unknown as { routePath?: string }).routePath ??
+                c.req.path
+              const normalizedName = `${c.req.method} ${routePattern}`
+              span.updateName(normalizedName)
               span.setAttribute('http.method', c.req.method)
-              span.setAttribute('http.route', c.req.path)
+              span.setAttribute('http.route', routePattern)
               span.setAttribute('http.status_code', c.res.status)
               span.setAttribute('http.duration_ms', Date.now() - start)
               span.end()

--- a/apps/vps/src/services/post.service.ts
+++ b/apps/vps/src/services/post.service.ts
@@ -318,7 +318,11 @@ const getAllEffect = (options: {
       data: compiledData,
       pagination: createPaginationMetadata(total, limit, offset)
     }
-  })
+  }).pipe(
+    Effect.withSpan('post.getAll', {
+      attributes: { 'post.type': options.type ?? 'all' }
+    })
+  )
 
 const getEditorialsEffect = (options: { limit: number; offset: number }) =>
   Effect.gen(function* () {
@@ -349,7 +353,7 @@ const getEditorialsEffect = (options: { limit: number; offset: number }) =>
       ...posts,
       data
     }
-  })
+  }).pipe(Effect.withSpan('post.getEditorials'))
 
 const getMicroPostsEffect = (options: { limit: number; offset: number }) =>
   Effect.gen(function* () {
@@ -380,7 +384,7 @@ const getMicroPostsEffect = (options: { limit: number; offset: number }) =>
       ...posts,
       data
     }
-  })
+  }).pipe(Effect.withSpan('post.getMicroPosts'))
 
 const getByTagEffect = (
   tag: string,
@@ -495,7 +499,7 @@ const getEditorialBySlugEffect = (slug: string) =>
           })
       )
     )
-  })
+  }).pipe(Effect.withSpan('post.getEditorialBySlug', { attributes: { 'post.slug': slug } }))
 
 const getMicroPostBySlugEffect = (slug: string) =>
   Effect.gen(function* () {
@@ -510,7 +514,7 @@ const getMicroPostBySlugEffect = (slug: string) =>
           })
       )
     )
-  })
+  }).pipe(Effect.withSpan('post.getMicroPostBySlug', { attributes: { 'post.slug': slug } }))
 
 const createEffect = (data: InsertPost, creatorIds: string[]) =>
   Effect.gen(function* () {

--- a/apps/vps/src/services/sentry-client.service.ts
+++ b/apps/vps/src/services/sentry-client.service.ts
@@ -42,6 +42,7 @@ export const SentryClientServiceLive = Layer.effect(
         Sentry.init({
           dsn: sentry.dsn,
           environment: sentry.environment,
+          release: process.env.SENTRY_RELEASE,
           tracesSampleRate: 1.0,
           sendDefaultPii: false,
           enableLogs: true,

--- a/apps/www/src/env.ts
+++ b/apps/www/src/env.ts
@@ -2,5 +2,6 @@ export const env = {
   isDev: import.meta.env.DEV,
   spotifyClientId: import.meta.env.VITE_SPOTIFY_CLIENT_ID,
   sentryDsn: import.meta.env.VITE_PUBLIC_SENTRY_DSN,
-  sentryEnvironment: import.meta.env.VITE_PUBLIC_SENTRY_ENVIRONMENT
+  sentryEnvironment: import.meta.env.VITE_PUBLIC_SENTRY_ENVIRONMENT,
+  sentryRelease: import.meta.env.VITE_PUBLIC_SENTRY_RELEASE as string | undefined
 }

--- a/apps/www/src/runtime/index.ts
+++ b/apps/www/src/runtime/index.ts
@@ -19,8 +19,15 @@ const analyticsLayer = env.sentryDsn
       dsn: env.sentryDsn,
       environment:
         env.sentryEnvironment ?? (env.isDev ? 'development' : 'production'),
+      release: env.sentryRelease,
       debug: env.isDev,
-      tracesSampleRate: env.isDev ? 1.0 : 0.1
+      // temporarily raised to 1.0 for end-to-end trace investigation
+      tracesSampleRate: 1.0,
+      tracePropagationTargets: [
+        'https://vps.goosebumps.fm',
+        'http://127.0.0.1:3003',
+        'http://localhost:3003'
+      ]
     })
   : NoopAnalyticsLayer
 

--- a/apps/www/src/services/analytics/sentry.ts
+++ b/apps/www/src/services/analytics/sentry.ts
@@ -10,6 +10,8 @@ export interface SentryAnalyticsOptions {
   readonly debug?: boolean
   readonly tracesSampleRate?: number
   readonly replaysOnErrorSampleRate?: number
+  readonly tracePropagationTargets?: (string | RegExp)[]
+  readonly release?: string
 }
 
 const makeSentryClientLayer = (options: SentryAnalyticsOptions) =>
@@ -18,6 +20,7 @@ const makeSentryClientLayer = (options: SentryAnalyticsOptions) =>
       Sentry.init({
         dsn: options.dsn,
         environment: options.environment,
+        release: options.release,
         debug: options.debug ?? false,
         integrations: [
           Sentry.browserTracingIntegration(),
@@ -27,6 +30,7 @@ const makeSentryClientLayer = (options: SentryAnalyticsOptions) =>
           })
         ],
         tracesSampleRate: options.tracesSampleRate ?? 0.1,
+        tracePropagationTargets: options.tracePropagationTargets,
         replaysSessionSampleRate: 0,
         replaysOnErrorSampleRate: options.replaysOnErrorSampleRate ?? 1.0,
         sendDefaultPii: false

--- a/infra/vps.ts
+++ b/infra/vps.ts
@@ -44,6 +44,9 @@ export const service = new sst.aws.Service('gbfm_vps', {
     target: 'release',
     dockerfile: 'apps/vps/Dockerfile'
   },
+  environment: {
+    SENTRY_RELEASE: process.env.SENTRY_RELEASE ?? ''
+  },
   link: [
     // database,
     email,

--- a/infra/www.ts
+++ b/infra/www.ts
@@ -13,6 +13,7 @@ export const www = new sst.aws.StaticSite('gbfm-www', {
     VITE_VPS_BASE_URL: isLocal ? 'http://127.0.0.1:3003' : vps_gateway.url,
     VITE_PUBLIC_SENTRY_DSN: secret.VITE_PUBLIC_SENTRY_DSN.value,
     VITE_PUBLIC_SENTRY_ENVIRONMENT: $app.stage,
+    VITE_PUBLIC_SENTRY_RELEASE: process.env.SENTRY_RELEASE ?? '',
     VITE_SPOTIFY_CLIENT_ID: secret.SpotifyClientId.value
   },
   domain: {


### PR DESCRIPTION
- Frontend: raise tracesSampleRate to 1.0 for investigation
- Frontend: add tracePropagationTargets for vps.goosebumps.fm and localhost:3003 to stitch frontend/backend traces
- Frontend: add release support via VITE_PUBLIC_SENTRY_RELEASE env var
- Backend: add SENTRY_RELEASE support in instrument.ts and sentry-client.service.ts
- Backend: normalize transaction names using Hono routePath pattern (e.g. /content/posts/:slug) instead of full URL so spans aggregate by route
- Backend: add Effect.withSpan to PostService hot paths (getAll, getEditorials, getMicroPosts, getEditorialBySlug, getMicroPostBySlug)

Closes #113