### PR TITLE
fix: apply biome formatting to pass CI lint check

### DIFF
--- a/apps/vps/src/services/post.service.ts
+++ b/apps/vps/src/services/post.service.ts
@@ -577,7 +577,11 @@ const getEditorialBySlugEffect = (slug: string, mdx: MdxService) =>
           })
       )
     )
-  }).pipe(Effect.withSpan('post.getEditorialBySlug', { attributes: { 'post.slug': slug } }))
+  }).pipe(
+    Effect.withSpan('post.getEditorialBySlug', {
+      attributes: { 'post.slug': slug }
+    })
+  )
 
 const getMicroPostBySlugEffect = (slug: string, mdx: MdxService) =>
   Effect.gen(function* () {
@@ -592,7 +596,11 @@ const getMicroPostBySlugEffect = (slug: string, mdx: MdxService) =>
           })
       )
     )
-  }).pipe(Effect.withSpan('post.getMicroPostBySlug', { attributes: { 'post.slug': slug } }))
+  }).pipe(
+    Effect.withSpan('post.getMicroPostBySlug', {
+      attributes: { 'post.slug': slug }
+    })
+  )
 
 const createEffect = (data: InsertPost, creatorIds: string[]) =>
   Effect.gen(function* () {

--- a/apps/www/src/env.ts
+++ b/apps/www/src/env.ts
@@ -3,5 +3,7 @@ export const env = {
   spotifyClientId: import.meta.env.VITE_SPOTIFY_CLIENT_ID,
   sentryDsn: import.meta.env.VITE_PUBLIC_SENTRY_DSN,
   sentryEnvironment: import.meta.env.VITE_PUBLIC_SENTRY_ENVIRONMENT,
-  sentryRelease: import.meta.env.VITE_PUBLIC_SENTRY_RELEASE as string | undefined
+  sentryRelease: import.meta.env.VITE_PUBLIC_SENTRY_RELEASE as
+    | string
+    | undefined
 }


### PR DESCRIPTION
apps/vps/src/services/post.service.ts and apps/www/src/env.ts had
formatting that diverged from Biome's output, causing `biome ci` to fail.

https://claude.ai/code/session_01YUBWVzVqpYaF5U21FawrSi