### PR TITLE
refactor(www): migrate VPS_BASE_URL call sites to apiUrl() and fix Sentry trace targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  pull_request:
+    branches: [prod]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-bun-workspace
+
+      - name: Run OXC checks
+        run: bun run oxc:ci
+
+  typecheck:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-bun-workspace
+
+      - name: Type check all packages
+        run: bun run typecheck
+
+  tests:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-bun-workspace
+
+      - name: Run unit and integration tests
+        run: bun run test
+
+  build-www:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-bun-workspace
+
+      - name: Build www package
+        run: cd apps/www && bun run build

--- a/apps/www/src/components/TweetMusicEntityCard.tsx
+++ b/apps/www/src/components/TweetMusicEntityCard.tsx
@@ -2,7 +2,7 @@ import { LINK_STATUS } from '@gbfm/core/status'
 import { useQuery } from '@tanstack/react-query'
 import { Music4 } from 'lucide-react'
 import { StreamLinks } from '@/components/StreamLinks'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 
 type MusicEntityType = 'album' | 'track' | 'playlist'
 
@@ -53,7 +53,7 @@ export function TweetMusicEntityCard({ entityType, entityId }: Props) {
         return Promise.reject(new Error('Unsupported music entity type'))
       }
 
-      return fetcher(`${VPS_BASE_URL}/music/${entityPathByType[supportedType]}/${entityId}`)
+      return fetcher(apiUrl(`/music/${entityPathByType[supportedType]}/${entityId}`))
     },
     enabled: Boolean(supportedType && entityId)
   })
@@ -61,7 +61,7 @@ export function TweetMusicEntityCard({ entityType, entityId }: Props) {
   // todo: we can probs consolidate this into the music entity query above
   const { data: links } = useQuery<EntityLink[]>({
     queryKey: ['music-entity-links', entityType, entityId],
-    queryFn: () => fetcher(`${VPS_BASE_URL}/music/${entityType}/${entityId}/links?status=verified`),
+    queryFn: () => fetcher(apiUrl(`/music/${entityType}/${entityId}/links?status=verified`)),
     enabled: Boolean(supportedType && entityId)
   })
 

--- a/apps/www/src/components/dashboard/RemindersCard.tsx
+++ b/apps/www/src/components/dashboard/RemindersCard.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { Bell, History, type LucideIcon, Plus } from 'lucide-react'
 import { useState } from 'react'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 
 interface MusicReminder {
   id: string
@@ -24,7 +24,7 @@ export function RemindersCard() {
 
   const { data, isPending } = useQuery<RemindersResponse>({
     queryKey: ['reminders'],
-    queryFn: () => fetcher(`${VPS_BASE_URL}/music-reminders`)
+    queryFn: () => fetcher(apiUrl('/music-reminders'))
   })
 
   const upcomingReminders =

--- a/apps/www/src/components/editor.tsx
+++ b/apps/www/src/components/editor.tsx
@@ -14,7 +14,7 @@ import { useMutation, useQuery } from '@tanstack/react-query'
 import { useSearch } from '@tanstack/react-router'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod/v4'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 
 type ContentType = {
   value: string
@@ -91,14 +91,14 @@ export function Editor() {
     queryKey: ['content', id],
     queryFn: async () => {
       if (!id) return null
-      return await fetcher(`${VPS_BASE_URL}/content/${id}`)
+      return await fetcher(apiUrl(`/content/${id}`))
     },
     enabled: Boolean(id)
   })
 
   const { mutate, isPending } = useMutation({
     mutationFn: async (data: FormData) => {
-      const endpoint = id ? `${VPS_BASE_URL}/content/${id}` : `${VPS_BASE_URL}/content`
+      const endpoint = id ? apiUrl(`/content/${id}`) : apiUrl('/content')
       const method = id ? 'PUT' : 'POST'
 
       return await fetcher(endpoint, {

--- a/apps/www/src/components/mix-uploader/S3AudioFilePicker.tsx
+++ b/apps/www/src/components/mix-uploader/S3AudioFilePicker.tsx
@@ -5,7 +5,7 @@ import {
 } from '@gbfm/ui'
 import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 
 interface S3AudioFilePickerProps {
   open: boolean
@@ -27,7 +27,7 @@ export function S3MediaFilePicker({
 
   const { data: configData } = useQuery<BucketConfig>({
     queryKey: ['file-manager', 'config'],
-    queryFn: () => fetcher<BucketConfig>(`${VPS_BASE_URL}/file-manager/config`),
+    queryFn: () => fetcher<BucketConfig>(apiUrl('/file-manager/config')),
     staleTime: Infinity,
     enabled: open
   })
@@ -43,7 +43,7 @@ export function S3MediaFilePicker({
     queryKey: ['file-manager', 'list', effectiveBucket],
     queryFn: () =>
       fetcher<{ objects: S3Object[] }>(
-        `${VPS_BASE_URL}/file-manager/list?bucketName=${encodeURIComponent(effectiveBucket)}`
+        apiUrl(`/file-manager/list?bucketName=${encodeURIComponent(effectiveBucket)}`)
       ),
     enabled: Boolean(effectiveBucket) && open,
     staleTime: 30_000

--- a/apps/www/src/hooks/useMixPlayTracking.ts
+++ b/apps/www/src/hooks/useMixPlayTracking.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { VPS_BASE_URL } from '@/lib/http'
+import { apiUrl } from '@/lib/http'
 import { useAudioPlayerStore } from '@/store/audioPlayer'
 
 /**
@@ -62,7 +62,7 @@ export function useMixPlayTracking() {
     if (isWithinDedupWindow(currentTrackId)) return
     recordPlaySession(currentTrackId)
 
-    fetch(`${VPS_BASE_URL}/content/audio/${currentTrackId}/play`, {
+    fetch(apiUrl(`/content/audio/${currentTrackId}/play`), {
       method: 'POST',
       credentials: 'include'
     }).catch(() => {})

--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -31,7 +31,7 @@ type User = {
 
 import type { AlbumApiResponse, PlaylistApiResponse, TrackAPIResponse } from '@/types'
 
-export const VPS_BASE_URL = import.meta.env.VITE_VPS_BASE_URL || ''
+const VPS_BASE_URL = import.meta.env.VITE_VPS_BASE_URL || ''
 
 export function apiUrl(path: string): string {
   return `${VPS_BASE_URL}${path}`
@@ -207,7 +207,7 @@ export function useAudioByType(
 export function useAudioTags(type: 'mix' | 'track' | 'misc') {
   const { data, error, isPending } = useQuery<string[], Error>({
     queryKey: ['audio-tags', type],
-    queryFn: async () => fetcher<string[]>(`${VPS_BASE_URL}/content/audio/${type}/tags`),
+    queryFn: async () => fetcher<string[]>(apiUrl(`/content/audio/${type}/tags`)),
     staleTime: 1000 * 60 * 60
   })
   return { data: data ?? [], error, isPending }
@@ -216,7 +216,7 @@ export function useAudioTags(type: 'mix' | 'track' | 'misc') {
 export function useEditorialTags() {
   const { data, error, isPending } = useQuery<string[], Error>({
     queryKey: ['editorial-tags'],
-    queryFn: async () => fetcher<string[]>(`${VPS_BASE_URL}/content/posts/editorials/tags`),
+    queryFn: async () => fetcher<string[]>(apiUrl('/content/posts/editorials/tags')),
     staleTime: 1000 * 60 * 60
   })
   return { data: data ?? [], error, isPending }
@@ -225,7 +225,7 @@ export function useEditorialTags() {
 export function useAudioBySlug(type: 'mix' | 'track' | 'misc', slug: string) {
   const { data, error, isPending } = useQuery<SelectMdxCompiledAudio, Error>({
     queryKey: ['audio', type, slug],
-    queryFn: async () => fetcher(`${VPS_BASE_URL}/content/audio/${type}/${slug}`),
+    queryFn: async () => fetcher(apiUrl(`/content/audio/${type}/${slug}`)),
     enabled: Boolean(slug) // Only run query if slug is provided
   })
 
@@ -296,7 +296,7 @@ export function useMicroPosts(limit = DEFAULT_PAGE_SIZE) {
 export function useEditorialPostBySlug(slug: string) {
   const { data, error, isPending } = useQuery<SelectMdxCompiledEditorialPost, Error>({
     queryKey: ['post', 'editorial', slug],
-    queryFn: async () => fetcher(`${VPS_BASE_URL}/content/posts/editorials/${slug}`),
+    queryFn: async () => fetcher(apiUrl(`/content/posts/editorials/${slug}`)),
     enabled: Boolean(slug)
   })
 
@@ -310,7 +310,7 @@ export function useEditorialPostBySlug(slug: string) {
 export function useMicroPostBySlug(slug: string) {
   const { data, error, isPending } = useQuery<SelectMdxCompiledMicroPost, Error>({
     queryKey: ['post', 'micro', slug],
-    queryFn: async () => fetcher(`${VPS_BASE_URL}/content/posts/micro/${slug}`),
+    queryFn: async () => fetcher(apiUrl(`/content/posts/micro/${slug}`)),
     enabled: Boolean(slug)
   })
 
@@ -344,7 +344,7 @@ export function useSpotifyProxy<T extends SpotifyContentType>({
     queryKey: ['spotify/proxy', spotifyContentType, id],
 
     queryFn: async () =>
-      fetcher(`${VPS_BASE_URL}/spotify/${spotifyContentType}`, {
+      fetcher(apiUrl(`/spotify/${spotifyContentType}`), {
         method: 'POST',
         body: JSON.stringify({ id })
       }),
@@ -371,7 +371,7 @@ export function useEnrichTrackFromUrl(url: string) {
   const { data, error, isLoading } = useQuery<EnrichedTrack>({
     queryKey: ['spotify/enrich', url],
     queryFn: async () =>
-      fetcher(`${VPS_BASE_URL}/spotify/enrich`, {
+      fetcher(apiUrl('/spotify/enrich'), {
         method: 'POST',
         body: JSON.stringify({ url })
       }),
@@ -406,7 +406,7 @@ export function useResolveMusicEntity(url: string) {
   const { data, error, isLoading } = useQuery<ResolvedMusicEntity>({
     queryKey: ['music/resolve', url],
     queryFn: async () =>
-      fetcher(`${VPS_BASE_URL}/music/resolve`, {
+      fetcher(apiUrl('/music/resolve'), {
         method: 'POST',
         body: JSON.stringify({ url })
       }),
@@ -424,7 +424,7 @@ export function useResolveMusicEntity(url: string) {
 export function useUserLOL() {
   const { data, error, isPending } = useQuery<User, Error>({
     queryKey: ['user'],
-    queryFn: async () => fetcher(`${VPS_BASE_URL}/user/profile`)
+    queryFn: async () => fetcher(apiUrl('/user/profile'))
   })
 
   return {
@@ -437,7 +437,7 @@ export function useUserLOL() {
 export function useUpdateProfile() {
   const { mutateAsync: updateProfile, isPending } = useMutation<User, Error, FormData | User>({
     mutationFn: async (data) =>
-      fetcher(`${VPS_BASE_URL}/user/profile`, {
+      fetcher(apiUrl('/user/profile'), {
         method: 'PATCH',
         body: data instanceof FormData ? data : JSON.stringify(data)
       })
@@ -452,7 +452,7 @@ export function useUpdateProfile() {
 export function useAdminUserSocialLinks(userId: string) {
   return useQuery<SocialLink[], Error>({
     queryKey: ['admin', 'user-social-links', userId],
-    queryFn: () => fetcher<SocialLink[]>(`${VPS_BASE_URL}/user/admin/${userId}/social-links`),
+    queryFn: () => fetcher<SocialLink[]>(apiUrl(`/user/admin/${userId}/social-links`)),
     enabled: Boolean(userId)
   })
 }
@@ -461,7 +461,7 @@ export function useReplaceAdminUserSocialLinks() {
   const queryClient = useQueryClient()
   return useMutation<SocialLink[], Error, { userId: string; links: SocialLink[] }>({
     mutationFn: ({ userId, links }) =>
-      fetcher<SocialLink[]>(`${VPS_BASE_URL}/user/admin/${userId}/social-links`, {
+      fetcher<SocialLink[]>(apiUrl(`/user/admin/${userId}/social-links`), {
         method: 'PUT',
         body: JSON.stringify(links)
       }),
@@ -476,7 +476,7 @@ export function useReplaceAdminUserSocialLinks() {
 export function useUpdateAdminUserBio() {
   return useMutation<{ bio: string | null }, Error, { userId: string; bio: string }>({
     mutationFn: ({ userId, bio }) =>
-      fetcher<{ bio: string | null }>(`${VPS_BASE_URL}/user/admin/${userId}/bio`, {
+      fetcher<{ bio: string | null }>(apiUrl(`/user/admin/${userId}/bio`), {
         method: 'PATCH',
         body: JSON.stringify({ bio })
       })
@@ -486,7 +486,7 @@ export function useUpdateAdminUserBio() {
 export function useAdminUserBio(userId: string) {
   return useQuery<{ bio: string | null }, Error>({
     queryKey: ['admin', 'user-bio', userId],
-    queryFn: () => fetcher<{ bio: string | null }>(`${VPS_BASE_URL}/user/admin/${userId}/bio`),
+    queryFn: () => fetcher<{ bio: string | null }>(apiUrl(`/user/admin/${userId}/bio`)),
     enabled: Boolean(userId)
   })
 }
@@ -506,7 +506,7 @@ export type EmailPreferences = {
 export function useEmailPreferences() {
   const { data, error, isPending } = useQuery<EmailPreferences, Error>({
     queryKey: ['email-preferences'],
-    queryFn: async () => fetcher(`${VPS_BASE_URL}/user/email-preferences`)
+    queryFn: async () => fetcher(apiUrl('/user/email-preferences'))
   })
 
   return {
@@ -523,7 +523,7 @@ export function useUpdateEmailPreferences() {
     Partial<EmailPreferences>
   >({
     mutationFn: async (preferences) =>
-      fetcher(`${VPS_BASE_URL}/user/email-preferences`, {
+      fetcher(apiUrl('/user/email-preferences'), {
         method: 'PATCH',
         body: JSON.stringify(preferences)
       })
@@ -602,7 +602,7 @@ type NewsletterSubscriber = {
 export function useAdminNewsletterSubscribers() {
   return useQuery<{ subscribers: NewsletterSubscriber[] }, Error>({
     queryKey: ['admin', 'newsletter-subscribers'],
-    queryFn: async () => fetcher(`${VPS_BASE_URL}/admin/newsletter-subscribers`)
+    queryFn: async () => fetcher(apiUrl('/admin/newsletter-subscribers'))
   })
 }
 
@@ -635,7 +635,7 @@ export function useAllLabels({ limit = DEFAULT_PAGE_SIZE }: PaginationOptions = 
 export function useLabelBySlug(slug: string) {
   const { data, error, isPending } = useQuery<SelectMdxCompiledLabel, Error>({
     queryKey: ['label', slug],
-    queryFn: async () => fetcher(`${VPS_BASE_URL}/content/labels/${slug}`),
+    queryFn: async () => fetcher(apiUrl(`/content/labels/${slug}`)),
     enabled: Boolean(slug)
   })
 
@@ -679,7 +679,7 @@ export function useReleasesByLabel(
 export function useReleaseBySlug(slug: string) {
   const { data, error, isPending } = useQuery<SelectMdxCompiledRelease, Error>({
     queryKey: ['release', slug],
-    queryFn: async () => fetcher(`${VPS_BASE_URL}/content/releases/${slug}`),
+    queryFn: async () => fetcher(apiUrl(`/content/releases/${slug}`)),
     enabled: Boolean(slug)
   })
 
@@ -719,7 +719,7 @@ export function useFavorites() {
   const isAuthenticated = Boolean(session?.user)
   const { data, error, isPending, refetch } = useQuery<FavoritesResponse, Error>({
     queryKey: ['favorites'],
-    queryFn: async () => fetcher(`${VPS_BASE_URL}/favorites`),
+    queryFn: async () => fetcher(apiUrl('/favorites')),
     enabled: isAuthenticated
   })
 
@@ -740,7 +740,7 @@ export function useAddFavorite() {
     { audioId: string }
   >({
     mutationFn: async ({ audioId }) =>
-      fetcher(`${VPS_BASE_URL}/favorites`, {
+      fetcher(apiUrl('/favorites'), {
         method: 'POST',
         body: JSON.stringify({ audioId })
       }),
@@ -763,7 +763,7 @@ export function useRemoveFavorite() {
     { audioId: string }
   >({
     mutationFn: async ({ audioId }) =>
-      fetcher(`${VPS_BASE_URL}/favorites/${audioId}`, {
+      fetcher(apiUrl(`/favorites/${audioId}`), {
         method: 'DELETE'
       }),
     onSuccess: () => {
@@ -785,7 +785,7 @@ export function useAddShowFavorite() {
     { showId: string }
   >({
     mutationFn: async ({ showId }) =>
-      fetcher(`${VPS_BASE_URL}/favorites`, {
+      fetcher(apiUrl('/favorites'), {
         method: 'POST',
         body: JSON.stringify({ showId })
       }),
@@ -808,7 +808,7 @@ export function useRemoveShowFavorite() {
     { showId: string }
   >({
     mutationFn: async ({ showId }) =>
-      fetcher(`${VPS_BASE_URL}/favorites/show/${showId}`, {
+      fetcher(apiUrl(`/favorites/show/${showId}`), {
         method: 'DELETE'
       }),
     onSuccess: () => {
@@ -855,7 +855,7 @@ export function useAllShows({ limit = DEFAULT_PAGE_SIZE }: PaginationOptions = {
 export function useShowBySlug(slug: string) {
   const { data, error, isPending } = useQuery<SelectMdxCompiledShow, Error>({
     queryKey: ['show', slug],
-    queryFn: async () => fetcher(`${VPS_BASE_URL}/shows/${slug}`),
+    queryFn: async () => fetcher(apiUrl(`/shows/${slug}`)),
     enabled: Boolean(slug)
   })
 
@@ -877,9 +877,7 @@ export function useShowById(id: string | null | undefined) {
   const { data, error, isPending } = useQuery<ShowBasicInfo, Error>({
     queryKey: ['show-by-id', id],
     queryFn: async () => {
-      const shows = await fetcher<PaginatedResponse<ShowWithHosts>>(
-        `${VPS_BASE_URL}/shows?limit=100`
-      )
+      const shows = await fetcher<PaginatedResponse<ShowWithHosts>>(apiUrl('/shows?limit=100'))
       const show = shows.data.find((s) => s.id === id)
       if (!show) throw new Error('Show not found')
       return {
@@ -940,7 +938,7 @@ export function useUserSubscriptions() {
   const { data, error, isPending } = useQuery<PaginatedResponse<SubscriptionWithShow>, Error>({
     queryKey: ['user-subscriptions'],
     queryFn: async () =>
-      fetcher<PaginatedResponse<SubscriptionWithShow>>(`${VPS_BASE_URL}/user/subscriptions`),
+      fetcher<PaginatedResponse<SubscriptionWithShow>>(apiUrl('/user/subscriptions')),
     enabled: isAuthenticated
   })
 
@@ -959,7 +957,7 @@ export function useSubscribeToShow() {
     { showId: string }
   >({
     mutationFn: async ({ showId }) =>
-      fetcher(`${VPS_BASE_URL}/shows/${showId}/subscribe`, {
+      fetcher(apiUrl(`/shows/${showId}/subscribe`), {
         method: 'POST'
       }),
     onSuccess: () => {
@@ -977,7 +975,7 @@ export function useUnsubscribeFromShow() {
   const queryClient = useQueryClient()
   const { mutateAsync: unsubscribe, isPending } = useMutation<void, Error, { showId: string }>({
     mutationFn: async ({ showId }) =>
-      fetcher(`${VPS_BASE_URL}/shows/${showId}/unsubscribe`, {
+      fetcher(apiUrl(`/shows/${showId}/unsubscribe`), {
         method: 'DELETE'
       }),
     onSuccess: () => {
@@ -1058,7 +1056,7 @@ export function useResolveSlug(slug: string) {
   const { data, error, isPending } = useQuery<ResolveResult, Error>({
     queryKey: ['resolve', slug],
     queryFn: async () => {
-      return fetcher<ResolveResult>(`${VPS_BASE_URL}/resolve/${slug}`)
+      return fetcher<ResolveResult>(apiUrl(`/resolve/${slug}`))
     },
     enabled: Boolean(slug),
     retry: false
@@ -1083,7 +1081,7 @@ export type DjListItem = {
 export function useDjs() {
   return useQuery<DjListItem[], Error>({
     queryKey: ['djs'],
-    queryFn: () => fetcher<DjListItem[]>(`${VPS_BASE_URL}/user/djs`),
+    queryFn: () => fetcher<DjListItem[]>(apiUrl('/user/djs')),
     staleTime: 1000 * 60 * 5
   })
 }
@@ -1092,7 +1090,7 @@ export function usePublicProfile(username: string) {
   const { data, error, isPending } = useQuery<PublicProfile, Error>({
     queryKey: ['profile', username],
     queryFn: async () => {
-      const profile = await fetcher<PublicProfile>(`${VPS_BASE_URL}/profile/${username}`)
+      const profile = await fetcher<PublicProfile>(apiUrl(`/profile/${username}`))
       if (!profile?.id) throw new Error('Profile not found')
       return profile
     },
@@ -1115,7 +1113,7 @@ type NewsletterSubscribeResponse = {
 export function useNewsletterSubscribe() {
   return useMutation<NewsletterSubscribeResponse, Error, { email: string; name?: string }>({
     mutationFn: async ({ email, name }) =>
-      fetcher<NewsletterSubscribeResponse>(`${VPS_BASE_URL}/newsletter/subscribe`, {
+      fetcher<NewsletterSubscribeResponse>(apiUrl('/newsletter/subscribe'), {
         method: 'POST',
         body: JSON.stringify({ email, name, source: 'subscribe_page' })
       })
@@ -1125,7 +1123,7 @@ export function useNewsletterSubscribe() {
 export function useNewsletterUnsubscribe() {
   return useMutation<{ success: boolean }, Error, { token: string }>({
     mutationFn: async ({ token }) =>
-      fetcher<{ success: boolean }>(`${VPS_BASE_URL}/newsletter/unsubscribe`, {
+      fetcher<{ success: boolean }>(apiUrl('/newsletter/unsubscribe'), {
         method: 'POST',
         body: JSON.stringify({ token })
       })
@@ -1135,7 +1133,7 @@ export function useNewsletterUnsubscribe() {
 export function useRequestNewsletterUnsubscribe() {
   return useMutation<{ sent: boolean }, Error, { email: string }>({
     mutationFn: async ({ email }) =>
-      fetcher<{ sent: boolean }>(`${VPS_BASE_URL}/newsletter/request-unsubscribe`, {
+      fetcher<{ sent: boolean }>(apiUrl('/newsletter/request-unsubscribe'), {
         method: 'POST',
         body: JSON.stringify({ email })
       })
@@ -1150,7 +1148,7 @@ type QRPdfResponse = {
 export function useMixQRPdf(slug: string, enabled = false) {
   return useQuery<QRPdfResponse>({
     queryKey: ['mix-qr-pdf', slug],
-    queryFn: () => fetcher<QRPdfResponse>(`${VPS_BASE_URL}/content/audio/mix/${slug}/qr-pdf`),
+    queryFn: () => fetcher<QRPdfResponse>(apiUrl(`/content/audio/mix/${slug}/qr-pdf`)),
     enabled,
     staleTime: 1000 * 60 * 60 * 24
   })
@@ -1159,7 +1157,7 @@ export function useMixQRPdf(slug: string, enabled = false) {
 export function useShowQRPdf(slug: string, enabled = false) {
   return useQuery<QRPdfResponse>({
     queryKey: ['show-qr-pdf', slug],
-    queryFn: () => fetcher<QRPdfResponse>(`${VPS_BASE_URL}/shows/${slug}/qr-pdf`),
+    queryFn: () => fetcher<QRPdfResponse>(apiUrl(`/shows/${slug}/qr-pdf`)),
     enabled,
     staleTime: 1000 * 60 * 60 * 24
   })
@@ -1229,14 +1227,14 @@ export interface AdminMusicEntityLink {
 export function useAdminArtists() {
   return useQuery<MusicArtist[]>({
     queryKey: ['admin', 'artists'],
-    queryFn: () => fetcher(`${VPS_BASE_URL}/music/artists`)
+    queryFn: () => fetcher(apiUrl('/music/artists'))
   })
 }
 
 export function useAdminArtist(id: string) {
   return useQuery<MusicArtist>({
     queryKey: ['admin', 'artists', id],
-    queryFn: () => fetcher(`${VPS_BASE_URL}/music/artists/${id}`),
+    queryFn: () => fetcher(apiUrl(`/music/artists/${id}`)),
     enabled: Boolean(id)
   })
 }
@@ -1245,7 +1243,7 @@ export function useUpdateAdminArtist() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) =>
-      fetcher<MusicArtist>(`${VPS_BASE_URL}/music/artists/${id}`, {
+      fetcher<MusicArtist>(apiUrl(`/music/artists/${id}`), {
         method: 'PATCH',
         body: JSON.stringify(data)
       }),
@@ -1259,8 +1257,7 @@ export function useUpdateAdminArtist() {
 export function useDeleteAdminArtist() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (id: string) =>
-      fetcher(`${VPS_BASE_URL}/music/artists/${id}`, { method: 'DELETE' }),
+    mutationFn: (id: string) => fetcher(apiUrl(`/music/artists/${id}`), { method: 'DELETE' }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['admin', 'artists'] })
   })
 }
@@ -1268,14 +1265,14 @@ export function useDeleteAdminArtist() {
 export function useAdminAlbums() {
   return useQuery<MusicAlbum[]>({
     queryKey: ['admin', 'albums'],
-    queryFn: () => fetcher(`${VPS_BASE_URL}/music/albums`)
+    queryFn: () => fetcher(apiUrl('/music/albums'))
   })
 }
 
 export function useAdminAlbum(id: string) {
   return useQuery<MusicAlbum>({
     queryKey: ['admin', 'albums', id],
-    queryFn: () => fetcher(`${VPS_BASE_URL}/music/albums/${id}`),
+    queryFn: () => fetcher(apiUrl(`/music/albums/${id}`)),
     enabled: Boolean(id)
   })
 }
@@ -1284,7 +1281,7 @@ export function useUpdateAdminAlbum() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) =>
-      fetcher<MusicAlbum>(`${VPS_BASE_URL}/music/albums/${id}`, {
+      fetcher<MusicAlbum>(apiUrl(`/music/albums/${id}`), {
         method: 'PATCH',
         body: JSON.stringify(data)
       }),
@@ -1298,7 +1295,7 @@ export function useUpdateAdminAlbum() {
 export function useDeleteAdminAlbum() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (id: string) => fetcher(`${VPS_BASE_URL}/music/albums/${id}`, { method: 'DELETE' }),
+    mutationFn: (id: string) => fetcher(apiUrl(`/music/albums/${id}`), { method: 'DELETE' }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['admin', 'albums'] })
   })
 }
@@ -1306,14 +1303,14 @@ export function useDeleteAdminAlbum() {
 export function useAdminTracks() {
   return useQuery<MusicTrack[]>({
     queryKey: ['admin', 'tracks'],
-    queryFn: () => fetcher(`${VPS_BASE_URL}/music/tracks`)
+    queryFn: () => fetcher(apiUrl('/music/tracks'))
   })
 }
 
 export function useAdminTrack(id: string) {
   return useQuery<MusicTrack>({
     queryKey: ['admin', 'tracks', id],
-    queryFn: () => fetcher(`${VPS_BASE_URL}/music/tracks/${id}`),
+    queryFn: () => fetcher(apiUrl(`/music/tracks/${id}`)),
     enabled: Boolean(id)
   })
 }
@@ -1322,7 +1319,7 @@ export function useUpdateAdminTrack() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) =>
-      fetcher<MusicTrack>(`${VPS_BASE_URL}/music/tracks/${id}`, {
+      fetcher<MusicTrack>(apiUrl(`/music/tracks/${id}`), {
         method: 'PATCH',
         body: JSON.stringify(data)
       }),
@@ -1336,7 +1333,7 @@ export function useUpdateAdminTrack() {
 export function useDeleteAdminTrack() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (id: string) => fetcher(`${VPS_BASE_URL}/music/tracks/${id}`, { method: 'DELETE' }),
+    mutationFn: (id: string) => fetcher(apiUrl(`/music/tracks/${id}`), { method: 'DELETE' }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['admin', 'tracks'] })
   })
 }
@@ -1344,7 +1341,7 @@ export function useDeleteAdminTrack() {
 export function useAdminEntityLinks(entityType: string, entityId: string, enabled = true) {
   return useQuery<AdminMusicEntityLink[]>({
     queryKey: ['admin', 'links', entityType, entityId],
-    queryFn: () => fetcher(`${VPS_BASE_URL}/music/${entityType}/${entityId}/links`),
+    queryFn: () => fetcher(apiUrl(`/music/${entityType}/${entityId}/links`)),
     enabled: enabled && Boolean(entityId)
   })
 }
@@ -1364,7 +1361,7 @@ export function useAddAdminEntityLink() {
       url: string
       status?: LinkStatus
     }) =>
-      fetcher<AdminMusicEntityLink>(`${VPS_BASE_URL}/music/${entityType}/${entityId}/links`, {
+      fetcher<AdminMusicEntityLink>(apiUrl(`/music/${entityType}/${entityId}/links`), {
         method: 'POST',
         body: JSON.stringify({ platform, url, status })
       }),
@@ -1389,10 +1386,10 @@ export function useUpdateAdminEntityLinkStatus() {
       linkId: string
       status: LinkStatus
     }) =>
-      fetcher<AdminMusicEntityLink>(
-        `${VPS_BASE_URL}/music/${entityType}/${entityId}/links/${linkId}`,
-        { method: 'PATCH', body: JSON.stringify({ status }) }
-      ),
+      fetcher<AdminMusicEntityLink>(apiUrl(`/music/${entityType}/${entityId}/links/${linkId}`), {
+        method: 'PATCH',
+        body: JSON.stringify({ status })
+      }),
     onSuccess: (_, { entityType, entityId }) =>
       qc.invalidateQueries({
         queryKey: ['admin', 'links', entityType, entityId]
@@ -1412,7 +1409,7 @@ export function useDeleteAdminEntityLink() {
       entityId: string
       linkId: string
     }) =>
-      fetcher(`${VPS_BASE_URL}/music/${entityType}/${entityId}/links/${linkId}`, {
+      fetcher(apiUrl(`/music/${entityType}/${entityId}/links/${linkId}`), {
         method: 'DELETE'
       }),
     onSuccess: (_, { entityType, entityId }) =>
@@ -1434,7 +1431,7 @@ export function useAddArtistToAlbum() {
       artistId: string
       role?: string
     }) =>
-      fetcher(`${VPS_BASE_URL}/music/albums/${albumId}/artists/${artistId}`, {
+      fetcher(apiUrl(`/music/albums/${albumId}/artists/${artistId}`), {
         method: 'PUT',
         body: JSON.stringify({ role })
       }),
@@ -1447,7 +1444,7 @@ export function useRemoveArtistFromAlbum() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: ({ albumId, artistId }: { albumId: string; artistId: string }) =>
-      fetcher(`${VPS_BASE_URL}/music/albums/${albumId}/artists/${artistId}`, {
+      fetcher(apiUrl(`/music/albums/${albumId}/artists/${artistId}`), {
         method: 'DELETE'
       }),
     onSuccess: (_, { albumId }) =>
@@ -1467,7 +1464,7 @@ export function useAddArtistToTrack() {
       artistId: string
       role?: string
     }) =>
-      fetcher(`${VPS_BASE_URL}/music/tracks/${trackId}/artists/${artistId}`, {
+      fetcher(apiUrl(`/music/tracks/${trackId}/artists/${artistId}`), {
         method: 'PUT',
         body: JSON.stringify({ role })
       }),
@@ -1480,7 +1477,7 @@ export function useRemoveArtistFromTrack() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: ({ trackId, artistId }: { trackId: string; artistId: string }) =>
-      fetcher(`${VPS_BASE_URL}/music/tracks/${trackId}/artists/${artistId}`, {
+      fetcher(apiUrl(`/music/tracks/${trackId}/artists/${artistId}`), {
         method: 'DELETE'
       }),
     onSuccess: (_, { trackId }) =>

--- a/apps/www/src/lib/useFeaturedMix.ts
+++ b/apps/www/src/lib/useFeaturedMix.ts
@@ -1,13 +1,13 @@
 import type { SelectAudio } from '@gbfm/vps/schemas'
 import { useQuery } from '@tanstack/react-query'
-import { fetcher, type PaginatedResponse, VPS_BASE_URL } from './http'
+import { apiUrl, fetcher, type PaginatedResponse } from './http'
 
 export function useFeaturedMix() {
   const { data, error, isPending } = useQuery<SelectAudio, Error>({
     queryKey: ['featured-mix'],
     queryFn: async () => {
       const response = await fetcher<PaginatedResponse<SelectAudio>>(
-        `${VPS_BASE_URL}/content/audio/mix?limit=1&offset=0`
+        apiUrl('/content/audio/mix?limit=1&offset=0')
       )
       return response.data[0]
     },

--- a/apps/www/src/routes/$slug.tsx
+++ b/apps/www/src/routes/$slug.tsx
@@ -1,13 +1,13 @@
 import { createFileRoute, Link, Navigate } from '@tanstack/react-router'
 import { PublicProfilePage } from '@/components/profile/PublicProfilePage'
-import { fetcher, type ResolveResult, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher, type ResolveResult } from '@/lib/http'
 import { generateProfileSEO, generateResolvedShowSEO, generateSEOMeta } from '@/lib/seo'
 
 export const Route = createFileRoute('/$slug')({
   component: SlugPage,
   loader: async ({ params }) => {
     try {
-      const resolved = await fetcher<ResolveResult>(`${VPS_BASE_URL}/resolve/${params.slug}`)
+      const resolved = await fetcher<ResolveResult>(apiUrl(`/resolve/${params.slug}`))
       return { resolved }
     } catch {
       return { resolved: null }

--- a/apps/www/src/routes/admin/-overview.data.ts
+++ b/apps/www/src/routes/admin/-overview.data.ts
@@ -1,12 +1,12 @@
 import type { AdminOverview } from '@gbfm/vps/schemas'
 import { useQuery } from '@tanstack/react-query'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 
 export type { AdminOverviewContentBreakdown } from '@gbfm/vps/schemas'
 
 export function useAdminOverview() {
   return useQuery<AdminOverview, Error>({
     queryKey: ['admin', 'overview'],
-    queryFn: () => fetcher<AdminOverview>(`${VPS_BASE_URL}/admin/overview`)
+    queryFn: () => fetcher<AdminOverview>(apiUrl('/admin/overview'))
   })
 }

--- a/apps/www/src/routes/admin/_components/-ContentTab.tsx
+++ b/apps/www/src/routes/admin/_components/-ContentTab.tsx
@@ -25,7 +25,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { ArrowUpDown, Check, Plus, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { fetcher, type PaginatedResponse, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher, type PaginatedResponse } from '@/lib/http'
 
 interface AudioItem {
   id: string
@@ -466,33 +466,31 @@ export function ContentTab() {
   const { data: mixesData, isPending: mixesPending } = useQuery({
     queryKey: ['admin', 'mixes'],
     queryFn: () =>
-      fetcher<PaginatedResponse<AudioItem>>(`${VPS_BASE_URL}/content/audio/mix?limit=50&offset=0`)
+      fetcher<PaginatedResponse<AudioItem>>(apiUrl('/content/audio/mix?limit=50&offset=0'))
   })
 
   const { data: labelsData, isPending: labelsPending } = useQuery({
     queryKey: ['admin', 'labels'],
     queryFn: () =>
-      fetcher<PaginatedResponse<LabelItem>>(`${VPS_BASE_URL}/content/labels?limit=50&offset=0`)
+      fetcher<PaginatedResponse<LabelItem>>(apiUrl('/content/labels?limit=50&offset=0'))
   })
 
   const { data: editorialData, isPending: editorialPending } = useQuery({
     queryKey: ['admin', 'posts', 'post'],
     queryFn: () =>
       fetcher<PaginatedResponse<EditorialPostItem>>(
-        `${VPS_BASE_URL}/content/posts/editorials?limit=50&offset=0`
+        apiUrl('/content/posts/editorials?limit=50&offset=0')
       )
   })
   const { data: tweetData, isPending: tweetPending } = useQuery({
     queryKey: ['admin', 'posts', 'micro'],
     queryFn: () =>
-      fetcher<PaginatedResponse<TweetPostItem>>(
-        `${VPS_BASE_URL}/content/posts/micro?limit=50&offset=0`
-      )
+      fetcher<PaginatedResponse<TweetPostItem>>(apiUrl('/content/posts/micro?limit=50&offset=0'))
   })
 
   const updateMixMutation = useMutation({
     mutationFn: ({ slug, tags }: { slug: string; tags: string[] }) =>
-      fetcher(`${VPS_BASE_URL}/content/audio/mix/${slug}`, {
+      fetcher(apiUrl(`/content/audio/mix/${slug}`), {
         method: 'PATCH',
         body: JSON.stringify({ tags })
       }),

--- a/apps/www/src/routes/admin/_components/-FilesTab.tsx
+++ b/apps/www/src/routes/admin/_components/-FilesTab.tsx
@@ -13,7 +13,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeftRight, ArrowRight, Copy, Loader2 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 
 const STORAGE_KEY_BUCKET_A = 'filemanager:bucketA'
 const STORAGE_KEY_BUCKET_B = 'filemanager:bucketB'
@@ -48,7 +48,7 @@ export function FilesTab() {
 
   const { data: configData } = useQuery<BucketConfig>({
     queryKey: ['file-manager', 'config'],
-    queryFn: () => fetcher<BucketConfig>(`${VPS_BASE_URL}/file-manager/config`),
+    queryFn: () => fetcher<BucketConfig>(apiUrl('/file-manager/config')),
     staleTime: Infinity
   })
 
@@ -128,7 +128,7 @@ export function FilesTab() {
     queryKey: ['file-manager', 'list', bucketA],
     queryFn: () =>
       fetcher<{ objects: S3Object[] }>(
-        `${VPS_BASE_URL}/file-manager/list?bucketName=${encodeURIComponent(bucketA)}`
+        apiUrl(`/file-manager/list?bucketName=${encodeURIComponent(bucketA)}`)
       ),
     enabled: Boolean(bucketA),
     staleTime: 30_000
@@ -138,7 +138,7 @@ export function FilesTab() {
     queryKey: ['file-manager', 'list', bucketB],
     queryFn: () =>
       fetcher<{ objects: S3Object[] }>(
-        `${VPS_BASE_URL}/file-manager/list?bucketName=${encodeURIComponent(bucketB)}`
+        apiUrl(`/file-manager/list?bucketName=${encodeURIComponent(bucketB)}`)
       ),
     enabled: Boolean(bucketB),
     staleTime: 30_000
@@ -153,7 +153,7 @@ export function FilesTab() {
     { key: string; sourceBucket: string; destinationBucket: string }
   >({
     mutationFn: (body) =>
-      fetcher(`${VPS_BASE_URL}/file-manager/copy`, {
+      fetcher(apiUrl('/file-manager/copy'), {
         method: 'POST',
         body: JSON.stringify(body)
       }),

--- a/apps/www/src/routes/admin/_components/-ImageUploadField.tsx
+++ b/apps/www/src/routes/admin/_components/-ImageUploadField.tsx
@@ -2,7 +2,7 @@ import { Button, Label, toast } from '@gbfm/ui'
 import { FolderOpen, ImageIcon, Loader2, Trash2, Upload } from 'lucide-react'
 import { useId, useState } from 'react'
 import { S3MediaFilePicker } from '@/components/mix-uploader/S3AudioFilePicker'
-import { VPS_BASE_URL } from '@/lib/http'
+import { apiUrl } from '@/lib/http'
 import { readResponseErrorMessage, readUploadResponse } from '@/lib/response'
 
 interface ImageUploadFieldProps {
@@ -42,7 +42,7 @@ export function ImageUploadField({
       formData.append('imageFile', file)
       formData.append('fileType', 'image')
 
-      const response = await fetch(`${VPS_BASE_URL}/upload/file`, {
+      const response = await fetch(apiUrl('/upload/file'), {
         method: 'POST',
         body: formData
       })

--- a/apps/www/src/routes/admin/_components/-PlaylistEditor.tsx
+++ b/apps/www/src/routes/admin/_components/-PlaylistEditor.tsx
@@ -18,7 +18,7 @@ import { Button, Input, Label, Textarea, toast } from '@gbfm/ui'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ExternalLink, Loader2, RefreshCw } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 import { checkSavedTracksEffect, spotifyIdFromUrl } from '@/lib/spotify-pkce'
 import { runAppEffect } from '@/runtime'
 import { ImageUploadField } from './-ImageUploadField'
@@ -70,7 +70,7 @@ export function PlaylistEditor({ playlist }: Props) {
   const tracksQuery = useQuery({
     queryKey: ['playlist-tracks', playlist.id],
     queryFn: async () =>
-      fetcher<PlaylistTracksApiRow[]>(`${VPS_BASE_URL}/music/playlists/${playlist.id}/tracks`)
+      fetcher<PlaylistTracksApiRow[]>(apiUrl(`/music/playlists/${playlist.id}/tracks`))
   })
 
   useEffect(() => {
@@ -133,7 +133,7 @@ export function PlaylistEditor({ playlist }: Props) {
 
   const reorderMutation = useMutation({
     mutationFn: async (trackIds: string[]) =>
-      fetcher(`${VPS_BASE_URL}/music/playlists/${playlist.id}/tracks/order`, {
+      fetcher(apiUrl(`/music/playlists/${playlist.id}/tracks/order`), {
         method: 'PUT',
         body: JSON.stringify({ trackIds })
       }),
@@ -149,7 +149,7 @@ export function PlaylistEditor({ playlist }: Props) {
 
   const removeMutation = useMutation({
     mutationFn: async (trackId: string) =>
-      fetcher(`${VPS_BASE_URL}/music/playlists/${playlist.id}/tracks/${trackId}`, {
+      fetcher(apiUrl(`/music/playlists/${playlist.id}/tracks/${trackId}`), {
         method: 'DELETE'
       }),
     onSuccess: () => {
@@ -168,7 +168,7 @@ export function PlaylistEditor({ playlist }: Props) {
 
   const addSpotifyMutation = useMutation({
     mutationFn: async (url: string) =>
-      fetcher(`${VPS_BASE_URL}/music/playlists/${playlist.id}/tracks/spotify`, {
+      fetcher(apiUrl(`/music/playlists/${playlist.id}/tracks/spotify`), {
         method: 'POST',
         body: JSON.stringify({ url })
       }),
@@ -190,7 +190,7 @@ export function PlaylistEditor({ playlist }: Props) {
 
   const syncLinksMutation = useMutation({
     mutationFn: async () =>
-      fetcher<SyncResult>(`${VPS_BASE_URL}/music/playlists/${playlist.id}/sync-links`, {
+      fetcher<SyncResult>(apiUrl(`/music/playlists/${playlist.id}/sync-links`), {
         method: 'POST'
       }),
     onSuccess: (data) => {
@@ -213,7 +213,7 @@ export function PlaylistEditor({ playlist }: Props) {
 
   const metadataMutation = useMutation({
     mutationFn: async (data: { title: string; description?: string; coverImageUrl?: string }) =>
-      fetcher(`${VPS_BASE_URL}/music/playlists/${playlist.id}`, {
+      fetcher(apiUrl(`/music/playlists/${playlist.id}`), {
         method: 'PATCH',
         body: JSON.stringify(data)
       }),

--- a/apps/www/src/routes/admin/_components/-PlaylistsTab.tsx
+++ b/apps/www/src/routes/admin/_components/-PlaylistsTab.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { ArrowLeft, ChevronDown, ChevronRight, Loader2, Pencil, Plus } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 import { PlaylistEditor, type PlaylistSummary } from './-PlaylistEditor'
 import { SpotifyConnectionCard } from './-SpotifyConnectionCard'
 
@@ -19,7 +19,7 @@ export function PlaylistsTab() {
 
   const playlistsQuery = useQuery({
     queryKey: ['playlists'],
-    queryFn: async () => fetcher<PlaylistSummary[]>(`${VPS_BASE_URL}/music/playlists`)
+    queryFn: async () => fetcher<PlaylistSummary[]>(apiUrl('/music/playlists'))
   })
 
   useEffect(() => {
@@ -30,7 +30,7 @@ export function PlaylistsTab() {
 
   const importMutation = useMutation({
     mutationFn: async (playlistUrl: string) =>
-      fetcher<ImportResult>(`${VPS_BASE_URL}/music/playlists/import/spotify`, {
+      fetcher<ImportResult>(apiUrl('/music/playlists/import/spotify'), {
         method: 'POST',
         body: JSON.stringify({ url: playlistUrl })
       }),

--- a/apps/www/src/routes/admin/_components/-ShowsTab.tsx
+++ b/apps/www/src/routes/admin/_components/-ShowsTab.tsx
@@ -15,7 +15,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Edit, ExternalLink, Plus, Trash } from 'lucide-react'
 import { useState } from 'react'
-import { fetcher, type PaginatedResponse, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher, type PaginatedResponse } from '@/lib/http'
 import { ImageUploadField } from './-ImageUploadField'
 import { UserSearch } from './-UserSearch'
 
@@ -82,12 +82,12 @@ export function ShowsTab() {
 
   const { data: showsData, isPending: showsPending } = useQuery({
     queryKey: ['admin', 'shows'],
-    queryFn: () => fetcher<PaginatedResponse<ShowItem>>(`${VPS_BASE_URL}/shows?limit=50&offset=0`)
+    queryFn: () => fetcher<PaginatedResponse<ShowItem>>(apiUrl('/shows?limit=50&offset=0'))
   })
 
   const createShowMutation = useMutation({
     mutationFn: (data: ShowFormState) =>
-      fetcher(`${VPS_BASE_URL}/shows`, {
+      fetcher(apiUrl('/shows'), {
         method: 'POST',
         body: JSON.stringify({
           title: data.title,
@@ -118,7 +118,7 @@ export function ShowsTab() {
 
   const updateShowMutation = useMutation({
     mutationFn: ({ slug, data }: { slug: string; data: ShowFormState }) =>
-      fetcher(`${VPS_BASE_URL}/shows/${slug}`, {
+      fetcher(apiUrl(`/shows/${slug}`), {
         method: 'PATCH',
         body: JSON.stringify({
           title: data.title,
@@ -149,7 +149,7 @@ export function ShowsTab() {
   })
 
   const deleteShowMutation = useMutation({
-    mutationFn: (slug: string) => fetcher(`${VPS_BASE_URL}/shows/${slug}`, { method: 'DELETE' }),
+    mutationFn: (slug: string) => fetcher(apiUrl(`/shows/${slug}`), { method: 'DELETE' }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'shows'] })
       setDeleteDialog({ open: false, slug: '', title: '' })

--- a/apps/www/src/routes/admin/_components/-UserSearch.tsx
+++ b/apps/www/src/routes/admin/_components/-UserSearch.tsx
@@ -2,7 +2,7 @@ import { Badge, Button, Input } from '@gbfm/ui'
 import { useQuery } from '@tanstack/react-query'
 import { X } from 'lucide-react'
 import { useId, useState } from 'react'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 
 interface UserSearchResult {
   id: string
@@ -30,9 +30,7 @@ export function UserSearch({ selectedUsers, onSelectionChange, label = 'Hosts' }
   const { data: searchResults, isPending } = useQuery({
     queryKey: ['users', 'search', searchQuery],
     queryFn: () =>
-      fetcher<UserSearchResult[]>(
-        `${VPS_BASE_URL}/user/search?q=${encodeURIComponent(searchQuery)}`
-      ),
+      fetcher<UserSearchResult[]>(apiUrl(`/user/search?q=${encodeURIComponent(searchQuery)}`)),
     enabled: searchQuery.length >= 2
   })
 

--- a/apps/www/src/routes/admin/_components/-UsersTab.tsx
+++ b/apps/www/src/routes/admin/_components/-UsersTab.tsx
@@ -50,7 +50,7 @@ import {
   useAdminUserBio,
   useAdminUserSocialLinks,
   useReplaceAdminUserSocialLinks,
-  VPS_BASE_URL
+  apiUrl
 } from '@/lib/http'
 import { ImageUploadField } from './-ImageUploadField'
 
@@ -303,7 +303,7 @@ export function UsersTab() {
 
   const sendInviteMutation = useMutation({
     mutationFn: async (userId: string) =>
-      fetcher<{ success: boolean; emailId: string }>(`${VPS_BASE_URL}/invite/send`, {
+      fetcher<{ success: boolean; emailId: string }>(apiUrl('/invite/send'), {
         method: 'POST',
         body: JSON.stringify({ userId })
       }),
@@ -373,7 +373,7 @@ export function UsersTab() {
         }
       })
 
-      return fetcher<{ bio: string | null }>(`${VPS_BASE_URL}/user/admin/${editUser.id}/bio`, {
+      return fetcher<{ bio: string | null }>(apiUrl(`/user/admin/${editUser.id}/bio`), {
         method: 'PATCH',
         body: JSON.stringify({ bio: editUser.bio })
       })

--- a/apps/www/src/routes/admin/frontend-errors.tsx
+++ b/apps/www/src/routes/admin/frontend-errors.tsx
@@ -2,8 +2,13 @@ import { Button, Card, CardContent, CardHeader, CardTitle } from '@gbfm/ui'
 import { createFileRoute } from '@tanstack/react-router'
 import { AlertTriangle, CheckCircle2, RadioTower } from 'lucide-react'
 import * as React from 'react'
+<<<<<<< HEAD
 import { fetcher, VPS_BASE_URL } from '@/lib/http'
 import { AdminPage } from './_components/-AdminLayout'
+=======
+import { apiUrl, fetcher } from '@/lib/http'
+import { AdminAccessGuard } from './_components/-AdminAccessGuard'
+>>>>>>> c68a4ee7 (refactor(www): migrate VPS_BASE_URL call sites to apiUrl())
 
 export const Route = createFileRoute('/admin/frontend-errors')({
   component: FrontendErrorsPage
@@ -70,7 +75,7 @@ function FrontendErrorsPage() {
     setResult(null)
 
     try {
-      await fetcher<unknown>(`${VPS_BASE_URL}/admin/frontend-errors/${scenario.scenario}`)
+      await fetcher<unknown>(apiUrl(`/admin/frontend-errors/${scenario.scenario}`))
       setResult({
         label: scenario.label,
         ok: true,

--- a/apps/www/src/routes/admin/frontend-errors.tsx
+++ b/apps/www/src/routes/admin/frontend-errors.tsx
@@ -2,13 +2,8 @@ import { Button, Card, CardContent, CardHeader, CardTitle } from '@gbfm/ui'
 import { createFileRoute } from '@tanstack/react-router'
 import { AlertTriangle, CheckCircle2, RadioTower } from 'lucide-react'
 import * as React from 'react'
-<<<<<<< HEAD
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
-import { AdminPage } from './_components/-AdminLayout'
-=======
 import { apiUrl, fetcher } from '@/lib/http'
-import { AdminAccessGuard } from './_components/-AdminAccessGuard'
->>>>>>> c68a4ee7 (refactor(www): migrate VPS_BASE_URL call sites to apiUrl())
+import { AdminPage } from './_components/-AdminLayout'
 
 export const Route = createFileRoute('/admin/frontend-errors')({
   component: FrontendErrorsPage

--- a/apps/www/src/routes/auth/reset-password.tsx
+++ b/apps/www/src/routes/auth/reset-password.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react'
 import { z } from 'zod'
 import { AuthPageLayout, AuthStatusNotice } from '@/components/Auth/AuthPageLayout'
 import { useSession } from '@/lib/auth-client'
-import { VPS_BASE_URL } from '@/lib/http'
+import { apiUrl } from '@/lib/http'
 import { readResponseErrorMessage } from '@/lib/response'
 
 export const searchSchema = z.object({
@@ -20,7 +20,7 @@ export const Route = createFileRoute('/auth/reset-password')({
 })
 
 async function confirmInvite(token: string, password: string) {
-  const res = await fetch(`${VPS_BASE_URL}/invite/confirm`, {
+  const res = await fetch(apiUrl('/invite/confirm'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',

--- a/apps/www/src/routes/editorial/$slug.tsx
+++ b/apps/www/src/routes/editorial/$slug.tsx
@@ -7,7 +7,7 @@ import { MDXRendrr } from '@/components/MDXRendrr'
 import { RouteError } from '@/components/RouteError'
 import { ShareButton } from '@/components/ShareButton'
 import { DEFAULT_IMAGE_URL } from '@/lib/constants'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 import { generatePostSEO, generateSEOMeta } from '@/lib/seo'
 
 export const Route = createFileRoute('/editorial/$slug')({
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/editorial/$slug')({
   ),
   loader: async ({ params }) => {
     const post = await fetcher<SelectMdxCompiledEditorialPost>(
-      `${VPS_BASE_URL}/content/posts/editorials/${params.slug}`
+      apiUrl(`/content/posts/editorials/${params.slug}`)
     )
     return { post }
   },

--- a/apps/www/src/routes/label-upload.lazy.tsx
+++ b/apps/www/src/routes/label-upload.lazy.tsx
@@ -18,7 +18,7 @@ import { useId, useState } from 'react'
 import { z } from 'zod'
 import { SimpleMarkdownEditor } from '@/components/simple-markdown-editor'
 import { useSession } from '@/lib/auth-client'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 import { readResponseErrorMessage, readUploadResponse } from '@/lib/response'
 
 export const Route = createLazyFileRoute('/label-upload')({
@@ -99,7 +99,7 @@ function LabelUploadPage() {
         imageFormData.append('imageFile', data.artworkFile)
         imageFormData.append('fileType', 'image')
 
-        const imageUploadResponse = await fetch(`${VPS_BASE_URL}/upload/file`, {
+        const imageUploadResponse = await fetch(apiUrl('/upload/file'), {
           method: 'POST',
           body: imageFormData
         })
@@ -128,8 +128,8 @@ function LabelUploadPage() {
       }
 
       const endpoint = isEditMode
-        ? `${VPS_BASE_URL}/content/labels/${search.edit}`
-        : `${VPS_BASE_URL}/content/labels`
+        ? apiUrl(`/content/labels/${search.edit}`)
+        : apiUrl('/content/labels')
 
       const method = isEditMode ? 'PATCH' : 'POST'
 

--- a/apps/www/src/routes/labels/$labelSlug.tsx
+++ b/apps/www/src/routes/labels/$labelSlug.tsx
@@ -8,7 +8,7 @@ import { ReleasesTable } from '@/components/ReleasesTable'
 import { RouteError } from '@/components/RouteError'
 import { ShareButton } from '@/components/ShareButton'
 import { useSession } from '@/lib/auth-client'
-import { fetcher, useReleasesByLabel } from '@/lib/http'
+import { apiUrl, fetcher, useReleasesByLabel } from '@/lib/http'
 import { generateLabelSEO, generateSEOMeta } from '@/lib/seo'
 import { useContentStore } from '@/store'
 
@@ -17,7 +17,7 @@ export const Route = createFileRoute('/labels/$labelSlug')({
   errorComponent: ({ error }) => <RouteError error={error} />,
   loader: async ({ params }) => {
     const label = await fetcher<SelectMdxCompiledLabel>(
-      `${import.meta.env.VITE_VPS_BASE_URL}/content/labels/${params.labelSlug}`
+      apiUrl(`/content/labels/${params.labelSlug}`)
     )
     return { label }
   },

--- a/apps/www/src/routes/mix-upload.lazy.tsx
+++ b/apps/www/src/routes/mix-upload.lazy.tsx
@@ -29,7 +29,7 @@ import { z } from 'zod'
 import { S3AudioFilePicker } from '@/components/mix-uploader/S3AudioFilePicker'
 import { SimpleMarkdownEditor } from '@/components/simple-markdown-editor'
 import { authClient, useSession } from '@/lib/auth-client'
-import { fetcher, useAllShows, useAudioBySlug, useAudioTags, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher, useAllShows, useAudioBySlug, useAudioTags } from '@/lib/http'
 import { readResponseErrorMessage, readUploadResponse } from '@/lib/response'
 
 export const Route = createLazyFileRoute('/mix-upload')({
@@ -135,7 +135,7 @@ function MixUploadPage() {
 
   const updateTagsMutation = useMutation({
     mutationFn: (tags: string[]) =>
-      fetcher(`${VPS_BASE_URL}/content/audio/${editType}/${search.edit}`, {
+      fetcher(apiUrl(`/content/audio/${editType}/${search.edit}`), {
         method: 'PATCH',
         body: JSON.stringify({ tags })
       }),
@@ -175,7 +175,7 @@ function MixUploadPage() {
         uploadFormData.append('audioFile', data.audioFile)
         uploadFormData.append('fileType', 'audio')
 
-        const audioUploadResponse = await fetch(`${VPS_BASE_URL}/upload/file`, {
+        const audioUploadResponse = await fetch(apiUrl('/upload/file'), {
           method: 'POST',
           body: uploadFormData
         })
@@ -198,7 +198,7 @@ function MixUploadPage() {
         imageFormData.append('imageFile', data.artworkFile)
         imageFormData.append('fileType', 'image')
 
-        const imageUploadResponse = await fetch(`${VPS_BASE_URL}/upload/file`, {
+        const imageUploadResponse = await fetch(apiUrl('/upload/file'), {
           method: 'POST',
           body: imageFormData
         })
@@ -239,8 +239,8 @@ function MixUploadPage() {
       }
 
       const endpoint = isEditMode
-        ? `${VPS_BASE_URL}/content/audio/${editType}/${search.edit}`
-        : `${VPS_BASE_URL}/content/audio`
+        ? apiUrl(`/content/audio/${editType}/${search.edit}`)
+        : apiUrl('/content/audio')
 
       const result = await fetcher(endpoint, {
         method: isEditMode ? 'PATCH' : 'POST',

--- a/apps/www/src/routes/mixes/$mixId.tsx
+++ b/apps/www/src/routes/mixes/$mixId.tsx
@@ -27,7 +27,7 @@ import { MDXRendrr } from '@/components/MDXRendrr'
 import { RouteError } from '@/components/RouteError'
 import { useSession } from '@/lib/auth-client'
 import { DEFAULT_IMAGE_URL } from '@/lib/constants'
-import { fetcher, useMixQRPdf, useShowById, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher, useMixQRPdf, useShowById } from '@/lib/http'
 import { getShareUrl } from '@/lib/share'
 import { useContentStore } from '@/store'
 import { useAudioPlayerActions, useAudioPlayerPlaybackState } from '@/store/audioPlayer'
@@ -36,9 +36,7 @@ export const Route = createFileRoute('/mixes/$mixId')({
   component: MixPage,
   errorComponent: ({ error }) => <RouteError error={error} />,
   loader: async ({ params }) => {
-    const mix = await fetcher<SelectMdxCompiledAudio>(
-      `${VPS_BASE_URL}/content/audio/mix/${params.mixId}`
-    )
+    const mix = await fetcher<SelectMdxCompiledAudio>(apiUrl(`/content/audio/mix/${params.mixId}`))
     return { mix }
   },
   head: ({ loaderData, params }) => {

--- a/apps/www/src/routes/new/-EditorialPage.tsx
+++ b/apps/www/src/routes/new/-EditorialPage.tsx
@@ -20,7 +20,7 @@ import { useEffect, useId, useState } from 'react'
 import { PostPageHeader } from '@/components/PostPageHeader'
 import { SimpleMarkdownEditor } from '@/components/simple-markdown-editor'
 import { useSession } from '@/lib/auth-client'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 import { readResponseErrorMessage, readUploadResponse } from '@/lib/response'
 import { UserSearch } from '../admin/_components/-UserSearch'
 
@@ -264,7 +264,7 @@ export function EditorialPage() {
 
   const { data: existingPost, isPending: loadingPost } = useQuery({
     queryKey: ['post', search.edit],
-    queryFn: () => fetcher<PostItem>(`${VPS_BASE_URL}/content/posts/${search.edit}`),
+    queryFn: () => fetcher<PostItem>(apiUrl(`/content/posts/${search.edit}`)),
     enabled: isEditMode && Boolean(search.edit)
   })
 
@@ -295,7 +295,7 @@ export function EditorialPage() {
         imageFormData.append('imageFile', artworkFile)
         imageFormData.append('fileType', 'image')
 
-        const imageUploadResponse = await fetch(`${VPS_BASE_URL}/upload/file`, {
+        const imageUploadResponse = await fetch(apiUrl('/upload/file'), {
           method: 'POST',
           body: imageFormData
         })
@@ -327,8 +327,8 @@ export function EditorialPage() {
       }
 
       const endpoint = isEditMode
-        ? `${VPS_BASE_URL}/content/posts/${search.edit}`
-        : `${VPS_BASE_URL}/content/post`
+        ? apiUrl(`/content/posts/${search.edit}`)
+        : apiUrl('/content/post')
 
       return fetcher<PostItem>(endpoint, {
         method: isEditMode ? 'PATCH' : 'POST',

--- a/apps/www/src/routes/new/-TweetCapturePage.tsx
+++ b/apps/www/src/routes/new/-TweetCapturePage.tsx
@@ -21,13 +21,13 @@ import { type KeyboardEvent, useEffect, useMemo, useState } from 'react'
 import { PostPageHeader } from '@/components/PostPageHeader'
 import { useSession } from '@/lib/auth-client'
 import {
+  apiUrl,
   fetcher,
   useAddAdminEntityLink,
   useAdminEntityLinks,
   useDeleteAdminEntityLink,
   useResolveMusicEntity,
-  useUpdateAdminEntityLinkStatus,
-  VPS_BASE_URL
+  useUpdateAdminEntityLinkStatus
 } from '@/lib/http'
 
 type PostType = 'post' | 'micro'
@@ -223,7 +223,7 @@ export function TweetCapturePage() {
 
   const { data: existingPost, isPending: loadingPost } = useQuery({
     queryKey: ['post', search.edit],
-    queryFn: () => fetcher<PostItem>(`${VPS_BASE_URL}/content/posts/${search.edit}`),
+    queryFn: () => fetcher<PostItem>(apiUrl(`/content/posts/${search.edit}`)),
     enabled: isEditMode && Boolean(search.edit)
   })
 
@@ -231,7 +231,9 @@ export function TweetCapturePage() {
     queryKey: ['music-entity', existingPost?.musicEntityType, existingPost?.musicEntityId],
     queryFn: () =>
       fetcher(
-        `${VPS_BASE_URL}/music/${entityPathByType[existingPost?.musicEntityType ?? 'track']}/${existingPost?.musicEntityId}`
+        apiUrl(
+          `/music/${entityPathByType[existingPost?.musicEntityType ?? 'track']}/${existingPost?.musicEntityId}`
+        )
       ),
     enabled: Boolean(existingPost?.musicEntityType && existingPost.musicEntityId)
   })
@@ -377,8 +379,8 @@ export function TweetCapturePage() {
       }
 
       const endpoint = isEditMode
-        ? `${VPS_BASE_URL}/content/posts/${existingPost?.slug}`
-        : `${VPS_BASE_URL}/content/post`
+        ? apiUrl(`/content/posts/${existingPost?.slug}`)
+        : apiUrl('/content/post')
 
       return fetcher<PostItem>(endpoint, {
         method: isEditMode ? 'PATCH' : 'POST',

--- a/apps/www/src/routes/profile/$username.tsx
+++ b/apps/www/src/routes/profile/$username.tsx
@@ -1,13 +1,13 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { PublicProfilePage } from '@/components/profile/PublicProfilePage'
-import { fetcher, type PublicProfile, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher, type PublicProfile } from '@/lib/http'
 import { generateProfileSEO, generateSEOMeta } from '@/lib/seo'
 
 export const Route = createFileRoute('/profile/$username')({
   component: ProfilePage,
   loader: async ({ params }) => {
     try {
-      const profile = await fetcher<PublicProfile>(`${VPS_BASE_URL}/profile/${params.username}`)
+      const profile = await fetcher<PublicProfile>(apiUrl(`/profile/${params.username}`))
       if (!profile?.id) return { profile: null }
       return { profile }
     } catch {

--- a/apps/www/src/routes/releases/$slug.tsx
+++ b/apps/www/src/routes/releases/$slug.tsx
@@ -3,7 +3,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import * as React from 'react'
 import { LongPost } from '@/components/Layout/LongPost'
 import { RouteError } from '@/components/RouteError'
-import { fetcher } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 import { generateReleaseSEO, generateSEOMeta } from '@/lib/seo'
 import { useContentStore } from '@/store'
 
@@ -12,7 +12,7 @@ export const Route = createFileRoute('/releases/$slug')({
   errorComponent: ({ error }) => <RouteError error={error} />,
   loader: async ({ params }) => {
     const release = await fetcher<SelectMdxCompiledRelease>(
-      `${import.meta.env.VITE_VPS_BASE_URL}/content/releases/${params.slug}`
+      apiUrl(`/content/releases/${params.slug}`)
     )
     return { release }
   },

--- a/apps/www/src/routes/reminders.tsx
+++ b/apps/www/src/routes/reminders.tsx
@@ -4,7 +4,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { CalendarClock } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useSession } from '@/lib/auth-client'
-import { fetcher, useEnrichTrackFromUrl, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher, useEnrichTrackFromUrl } from '@/lib/http'
 
 interface MusicReminder {
   id: string
@@ -80,7 +80,7 @@ function MusicReminders() {
   // Query existing reminders
   const { data: reminders, isLoading: isLoadingReminders } = useQuery<RemindersResponse>({
     queryKey: ['reminders'],
-    queryFn: () => fetcher(`${VPS_BASE_URL}/music-reminders`)
+    queryFn: () => fetcher(apiUrl('/music-reminders'))
   })
 
   // Create reminder mutation
@@ -93,7 +93,7 @@ function MusicReminders() {
       reminderDate: string
       notes?: string
     }) => {
-      return fetcher(`${VPS_BASE_URL}/music-reminders`, {
+      return fetcher(apiUrl('/music-reminders'), {
         method: 'POST',
         body: JSON.stringify(data)
       })

--- a/apps/www/src/routes/shows/$showSlug.tsx
+++ b/apps/www/src/routes/shows/$showSlug.tsx
@@ -8,7 +8,7 @@ import { RouteError } from '@/components/RouteError'
 import { ShareButton } from '@/components/ShareButton'
 import { EpisodeGrid } from '@/components/shows/EpisodeGrid'
 import { ShowQRButton } from '@/components/shows/ShowQRButton'
-import { fetcher } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 import { generateSEOMeta, generateShowSEO } from '@/lib/seo'
 import { useContentStore } from '@/store'
 import { ShowMetadataManager } from './_components/-ShowMetadataManager'
@@ -17,9 +17,7 @@ export const Route = createFileRoute('/shows/$showSlug')({
   component: ShowPage,
   errorComponent: ({ error }) => <RouteError error={error} />,
   loader: async ({ params }) => {
-    const show = await fetcher<SelectMdxCompiledShow>(
-      `${import.meta.env.VITE_VPS_BASE_URL}/shows/${params.showSlug}`
-    )
+    const show = await fetcher<SelectMdxCompiledShow>(apiUrl(`/shows/${params.showSlug}`))
     return { show }
   },
   head: ({ loaderData, params }) => {

--- a/apps/www/src/routes/shows/_components/-ShowMetadataManager.tsx
+++ b/apps/www/src/routes/shows/_components/-ShowMetadataManager.tsx
@@ -17,7 +17,7 @@ import { useRouter } from '@tanstack/react-router'
 import { Settings2 } from 'lucide-react'
 import { useState } from 'react'
 import { useSession } from '@/lib/auth-client'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 import { ImageUploadField } from '@/routes/admin/_components/-ImageUploadField'
 
 interface ShowMetadataFormState {
@@ -61,7 +61,7 @@ export function ShowMetadataManager({ show }: ShowMetadataManagerProps) {
 
   const updateMutation = useMutation({
     mutationFn: (data: ShowMetadataFormState) =>
-      fetcher(`${VPS_BASE_URL}/shows/${show.slug}`, {
+      fetcher(apiUrl(`/shows/${show.slug}`), {
         method: 'PATCH',
         body: JSON.stringify({
           title: data.title,

--- a/apps/www/src/routes/tracks/$trackId.tsx
+++ b/apps/www/src/routes/tracks/$trackId.tsx
@@ -3,7 +3,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import * as React from 'react'
 import { LongPost } from '@/components/Layout/LongPost'
 import { RouteError } from '@/components/RouteError'
-import { fetcher } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 import { generateSEOMeta, generateTrackSEO } from '@/lib/seo'
 import { useContentStore } from '@/store'
 
@@ -12,7 +12,7 @@ export const Route = createFileRoute('/tracks/$trackId')({
   errorComponent: ({ error }) => <RouteError error={error} />,
   loader: async ({ params }) => {
     const track = await fetcher<SelectMdxCompiledAudio>(
-      `${import.meta.env.VITE_VPS_BASE_URL}/content/audio/track/${params.trackId}`
+      apiUrl(`/content/audio/track/${params.trackId}`)
     )
     return { track }
   },

--- a/apps/www/src/routes/tweet/$slug.tsx
+++ b/apps/www/src/routes/tweet/$slug.tsx
@@ -8,7 +8,7 @@ import { ShareButton } from '@/components/ShareButton'
 import { TweetAuthorRow } from '@/components/TweetAuthorRow'
 import { TweetMusicEntityCard } from '@/components/TweetMusicEntityCard'
 import { useSession } from '@/lib/auth-client'
-import { fetcher, VPS_BASE_URL } from '@/lib/http'
+import { apiUrl, fetcher } from '@/lib/http'
 import { generateMicroPostSEO, generateSEOMeta } from '@/lib/seo'
 
 export const Route = createFileRoute('/tweet/$slug')({
@@ -28,7 +28,7 @@ export const Route = createFileRoute('/tweet/$slug')({
   ),
   loader: async ({ params }) => {
     const post = await fetcher<SelectMdxCompiledMicroPost>(
-      `${VPS_BASE_URL}/content/posts/micro/${params.slug}`
+      apiUrl(`/content/posts/micro/${params.slug}`)
     )
     return { post }
   },

--- a/apps/www/src/runtime/index.ts
+++ b/apps/www/src/runtime/index.ts
@@ -22,8 +22,8 @@ const analyticsLayer = enableSentry
       // temporarily raised to 1.0 for end-to-end trace investigation
       tracesSampleRate: 1.0,
       tracePropagationTargets: env.isDev
-        ? ['https://vps.goosebumps.fm', 'http://127.0.0.1:3003', 'http://localhost:3003']
-        : ['https://vps.goosebumps.fm']
+        ? [/^\//, 'http://127.0.0.1:3003', 'http://localhost:3003']
+        : [/^\//, 'https://goosebumps.fm', 'https://www.goosebumps.fm', 'https://vps.goosebumps.fm']
     })
   : NoopAnalyticsLayer
 


### PR DESCRIPTION
## Summary

Migrates all `VPS_BASE_URL` template literal usages to `apiUrl()`/ `apiUrlObj()` helpers, and updates Sentry `tracePropagationTargets` to include the apex domain.

Preparatory work for #61 (Cloudflare proxy) and #106 (same-origin API migration). Closes #121.

## Changes

### Commit 1: `refactor(www): migrate VPS_BASE_URL call sites to apiUrl()`
- ~100 call sites across 33 files migrated from `${VPS_BASE_URL}/...` to `apiUrl('/...')`
- 4 route loaders switched from `import.meta.env.VITE_VPS_BASE_URL` to `apiUrl`
- `VPS_BASE_URL` made internal (non-exported)
- `auth-client.ts` left unchanged (needs raw base URL string for better-auth)

### Commit 2: `fix(www): add apex domain to Sentry tracePropagationTargets`
- Added `/^\//` (relative URL matcher), `goosebumps.fm`, and `www.goosebumps.fm`
- Kept `vps.goosebumps.fm` for backward compatibility during transition

## Validation
- `bun precommit` passes (typecheck, oxlint, oxfmt)