### PR TITLE
feat(upload): resumable chunked mix audio upload

### DIFF
--- a/apps/vps/src/app.ts
+++ b/apps/vps/src/app.ts
@@ -20,6 +20,7 @@ import search from '@/routes/search/search.index'
 import shows from '@/routes/shows/show.index'
 import spotify from '@/routes/spotify/spotify.index'
 import upload from '@/routes/upload/upload.index'
+import uploadMultipart from '@/routes/upload-multipart/upload-multipart.index'
 import betterAuthRoutes from '@/routes/user/better-auth.routes'
 import user from '@/routes/user/user.index'
 import { db } from './db'
@@ -61,6 +62,7 @@ const setupRoutesEffect = Effect.gen(function* () {
   app.route('/api/spotify', spotify)
   app.route('/api/file-manager', fileManager)
   app.route('/api/upload', upload)
+  app.route('/api/upload', uploadMultipart)
   app.route('/api/music', music)
   app.route('/api/music-reminders', musicReminders)
 

--- a/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.test.ts
+++ b/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest'
+import { ValidationError } from '@/errors'
+import { assertContiguousParts } from './upload-multipart.handlers'
+
+describe('assertContiguousParts', () => {
+  test('accepts a complete contiguous sequence', () => {
+    expect(() =>
+      assertContiguousParts([{ partNumber: 1 }, { partNumber: 2 }, { partNumber: 3 }])
+    ).not.toThrow()
+  })
+
+  test('accepts a single-part upload', () => {
+    expect(() => assertContiguousParts([{ partNumber: 1 }])).not.toThrow()
+  })
+
+  test('sorts before checking', () => {
+    expect(() =>
+      assertContiguousParts([{ partNumber: 3 }, { partNumber: 1 }, { partNumber: 2 }])
+    ).not.toThrow()
+  })
+
+  test('rejects when the first part is missing', () => {
+    expect(() => assertContiguousParts([{ partNumber: 2 }, { partNumber: 3 }])).toThrow(
+      ValidationError
+    )
+  })
+
+  test('rejects when a middle part is missing', () => {
+    expect(() =>
+      assertContiguousParts([{ partNumber: 1 }, { partNumber: 2 }, { partNumber: 4 }])
+    ).toThrow(ValidationError)
+  })
+
+  test('rejects duplicate part numbers', () => {
+    expect(() =>
+      assertContiguousParts([{ partNumber: 1 }, { partNumber: 2 }, { partNumber: 2 }])
+    ).toThrow(ValidationError)
+  })
+
+  test('error message names the missing part', () => {
+    expect(() => assertContiguousParts([{ partNumber: 1 }, { partNumber: 3 }])).toThrow(
+      new ValidationError({
+        message: 'Parts must be contiguous starting at 1. Missing part 2'
+      })
+    )
+  })
+})

--- a/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.ts
+++ b/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.ts
@@ -1,0 +1,303 @@
+import { getFormFile, getFormString } from '@gbfm/core/utils'
+import { Effect } from 'effect'
+import * as HttpStatusCodes from 'stoker/http-status-codes'
+import { ValidationError } from '@/errors'
+import type { AppRouteHandler } from '@/lib/types'
+import { runApp } from '@/runtime'
+import { ConfigService } from '@/services/config.service'
+import { S3Service } from '@/services/s3.service'
+
+import type {
+  AbortMultipartRoute,
+  CompleteMultipartRoute,
+  InitMultipartRoute,
+  MultipartStatusRoute,
+  UploadPartRoute
+} from './upload-multipart.routes'
+
+const CHUNK_SIZE = 10 * 1024 * 1024
+const MAX_AUDIO_SIZE = 200 * 1024 * 1024
+const MAX_CHUNK_SIZE = CHUNK_SIZE * 2
+
+const sanitizeKeySegment = (value: string): string => value.replace(/[^a-zA-Z0-9.-]/g, '_')
+
+const buildObjectKey = (fileType: string, fileName: string): string => {
+  const timestamp = Date.now()
+  const sanitizedName = sanitizeKeySegment(fileName)
+  return `${fileType}_${timestamp}_${sanitizedName}`
+}
+
+export const initMultipart: AppRouteHandler<InitMultipartRoute> = async (c) => {
+  const body = c.req.valid('json')
+
+  if (body.fileType !== 'audio' || !body.contentType.startsWith('audio/')) {
+    return c.json({ error: 'Only audio uploads are supported' }, HttpStatusCodes.BAD_REQUEST)
+  }
+
+  if (body.fileSize > MAX_AUDIO_SIZE) {
+    return c.json(
+      { error: `File too large. Maximum size is ${MAX_AUDIO_SIZE / (1024 * 1024)}MB` },
+      HttpStatusCodes.REQUEST_TOO_LONG
+    )
+  }
+
+  const key = buildObjectKey(body.fileType, body.fileName)
+
+  const program = Effect.gen(function* () {
+    const config = yield* ConfigService
+    const s3Service = yield* S3Service
+    const upload = yield* s3Service.createMultipartUpload(
+      key,
+      body.contentType,
+      config.buckets.userContent
+    )
+    return { uploadId: upload.uploadId, key: upload.key, chunkSize: CHUNK_SIZE }
+  }).pipe(
+    Effect.withSpan('api.upload.multipart.init', {
+      attributes: {
+        fileType: body.fileType,
+        key,
+        fileSize: body.fileSize
+      }
+    }),
+    Effect.map((result) => ({ ...result, status: HttpStatusCodes.OK }) as const),
+    Effect.catchTag('S3Error', (error) =>
+      Effect.gen(function* () {
+        yield* Effect.logError('[Upload] Multipart init error', { key, error: error.message })
+        return {
+          error: 'Failed to initialize multipart upload',
+          status: HttpStatusCodes.INTERNAL_SERVER_ERROR
+        } as const
+      })
+    )
+  )
+
+  const result = await runApp(program)
+
+  if ('error' in result) {
+    return c.json({ error: result.error }, result.status)
+  }
+  return c.json(
+    { uploadId: result.uploadId, key: result.key, chunkSize: result.chunkSize },
+    result.status
+  )
+}
+
+export const uploadPart: AppRouteHandler<UploadPartRoute> = async (c) => {
+  const formData = await c.req.formData()
+
+  const key = getFormString(formData, 'key')
+  const uploadId = getFormString(formData, 'uploadId')
+  const partNumberRaw = getFormString(formData, 'partNumber')
+  const chunk = getFormFile(formData, 'chunk')
+
+  if (!key || !uploadId || !chunk) {
+    return c.json({ error: 'Missing key, uploadId, or chunk' }, HttpStatusCodes.BAD_REQUEST)
+  }
+
+  const partNumber = Number.parseInt(partNumberRaw, 10)
+  if (!Number.isInteger(partNumber) || partNumber < 1 || partNumber > 10000) {
+    return c.json({ error: 'Invalid partNumber' }, HttpStatusCodes.BAD_REQUEST)
+  }
+
+  if (chunk.size === 0) {
+    return c.json({ error: 'Empty chunk' }, HttpStatusCodes.BAD_REQUEST)
+  }
+
+  if (chunk.size > MAX_CHUNK_SIZE) {
+    return c.json(
+      { error: `Chunk too large. Maximum is ${MAX_CHUNK_SIZE / (1024 * 1024)}MB` },
+      HttpStatusCodes.BAD_REQUEST
+    )
+  }
+
+  const program = Effect.gen(function* () {
+    const config = yield* ConfigService
+    const s3Service = yield* S3Service
+    const buffer = Buffer.from(yield* Effect.promise(() => chunk.arrayBuffer()))
+    const result = yield* s3Service.uploadMultipartPart(
+      key,
+      uploadId,
+      partNumber,
+      buffer,
+      config.buckets.userContent
+    )
+    return result
+  }).pipe(
+    Effect.withSpan('api.upload.multipart.part', {
+      attributes: {
+        key,
+        partNumber,
+        chunkSize: chunk.size
+      }
+    }),
+    Effect.map(
+      (result) =>
+        ({
+          partNumber: result.partNumber,
+          etag: result.etag,
+          size: result.size,
+          status: HttpStatusCodes.OK
+        }) as const
+    ),
+    Effect.catchTag('S3Error', (error) =>
+      Effect.gen(function* () {
+        yield* Effect.logError('[Upload] Multipart part error', {
+          key,
+          partNumber,
+          error: error.message
+        })
+        return {
+          error: 'Failed to upload part',
+          status: HttpStatusCodes.INTERNAL_SERVER_ERROR
+        } as const
+      })
+    )
+  )
+
+  const result = await runApp(program)
+
+  if ('error' in result) {
+    return c.json({ error: result.error }, result.status)
+  }
+  return c.json(
+    { partNumber: result.partNumber, etag: result.etag, size: result.size },
+    result.status
+  )
+}
+
+export const completeMultipart: AppRouteHandler<CompleteMultipartRoute> = async (c) => {
+  const body = c.req.valid('json')
+
+  const program = Effect.gen(function* () {
+    const config = yield* ConfigService
+    const s3Service = yield* S3Service
+
+    const sortedParts = body.parts.toSorted((a, b) => a.partNumber - b.partNumber)
+    const expectedPartNumber = (index: number) => index + 1
+    for (const [index, part] of sortedParts.entries()) {
+      if (part.partNumber !== expectedPartNumber(index)) {
+        return yield* Effect.fail(
+          new ValidationError({
+            message: `Parts must be contiguous starting at 1. Missing part ${expectedPartNumber(index)}`
+          })
+        )
+      }
+    }
+
+    yield* s3Service.completeMultipartUpload(
+      body.key,
+      body.uploadId,
+      sortedParts,
+      config.buckets.userContent
+    )
+
+    return { url: `${config.urls.bucketRouter}/user-content/${body.key}`, key: body.key }
+  }).pipe(
+    Effect.withSpan('api.upload.multipart.complete', {
+      attributes: {
+        key: body.key,
+        partCount: body.parts.length
+      }
+    }),
+    Effect.map((result) => ({ ...result, status: HttpStatusCodes.OK }) as const),
+    Effect.catchTags({
+      ValidationError: (error) =>
+        Effect.succeed({
+          error: error.message,
+          status: HttpStatusCodes.BAD_REQUEST
+        } as const),
+      S3Error: (error) =>
+        Effect.gen(function* () {
+          yield* Effect.logError('[Upload] Multipart complete error', {
+            key: body.key,
+            error: error.message
+          })
+          return {
+            error: 'Failed to complete multipart upload',
+            status: HttpStatusCodes.INTERNAL_SERVER_ERROR
+          } as const
+        })
+    })
+  )
+
+  const result = await runApp(program)
+
+  if ('error' in result) {
+    return c.json({ error: result.error }, result.status)
+  }
+  return c.json({ url: result.url, key: result.key }, result.status)
+}
+
+export const abortMultipart: AppRouteHandler<AbortMultipartRoute> = async (c) => {
+  const body = c.req.valid('json')
+
+  const program = Effect.gen(function* () {
+    const config = yield* ConfigService
+    const s3Service = yield* S3Service
+    yield* s3Service.abortMultipartUpload(body.key, body.uploadId, config.buckets.userContent)
+  }).pipe(
+    Effect.withSpan('api.upload.multipart.abort', {
+      attributes: { key: body.key }
+    }),
+    Effect.map(
+      () =>
+        ({
+          ok: true,
+          status: HttpStatusCodes.OK
+        }) as const
+    ),
+    Effect.catchTag('S3Error', (error) =>
+      Effect.gen(function* () {
+        yield* Effect.logError('[Upload] Multipart abort error', {
+          key: body.key,
+          error: error.message
+        })
+        return {
+          error: 'Failed to abort multipart upload',
+          status: HttpStatusCodes.INTERNAL_SERVER_ERROR
+        } as const
+      })
+    )
+  )
+
+  const result = await runApp(program)
+
+  if ('error' in result) {
+    return c.json({ error: result.error }, result.status)
+  }
+  return c.json({ ok: true } as const, result.status)
+}
+
+export const multipartStatus: AppRouteHandler<MultipartStatusRoute> = async (c) => {
+  const { key, uploadId } = c.req.valid('query')
+
+  const program = Effect.gen(function* () {
+    const config = yield* ConfigService
+    const s3Service = yield* S3Service
+    const parts = yield* s3Service.listMultipartParts(key, uploadId, config.buckets.userContent)
+    return { parts }
+  }).pipe(
+    Effect.withSpan('api.upload.multipart.status', { attributes: { key } }),
+    Effect.map((result) => ({ ...result, status: HttpStatusCodes.OK }) as const),
+    Effect.catchTag('S3Error', (error) =>
+      Effect.gen(function* () {
+        yield* Effect.logError('[Upload] Multipart status error', {
+          key,
+          error: error.message
+        })
+        return {
+          error: 'Failed to fetch multipart status',
+          status: HttpStatusCodes.INTERNAL_SERVER_ERROR
+        } as const
+      })
+    )
+  )
+
+  const result = await runApp(program)
+
+  if ('error' in result) {
+    return c.json({ error: result.error }, result.status)
+  }
+  return c.json({ parts: result.parts }, result.status)
+}

--- a/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.ts
+++ b/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.ts
@@ -1,9 +1,9 @@
 import { getFormFile, getFormString } from '@gbfm/core/utils'
 import { Effect } from 'effect'
 import * as HttpStatusCodes from 'stoker/http-status-codes'
-import { S3Error, ValidationError } from '@/errors'
-import type { AppRouteHandler } from '@/lib/types'
-import { runApp } from '@/runtime'
+import { ValidationError } from '@/errors'
+import { runEffect } from '@/lib/effect-hono'
+import type { AppBindings, AppRouteHandler } from '@/lib/types'
 import { ConfigService } from '@/services/config.service'
 import { S3Service } from '@/services/s3.service'
 
@@ -14,6 +14,7 @@ import type {
   MultipartStatusRoute,
   UploadPartRoute
 } from './upload-multipart.routes'
+import type { Context } from 'hono'
 
 const CHUNK_SIZE = 10 * 1024 * 1024
 const MAX_AUDIO_SIZE = 200 * 1024 * 1024
@@ -21,10 +22,19 @@ const MAX_CHUNK_SIZE = CHUNK_SIZE * 2
 
 const sanitizeKeySegment = (value: string): string => value.replace(/[^a-zA-Z0-9.-]/g, '_')
 
-const buildObjectKey = (fileType: string, fileName: string): string => {
+const buildObjectKey = (userId: string, fileType: string, fileName: string): string => {
   const timestamp = Date.now()
   const sanitizedName = sanitizeKeySegment(fileName)
-  return `${fileType}_${timestamp}_${sanitizedName}`
+  return `${sanitizeKeySegment(userId)}/${fileType}_${timestamp}_${sanitizedName}`
+}
+
+const validateKeyOwnership = (c: Context<AppBindings>, key: string): string | null => {
+  const user = c.get('user')
+  const prefix = `${sanitizeKeySegment(user.id)}/`
+  if (!key.startsWith(prefix)) {
+    return 'Upload key does not belong to current user'
+  }
+  return null
 }
 
 export const assertContiguousParts = (parts: ReadonlyArray<{ partNumber: number }>): void => {
@@ -40,10 +50,7 @@ export const assertContiguousParts = (parts: ReadonlyArray<{ partNumber: number 
 
 export const initMultipart: AppRouteHandler<InitMultipartRoute> = async (c) => {
   const body = c.req.valid('json')
-
-  if (body.fileType !== 'audio' || !body.contentType.startsWith('audio/')) {
-    return c.json({ error: 'Only audio uploads are supported' }, HttpStatusCodes.BAD_REQUEST)
-  }
+  const user = c.get('user')
 
   if (body.fileSize > MAX_AUDIO_SIZE) {
     return c.json(
@@ -52,7 +59,7 @@ export const initMultipart: AppRouteHandler<InitMultipartRoute> = async (c) => {
     )
   }
 
-  const key = buildObjectKey(body.fileType, body.fileName)
+  const key = buildObjectKey(user.id, body.fileType, body.fileName)
 
   const program = Effect.gen(function* () {
     const config = yield* ConfigService
@@ -68,30 +75,16 @@ export const initMultipart: AppRouteHandler<InitMultipartRoute> = async (c) => {
       attributes: {
         fileType: body.fileType,
         key,
-        fileSize: body.fileSize
+        fileSize: body.fileSize,
+        userId: user.id
       }
     }),
-    Effect.map((result) => ({ ...result, status: HttpStatusCodes.OK }) as const),
-    Effect.catchTag('S3Error', (error) =>
-      Effect.gen(function* () {
-        yield* Effect.logError('[Upload] Multipart init error', { key, error: error.message })
-        return {
-          error: 'Failed to initialize multipart upload',
-          status: HttpStatusCodes.INTERNAL_SERVER_ERROR
-        } as const
-      })
+    Effect.tapError((error) =>
+      Effect.logError('[Upload] Multipart init error', { key, error: getMessage(error) })
     )
   )
 
-  const result = await runApp(program)
-
-  if ('error' in result) {
-    return c.json({ error: result.error }, result.status)
-  }
-  return c.json(
-    { uploadId: result.uploadId, key: result.key, chunkSize: result.chunkSize },
-    result.status
-  )
+  return runEffect<InitMultipartRoute>(c, program)
 }
 
 export const uploadPart: AppRouteHandler<UploadPartRoute> = async (c) => {
@@ -99,16 +92,11 @@ export const uploadPart: AppRouteHandler<UploadPartRoute> = async (c) => {
 
   const key = getFormString(formData, 'key')
   const uploadId = getFormString(formData, 'uploadId')
-  const partNumberRaw = getFormString(formData, 'partNumber')
+  const partNumber = Number.parseInt(getFormString(formData, 'partNumber'), 10)
   const chunk = getFormFile(formData, 'chunk')
 
   if (!key || !uploadId || !chunk) {
     return c.json({ error: 'Missing key, uploadId, or chunk' }, HttpStatusCodes.BAD_REQUEST)
-  }
-
-  const partNumber = Number.parseInt(partNumberRaw, 10)
-  if (!Number.isInteger(partNumber) || partNumber < 1 || partNumber > 10000) {
-    return c.json({ error: 'Invalid partNumber' }, HttpStatusCodes.BAD_REQUEST)
   }
 
   if (chunk.size === 0) {
@@ -122,6 +110,11 @@ export const uploadPart: AppRouteHandler<UploadPartRoute> = async (c) => {
     )
   }
 
+  const ownershipError = validateKeyOwnership(c, key)
+  if (ownershipError) {
+    return c.json({ error: ownershipError }, HttpStatusCodes.BAD_REQUEST)
+  }
+
   const program = Effect.gen(function* () {
     const config = yield* ConfigService
     const s3Service = yield* S3Service
@@ -133,150 +126,98 @@ export const uploadPart: AppRouteHandler<UploadPartRoute> = async (c) => {
       buffer,
       config.buckets.userContent
     )
-    return result
+    return { partNumber: result.partNumber, etag: result.etag, size: result.size }
   }).pipe(
     Effect.withSpan('api.upload.multipart.part', {
-      attributes: {
+      attributes: { key, partNumber, chunkSize: chunk.size }
+    }),
+    Effect.tapError((error) =>
+      Effect.logError('[Upload] Multipart part error', {
         key,
         partNumber,
-        chunkSize: chunk.size
-      }
-    }),
-    Effect.map(
-      (result) =>
-        ({
-          partNumber: result.partNumber,
-          etag: result.etag,
-          size: result.size,
-          status: HttpStatusCodes.OK
-        }) as const
-    ),
-    Effect.catchTag('S3Error', (error) =>
-      Effect.gen(function* () {
-        yield* Effect.logError('[Upload] Multipart part error', {
-          key,
-          partNumber,
-          error: error.message
-        })
-        return {
-          error: 'Failed to upload part',
-          status: HttpStatusCodes.INTERNAL_SERVER_ERROR
-        } as const
+        error: getMessage(error)
       })
     )
   )
 
-  const result = await runApp(program)
-
-  if ('error' in result) {
-    return c.json({ error: result.error }, result.status)
-  }
-  return c.json(
-    { partNumber: result.partNumber, etag: result.etag, size: result.size },
-    result.status
-  )
+  return runEffect<UploadPartRoute>(c, program)
 }
 
 export const completeMultipart: AppRouteHandler<CompleteMultipartRoute> = async (c) => {
   const body = c.req.valid('json')
 
+  const ownershipError = validateKeyOwnership(c, body.key)
+  if (ownershipError) {
+    return c.json({ error: ownershipError }, HttpStatusCodes.BAD_REQUEST)
+  }
+
+  try {
+    assertContiguousParts(body.parts)
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return c.json({ error: error.message }, HttpStatusCodes.BAD_REQUEST)
+    }
+    throw error
+  }
+
   const program = Effect.gen(function* () {
     const config = yield* ConfigService
     const s3Service = yield* S3Service
-
-    const sortedParts = body.parts.toSorted((a, b) => a.partNumber - b.partNumber)
-    try {
-      assertContiguousParts(body.parts)
-    } catch (error) {
-      return yield* Effect.fail(error)
-    }
-
     yield* s3Service.completeMultipartUpload(
       body.key,
       body.uploadId,
-      sortedParts,
+      body.parts,
       config.buckets.userContent
     )
-
     return { url: `${config.urls.bucketRouter}/user-content/${body.key}`, key: body.key }
   }).pipe(
     Effect.withSpan('api.upload.multipart.complete', {
-      attributes: {
-        key: body.key,
-        partCount: body.parts.length
-      }
+      attributes: { key: body.key, partCount: body.parts.length }
     }),
-    Effect.map((result) => ({ ...result, status: HttpStatusCodes.OK }) as const),
-    Effect.catchTags({
-      ValidationError: (error: ValidationError) =>
-        Effect.succeed({
-          error: error.message,
-          status: HttpStatusCodes.BAD_REQUEST
-        } as const),
-      S3Error: (error: S3Error) =>
-        Effect.gen(function* () {
-          yield* Effect.logError('[Upload] Multipart complete error', {
-            key: body.key,
-            error: error.message
-          })
-          return {
-            error: 'Failed to complete multipart upload',
-            status: HttpStatusCodes.INTERNAL_SERVER_ERROR
-          } as const
-        })
-    })
+    Effect.tapError((error) =>
+      Effect.logError('[Upload] Multipart complete error', {
+        key: body.key,
+        error: getMessage(error)
+      })
+    )
   )
 
-  const result = await runApp(program)
-
-  if ('error' in result) {
-    return c.json({ error: result.error }, result.status)
-  }
-  return c.json({ url: result.url, key: result.key }, result.status)
+  return runEffect<CompleteMultipartRoute>(c, program)
 }
 
 export const abortMultipart: AppRouteHandler<AbortMultipartRoute> = async (c) => {
   const body = c.req.valid('json')
+
+  const ownershipError = validateKeyOwnership(c, body.key)
+  if (ownershipError) {
+    return c.json({ error: ownershipError }, HttpStatusCodes.BAD_REQUEST)
+  }
 
   const program = Effect.gen(function* () {
     const config = yield* ConfigService
     const s3Service = yield* S3Service
     yield* s3Service.abortMultipartUpload(body.key, body.uploadId, config.buckets.userContent)
   }).pipe(
-    Effect.withSpan('api.upload.multipart.abort', {
-      attributes: { key: body.key }
-    }),
-    Effect.map(
-      () =>
-        ({
-          ok: true,
-          status: HttpStatusCodes.OK
-        }) as const
-    ),
-    Effect.catchTag('S3Error', (error) =>
-      Effect.gen(function* () {
-        yield* Effect.logError('[Upload] Multipart abort error', {
-          key: body.key,
-          error: error.message
-        })
-        return {
-          error: 'Failed to abort multipart upload',
-          status: HttpStatusCodes.INTERNAL_SERVER_ERROR
-        } as const
+    Effect.withSpan('api.upload.multipart.abort', { attributes: { key: body.key } }),
+    Effect.tapError((error) =>
+      Effect.logError('[Upload] Multipart abort error', {
+        key: body.key,
+        error: getMessage(error)
       })
-    )
+    ),
+    Effect.map(() => ({ ok: true as const }))
   )
 
-  const result = await runApp(program)
-
-  if ('error' in result) {
-    return c.json({ error: result.error }, result.status)
-  }
-  return c.json({ ok: true } as const, result.status)
+  return runEffect<AbortMultipartRoute>(c, program)
 }
 
 export const multipartStatus: AppRouteHandler<MultipartStatusRoute> = async (c) => {
   const { key, uploadId } = c.req.valid('query')
+
+  const ownershipError = validateKeyOwnership(c, key)
+  if (ownershipError) {
+    return c.json({ error: ownershipError }, HttpStatusCodes.BAD_REQUEST)
+  }
 
   const program = Effect.gen(function* () {
     const config = yield* ConfigService
@@ -285,25 +226,15 @@ export const multipartStatus: AppRouteHandler<MultipartStatusRoute> = async (c) 
     return { parts }
   }).pipe(
     Effect.withSpan('api.upload.multipart.status', { attributes: { key } }),
-    Effect.map((result) => ({ ...result, status: HttpStatusCodes.OK }) as const),
-    Effect.catchTag('S3Error', (error) =>
-      Effect.gen(function* () {
-        yield* Effect.logError('[Upload] Multipart status error', {
-          key,
-          error: error.message
-        })
-        return {
-          error: 'Failed to fetch multipart status',
-          status: HttpStatusCodes.INTERNAL_SERVER_ERROR
-        } as const
+    Effect.tapError((error) =>
+      Effect.logError('[Upload] Multipart status error', {
+        key,
+        error: getMessage(error)
       })
     )
   )
 
-  const result = await runApp(program)
-
-  if ('error' in result) {
-    return c.json({ error: result.error }, result.status)
-  }
-  return c.json({ parts: result.parts }, result.status)
+  return runEffect<MultipartStatusRoute>(c, program)
 }
+
+const getMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error))

--- a/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.ts
+++ b/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.ts
@@ -1,7 +1,7 @@
 import { getFormFile, getFormString } from '@gbfm/core/utils'
 import { Effect } from 'effect'
 import * as HttpStatusCodes from 'stoker/http-status-codes'
-import { ValidationError } from '@/errors'
+import { S3Error, ValidationError } from '@/errors'
 import type { AppRouteHandler } from '@/lib/types'
 import { runApp } from '@/runtime'
 import { ConfigService } from '@/services/config.service'
@@ -25,6 +25,17 @@ const buildObjectKey = (fileType: string, fileName: string): string => {
   const timestamp = Date.now()
   const sanitizedName = sanitizeKeySegment(fileName)
   return `${fileType}_${timestamp}_${sanitizedName}`
+}
+
+export const assertContiguousParts = (parts: ReadonlyArray<{ partNumber: number }>): void => {
+  const sorted = parts.toSorted((a, b) => a.partNumber - b.partNumber)
+  for (const [index, part] of sorted.entries()) {
+    if (part.partNumber !== index + 1) {
+      throw new ValidationError({
+        message: `Parts must be contiguous starting at 1. Missing part ${index + 1}`
+      })
+    }
+  }
 }
 
 export const initMultipart: AppRouteHandler<InitMultipartRoute> = async (c) => {
@@ -174,15 +185,10 @@ export const completeMultipart: AppRouteHandler<CompleteMultipartRoute> = async 
     const s3Service = yield* S3Service
 
     const sortedParts = body.parts.toSorted((a, b) => a.partNumber - b.partNumber)
-    const expectedPartNumber = (index: number) => index + 1
-    for (const [index, part] of sortedParts.entries()) {
-      if (part.partNumber !== expectedPartNumber(index)) {
-        return yield* Effect.fail(
-          new ValidationError({
-            message: `Parts must be contiguous starting at 1. Missing part ${expectedPartNumber(index)}`
-          })
-        )
-      }
+    try {
+      assertContiguousParts(body.parts)
+    } catch (error) {
+      return yield* Effect.fail(error)
     }
 
     yield* s3Service.completeMultipartUpload(
@@ -202,12 +208,12 @@ export const completeMultipart: AppRouteHandler<CompleteMultipartRoute> = async 
     }),
     Effect.map((result) => ({ ...result, status: HttpStatusCodes.OK }) as const),
     Effect.catchTags({
-      ValidationError: (error) =>
+      ValidationError: (error: ValidationError) =>
         Effect.succeed({
           error: error.message,
           status: HttpStatusCodes.BAD_REQUEST
         } as const),
-      S3Error: (error) =>
+      S3Error: (error: S3Error) =>
         Effect.gen(function* () {
           yield* Effect.logError('[Upload] Multipart complete error', {
             key: body.key,

--- a/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.ts
+++ b/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.ts
@@ -237,4 +237,5 @@ export const multipartStatus: AppRouteHandler<MultipartStatusRoute> = async (c) 
   return runEffect<MultipartStatusRoute>(c, program)
 }
 
-const getMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error))
+const getMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)

--- a/apps/vps/src/routes/upload-multipart/upload-multipart.index.ts
+++ b/apps/vps/src/routes/upload-multipart/upload-multipart.index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create-app'
+
+import * as handlers from './upload-multipart.handlers'
+import * as routes from './upload-multipart.routes'
+
+const router = createRouter()
+  .openapi(routes.initMultipart, handlers.initMultipart)
+  .openapi(routes.uploadPart, handlers.uploadPart)
+  .openapi(routes.completeMultipart, handlers.completeMultipart)
+  .openapi(routes.abortMultipart, handlers.abortMultipart)
+  .openapi(routes.multipartStatus, handlers.multipartStatus)
+
+export default router

--- a/apps/vps/src/routes/upload-multipart/upload-multipart.routes.ts
+++ b/apps/vps/src/routes/upload-multipart/upload-multipart.routes.ts
@@ -25,7 +25,11 @@ export const initMultipart = createRoute({
     body: jsonContentRequired(
       z.object({
         fileName: z.string().min(1).max(255),
-        contentType: z.string().min(1).max(127),
+        contentType: z
+          .string()
+          .min(1)
+          .max(127)
+          .regex(/^audio\//, 'contentType must be an audio MIME type'),
         fileSize: z.number().int().positive(),
         fileType: z.literal('audio')
       }),
@@ -147,10 +151,8 @@ export const abortMultipart = createRoute({
     )
   },
   responses: {
-    [HttpStatusCodes.OK]: jsonContent(
-      z.object({ ok: z.literal(true) }),
-      'Multipart upload aborted'
-    ),
+    [HttpStatusCodes.OK]: jsonContent(z.object({ ok: z.literal(true) }), 'Multipart upload aborted'),
+    [HttpStatusCodes.BAD_REQUEST]: jsonContent(z.object({ error: z.string() }), 'Invalid request'),
     [HttpStatusCodes.UNAUTHORIZED]: jsonContent(z.object({ error: z.string() }), 'Unauthorized'),
     [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
       z.object({ error: z.string() }),
@@ -177,6 +179,7 @@ export const multipartStatus = createRoute({
       }),
       'Multipart upload status'
     ),
+    [HttpStatusCodes.BAD_REQUEST]: jsonContent(z.object({ error: z.string() }), 'Invalid request'),
     [HttpStatusCodes.UNAUTHORIZED]: jsonContent(z.object({ error: z.string() }), 'Unauthorized'),
     [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
       z.object({ error: z.string() }),

--- a/apps/vps/src/routes/upload-multipart/upload-multipart.routes.ts
+++ b/apps/vps/src/routes/upload-multipart/upload-multipart.routes.ts
@@ -1,0 +1,192 @@
+import { createRoute, z } from '@hono/zod-openapi'
+import * as HttpStatusCodes from 'stoker/http-status-codes'
+import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers'
+import { betterAuthMiddleware } from '@/middlewares/better-auth.middleware'
+
+const tags = ['Upload']
+
+const partTag = z.object({
+  partNumber: z.number().int().min(1).max(10000),
+  etag: z.string().min(1)
+})
+
+const completedPartTag = z.object({
+  partNumber: z.number().int().min(1).max(10000),
+  etag: z.string().min(1),
+  size: z.number().int().nonnegative()
+})
+
+export const initMultipart = createRoute({
+  path: '/multipart/init',
+  method: 'post',
+  middleware: [betterAuthMiddleware],
+  tags,
+  request: {
+    body: jsonContentRequired(
+      z.object({
+        fileName: z.string().min(1).max(255),
+        contentType: z.string().min(1).max(127),
+        fileSize: z.number().int().positive(),
+        fileType: z.literal('audio')
+      }),
+      'Multipart upload initialization'
+    )
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      z.object({
+        uploadId: z.string(),
+        key: z.string(),
+        chunkSize: z.number().int().positive()
+      }),
+      'Multipart upload initialized'
+    ),
+    [HttpStatusCodes.BAD_REQUEST]: jsonContent(
+      z.object({ error: z.string() }),
+      'Invalid initialization request'
+    ),
+    [HttpStatusCodes.UNAUTHORIZED]: jsonContent(z.object({ error: z.string() }), 'Unauthorized'),
+    [HttpStatusCodes.REQUEST_TOO_LONG]: jsonContent(
+      z.object({ error: z.string() }),
+      'File too large'
+    ),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      z.object({ error: z.string() }),
+      'Failed to initialize multipart upload'
+    )
+  }
+})
+
+export const uploadPart = createRoute({
+  path: '/multipart/part',
+  method: 'post',
+  middleware: [betterAuthMiddleware],
+  tags,
+  request: {
+    body: {
+      content: {
+        'multipart/form-data': {
+          schema: z.object({
+            key: z.string().min(1),
+            uploadId: z.string().min(1),
+            partNumber: z
+              .string()
+              .regex(/^[0-9]+$/)
+              .transform((value) => Number.parseInt(value, 10))
+              .refine((value) => value >= 1 && value <= 10000, {
+                message: 'partNumber must be between 1 and 10000'
+              }),
+            chunk: z.any()
+          })
+        }
+      }
+    }
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      z.object({
+        partNumber: z.number().int().min(1).max(10000),
+        etag: z.string().min(1),
+        size: z.number().int().nonnegative()
+      }),
+      'Part uploaded'
+    ),
+    [HttpStatusCodes.BAD_REQUEST]: jsonContent(z.object({ error: z.string() }), 'Invalid part'),
+    [HttpStatusCodes.UNAUTHORIZED]: jsonContent(z.object({ error: z.string() }), 'Unauthorized'),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      z.object({ error: z.string() }),
+      'Failed to upload part'
+    )
+  }
+})
+
+export const completeMultipart = createRoute({
+  path: '/multipart/complete',
+  method: 'post',
+  middleware: [betterAuthMiddleware],
+  tags,
+  request: {
+    body: jsonContentRequired(
+      z.object({
+        key: z.string().min(1),
+        uploadId: z.string().min(1),
+        parts: z.array(partTag).min(1).max(10000)
+      }),
+      'Multipart upload completion'
+    )
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      z.object({
+        url: z.string(),
+        key: z.string()
+      }),
+      'Multipart upload completed'
+    ),
+    [HttpStatusCodes.BAD_REQUEST]: jsonContent(z.object({ error: z.string() }), 'Invalid request'),
+    [HttpStatusCodes.UNAUTHORIZED]: jsonContent(z.object({ error: z.string() }), 'Unauthorized'),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      z.object({ error: z.string() }),
+      'Failed to complete multipart upload'
+    )
+  }
+})
+
+export const abortMultipart = createRoute({
+  path: '/multipart/abort',
+  method: 'post',
+  middleware: [betterAuthMiddleware],
+  tags,
+  request: {
+    body: jsonContentRequired(
+      z.object({
+        key: z.string().min(1),
+        uploadId: z.string().min(1)
+      }),
+      'Abort multipart upload'
+    )
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      z.object({ ok: z.literal(true) }),
+      'Multipart upload aborted'
+    ),
+    [HttpStatusCodes.UNAUTHORIZED]: jsonContent(z.object({ error: z.string() }), 'Unauthorized'),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      z.object({ error: z.string() }),
+      'Failed to abort multipart upload'
+    )
+  }
+})
+
+export const multipartStatus = createRoute({
+  path: '/multipart/status',
+  method: 'get',
+  middleware: [betterAuthMiddleware],
+  tags,
+  request: {
+    query: z.object({
+      key: z.string().min(1),
+      uploadId: z.string().min(1)
+    })
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      z.object({
+        parts: z.array(completedPartTag)
+      }),
+      'Multipart upload status'
+    ),
+    [HttpStatusCodes.UNAUTHORIZED]: jsonContent(z.object({ error: z.string() }), 'Unauthorized'),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      z.object({ error: z.string() }),
+      'Failed to fetch multipart status'
+    )
+  }
+})
+
+export type InitMultipartRoute = typeof initMultipart
+export type UploadPartRoute = typeof uploadPart
+export type CompleteMultipartRoute = typeof completeMultipart
+export type AbortMultipartRoute = typeof abortMultipart
+export type MultipartStatusRoute = typeof multipartStatus

--- a/apps/vps/src/routes/upload-multipart/upload-multipart.routes.ts
+++ b/apps/vps/src/routes/upload-multipart/upload-multipart.routes.ts
@@ -151,7 +151,10 @@ export const abortMultipart = createRoute({
     )
   },
   responses: {
-    [HttpStatusCodes.OK]: jsonContent(z.object({ ok: z.literal(true) }), 'Multipart upload aborted'),
+    [HttpStatusCodes.OK]: jsonContent(
+      z.object({ ok: z.literal(true) }),
+      'Multipart upload aborted'
+    ),
     [HttpStatusCodes.BAD_REQUEST]: jsonContent(z.object({ error: z.string() }), 'Invalid request'),
     [HttpStatusCodes.UNAUTHORIZED]: jsonContent(z.object({ error: z.string() }), 'Unauthorized'),
     [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(

--- a/apps/vps/src/services/s3.service.ts
+++ b/apps/vps/src/services/s3.service.ts
@@ -1,14 +1,32 @@
 import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
   CopyObjectCommand,
+  CreateMultipartUploadCommand,
   DeleteObjectCommand,
   HeadObjectCommand,
+  type CompletedPart,
   ListBucketsCommand,
   ListObjectsV2Command,
+  ListPartsCommand,
   PutObjectCommand,
-  S3Client
+  S3Client,
+  UploadPartCommand
 } from '@aws-sdk/client-s3'
 import { Context, Effect, Layer } from 'effect'
-import { S3Error } from '@/errors'
+import { getErrorMessage, S3Error } from '@/errors'
+
+export interface S3MultipartPart {
+  readonly partNumber: number
+  readonly etag: string
+  readonly size: number
+}
+
+export interface S3MultipartUpload {
+  readonly uploadId: string
+  readonly key: string
+  readonly bucket: string
+}
 
 // Service interface
 export interface S3Service {
@@ -35,6 +53,39 @@ export interface S3Service {
   ) => Effect.Effect<void, S3Error>
 
   readonly listBuckets: () => Effect.Effect<string[], S3Error>
+
+  readonly createMultipartUpload: (
+    key: string,
+    contentType: string,
+    bucketName: string
+  ) => Effect.Effect<S3MultipartUpload, S3Error>
+
+  readonly uploadMultipartPart: (
+    key: string,
+    uploadId: string,
+    partNumber: number,
+    body: Buffer | Uint8Array | Blob,
+    bucketName: string
+  ) => Effect.Effect<{ partNumber: number; etag: string; size: number }, S3Error>
+
+  readonly completeMultipartUpload: (
+    key: string,
+    uploadId: string,
+    parts: ReadonlyArray<{ partNumber: number; etag: string }>,
+    bucketName: string
+  ) => Effect.Effect<{ key: string; bucket: string }, S3Error>
+
+  readonly abortMultipartUpload: (
+    key: string,
+    uploadId: string,
+    bucketName: string
+  ) => Effect.Effect<void, S3Error>
+
+  readonly listMultipartParts: (
+    key: string,
+    uploadId: string,
+    bucketName: string
+  ) => Effect.Effect<S3MultipartPart[], S3Error>
 }
 
 // Service tag for dependency injection
@@ -248,6 +299,201 @@ const copyFileEffect = (key: string, sourceBucket: string, destinationBucket: st
     })
   )
 
+const createMultipartUploadEffect = (key: string, contentType: string, bucketName: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const s3 = new S3Client({})
+      const response = await s3.send(
+        new CreateMultipartUploadCommand({
+          Bucket: bucketName,
+          Key: key,
+          ContentType: contentType
+        })
+      )
+      if (!response.UploadId) {
+        throw new Error('S3 did not return an UploadId')
+      }
+      return { uploadId: response.UploadId, key, bucket: bucketName } satisfies S3MultipartUpload
+    },
+    catch: (error) =>
+      new S3Error({
+        message: `Failed to create multipart upload: ${getErrorMessage(error)}`,
+        operation: 'createMultipartUpload',
+        key
+      })
+  }).pipe(
+    Effect.withSpan('aws.s3.createMultipartUpload', {
+      attributes: {
+        'aws.service': 's3',
+        's3.bucket': bucketName,
+        's3.key_prefix': getKeyPrefix(key),
+        'content.type': contentType
+      }
+    })
+  )
+
+const uploadMultipartPartEffect = (
+  key: string,
+  uploadId: string,
+  partNumber: number,
+  body: Buffer | Uint8Array | Blob,
+  bucketName: string
+) =>
+  Effect.tryPromise({
+    try: async () => {
+      const s3 = new S3Client({})
+      const response = await s3.send(
+        new UploadPartCommand({
+          Bucket: bucketName,
+          Key: key,
+          UploadId: uploadId,
+          PartNumber: partNumber,
+          Body: body
+        })
+      )
+      if (!response.ETag) {
+        throw new Error('S3 did not return an ETag for the uploaded part')
+      }
+      const size = body instanceof Blob ? body.size : body.byteLength
+      return { partNumber, etag: response.ETag, size }
+    },
+    catch: (error) =>
+      new S3Error({
+        message: `Failed to upload multipart part: ${getErrorMessage(error)}`,
+        operation: 'uploadMultipartPart',
+        key
+      })
+  }).pipe(
+    Effect.withSpan('aws.s3.uploadPart', {
+      attributes: {
+        'aws.service': 's3',
+        's3.bucket': bucketName,
+        's3.key_prefix': getKeyPrefix(key),
+        's3.part_number': partNumber,
+        'payload.size_bytes': body instanceof Blob ? body.size : body.byteLength
+      }
+    })
+  )
+
+const completeMultipartUploadEffect = (
+  key: string,
+  uploadId: string,
+  parts: ReadonlyArray<{ partNumber: number; etag: string }>,
+  bucketName: string
+) =>
+  Effect.tryPromise({
+    try: async () => {
+      const s3 = new S3Client({})
+      const sortedParts: CompletedPart[] = parts
+        .toSorted((a, b) => a.partNumber - b.partNumber)
+        .map((p) => ({ ETag: p.etag, PartNumber: p.partNumber }))
+
+      await s3.send(
+        new CompleteMultipartUploadCommand({
+          Bucket: bucketName,
+          Key: key,
+          UploadId: uploadId,
+          MultipartUpload: { Parts: sortedParts }
+        })
+      )
+      return { key, bucket: bucketName }
+    },
+    catch: (error) =>
+      new S3Error({
+        message: `Failed to complete multipart upload: ${getErrorMessage(error)}`,
+        operation: 'completeMultipartUpload',
+        key
+      })
+  }).pipe(
+    Effect.withSpan('aws.s3.completeMultipartUpload', {
+      attributes: {
+        'aws.service': 's3',
+        's3.bucket': bucketName,
+        's3.key_prefix': getKeyPrefix(key),
+        's3.part_count': parts.length
+      }
+    })
+  )
+
+const abortMultipartUploadEffect = (key: string, uploadId: string, bucketName: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const s3 = new S3Client({})
+      await s3.send(
+        new AbortMultipartUploadCommand({
+          Bucket: bucketName,
+          Key: key,
+          UploadId: uploadId
+        })
+      )
+    },
+    catch: (error) =>
+      new S3Error({
+        message: `Failed to abort multipart upload: ${getErrorMessage(error)}`,
+        operation: 'abortMultipartUpload',
+        key
+      })
+  }).pipe(
+    Effect.withSpan('aws.s3.abortMultipartUpload', {
+      attributes: {
+        'aws.service': 's3',
+        's3.bucket': bucketName,
+        's3.key_prefix': getKeyPrefix(key)
+      }
+    })
+  )
+
+const listMultipartPartsEffect = (key: string, uploadId: string, bucketName: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const s3 = new S3Client({})
+      const collected: S3MultipartPart[] = []
+      let partNumberMarker: string | undefined
+
+      do {
+        const response = await s3.send(
+          new ListPartsCommand({
+            Bucket: bucketName,
+            Key: key,
+            UploadId: uploadId,
+            PartNumberMarker: partNumberMarker
+          })
+        )
+
+        for (const part of response.Parts ?? []) {
+          if (part.PartNumber && part.ETag) {
+            collected.push({
+              partNumber: part.PartNumber,
+              etag: part.ETag,
+              size: part.Size ?? 0
+            })
+          }
+        }
+
+        partNumberMarker =
+          response.IsTruncated && response.NextPartNumberMarker
+            ? String(response.NextPartNumberMarker)
+            : undefined
+      } while (partNumberMarker)
+
+      return collected.toSorted((a, b) => a.partNumber - b.partNumber)
+    },
+    catch: (error) =>
+      new S3Error({
+        message: `Failed to list multipart parts: ${getErrorMessage(error)}`,
+        operation: 'listMultipartParts',
+        key
+      })
+  }).pipe(
+    Effect.withSpan('aws.s3.listParts', {
+      attributes: {
+        'aws.service': 's3',
+        's3.bucket': bucketName,
+        's3.key_prefix': getKeyPrefix(key)
+      }
+    })
+  )
+
 const listBucketsEffect = () =>
   Effect.tryPromise({
     try: async () => {
@@ -284,5 +530,10 @@ export const S3ServiceLive = Layer.succeed(S3Service, {
   checkExists: checkExistsEffect,
   listObjects: listObjectsEffect,
   copyFile: copyFileEffect,
-  listBuckets: listBucketsEffect
+  listBuckets: listBucketsEffect,
+  createMultipartUpload: createMultipartUploadEffect,
+  uploadMultipartPart: uploadMultipartPartEffect,
+  completeMultipartUpload: completeMultipartUploadEffect,
+  abortMultipartUpload: abortMultipartUploadEffect,
+  listMultipartParts: listMultipartPartsEffect
 })

--- a/apps/www/src/hooks/useMixUploadDraft.ts
+++ b/apps/www/src/hooks/useMixUploadDraft.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { computeFileFingerprint } from '@/lib/upload/resumable-upload'
+import { runAppEffect } from '@/runtime'
+import {
+  type MixUploadDraft,
+  MixUploadDraftStorage,
+  clearMixUploadDraft,
+  emptyMixUploadDraft,
+  readMixUploadDraft
+} from '@/services/mix-upload-draft'
+import * as Effect from 'effect/Effect'
+
+export interface MixUploadDraftInput {
+  title: string
+  description: string
+  slug: string
+  content: string
+  thumbnailUrl: string
+  tags: readonly string[]
+  tracklist: ReadonlyArray<{ id: number; time: number; title: string }>
+  showId?: string
+  episodeNumber?: string
+  creatorId?: string
+  url?: string
+  audioFile: File | null
+  artworkFile: File | null
+}
+
+export interface UseMixUploadDraftReturn {
+  draft: MixUploadDraft | null
+  isLoaded: boolean
+  saveDraft: (input: MixUploadDraftInput) => void
+  clearDraft: () => Promise<void>
+  hasDraft: boolean
+}
+
+const DEBOUNCE_MS = 600
+
+const toDraft = (input: MixUploadDraftInput, prev: MixUploadDraft): MixUploadDraft => ({
+  ...prev,
+  title: input.title,
+  description: input.description,
+  slug: input.slug,
+  content: input.content,
+  thumbnailUrl: input.thumbnailUrl,
+  tags: [...input.tags],
+  tracklist: input.tracklist.map((t) => ({ id: t.id, time: t.time, title: t.title })),
+  showId: input.showId,
+  episodeNumber: input.episodeNumber,
+  creatorId: input.creatorId,
+  url: input.url,
+  audioFingerprint: input.audioFile
+    ? computeFileFingerprint(input.audioFile)
+    : prev.audioFingerprint,
+  audioFileName: input.audioFile?.name ?? prev.audioFileName,
+  artworkFingerprint: input.artworkFile
+    ? computeFileFingerprint(input.artworkFile)
+    : prev.artworkFingerprint,
+  artworkFileName: input.artworkFile?.name ?? prev.artworkFileName,
+  updatedAt: Date.now()
+})
+
+export function useMixUploadDraft(): UseMixUploadDraftReturn {
+  const [draft, setDraft] = useState<MixUploadDraft | null>(null)
+  const [isLoaded, setIsLoaded] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const latestRef = useRef<MixUploadDraft | null>(null)
+  latestRef.current = draft
+
+  useEffect(() => {
+    let cancelled = false
+    runAppEffect(readMixUploadDraft())
+      .then((value) => {
+        if (cancelled) return
+        setDraft(value)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setDraft(null)
+      })
+      .finally(() => {
+        if (cancelled) return
+        setIsLoaded(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const saveDraft = useCallback((input: MixUploadDraftInput) => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => {
+      const prev = latestRef.current ?? emptyMixUploadDraft()
+      const next = toDraft(input, prev)
+      latestRef.current = next
+      setDraft(next)
+      runAppEffect(Effect.andThen(MixUploadDraftStorage, (s) => s.write(next))).catch((error) => {
+        console.warn('Failed to save mix upload draft', error)
+      })
+    }, DEBOUNCE_MS)
+  }, [])
+
+  const clearDraftFn = useCallback(async () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    latestRef.current = null
+    setDraft(null)
+    await runAppEffect(clearMixUploadDraft()).catch(() => undefined)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  return {
+    draft,
+    isLoaded,
+    saveDraft,
+    clearDraft: clearDraftFn,
+    hasDraft: draft !== null
+  }
+}

--- a/apps/www/src/hooks/useResumableUpload.ts
+++ b/apps/www/src/hooks/useResumableUpload.ts
@@ -1,36 +1,42 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { apiUrl } from '@/lib/http'
+import * as Cause from 'effect/Cause'
+import * as Effect from 'effect/Effect'
+import * as Exit from 'effect/Exit'
 import { useOnlineStatus } from '@/hooks/useOnlineStatus'
-import { readResponseErrorMessage } from '@/lib/response'
+import { runAppEffect } from '@/runtime'
 import {
-  computeBackoff,
-  computeFileFingerprint,
-  createPersistedUpload,
-  isRetryableStatus,
-  missingPartNumbers,
-  parseAbortResponse,
-  parseCompleteResponse,
-  parseInitResponse,
-  parsePartResponse,
-  parsePersistedUpload,
-  parseStatusResponse,
-  sleep,
-  splitFileIntoChunks,
-  withUpdatedPart,
+  AlreadyInProgressError,
   type PersistedResumableUpload,
-  type ResumablePart,
-  type ResumableUploadPhase,
-  type ResumableUploadResult
-} from '@/lib/upload/resumable-upload'
+  type ResumableUploadError,
+  type ResumableUploadResult,
+  ResumableUploadStorage,
+  UnknownError,
+  cancelProgram,
+  uploadProgram
+} from '@/services/resumable-upload'
+import { computeFileFingerprint } from '@/lib/upload/resumable-upload'
 
-const STORAGE_PREFIX = 'gbfm:resumable-upload:'
-const MAX_PART_ATTEMPTS = 5
+export type {
+  PersistedResumableUpload,
+  ResumableUploadError,
+  ResumableUploadResult
+} from '@/services/resumable-upload'
 
-export interface UseResumableUploadOptions {
-  fileType: 'audio'
-  onComplete?: (result: ResumableUploadResult) => void
-  onError?: (error: Error) => void
-}
+export type ResumableUploadPhase =
+  | 'idle'
+  | 'preparing'
+  | 'uploading'
+  | 'paused'
+  | 'finalizing'
+  | 'completed'
+  | 'aborted'
+  | 'error'
+
+export type ResumableUploadOutcome =
+  | { readonly _tag: 'Success'; readonly result: ResumableUploadResult }
+  | { readonly _tag: 'Paused'; readonly checkpoint: PersistedResumableUpload }
+  | { readonly _tag: 'Aborted' }
+  | { readonly _tag: 'Error'; readonly error: ResumableUploadError }
 
 export interface UseResumableUploadState {
   phase: ResumableUploadPhase
@@ -38,45 +44,20 @@ export interface UseResumableUploadState {
   totalBytes: number
   currentPart: number
   totalParts: number
-  error: Error | null
+  error: ResumableUploadError | null
   result: ResumableUploadResult | null
+  checkpoint: PersistedResumableUpload | null
 }
 
 export interface UseResumableUploadReturn {
   state: UseResumableUploadState
-  start: (file: File) => Promise<ResumableUploadResult>
-  resume: (file: File) => Promise<ResumableUploadResult>
+  start: (file: File) => Promise<ResumableUploadOutcome>
+  resume: (file: File) => Promise<ResumableUploadOutcome>
   cancel: () => Promise<void>
   isInProgress: boolean
   isPaused: boolean
   isCompleted: boolean
   hasInProgress: boolean
-}
-
-const readStorage = (key: string): PersistedResumableUpload | null => {
-  try {
-    const raw = window.localStorage.getItem(STORAGE_PREFIX + key)
-    if (!raw) return null
-    return parsePersistedUpload(JSON.parse(raw))
-  } catch {
-    return null
-  }
-}
-
-const writeStorage = (value: PersistedResumableUpload): void => {
-  try {
-    window.localStorage.setItem(STORAGE_PREFIX + value.fileFingerprint, JSON.stringify(value))
-  } catch {
-    // ignored: storage may be full or disabled; uploads still work, they just can't resume
-  }
-}
-
-const clearStorage = (fingerprint: string): void => {
-  try {
-    window.localStorage.removeItem(STORAGE_PREFIX + fingerprint)
-  } catch {
-    // ignored
-  }
 }
 
 const initialState: UseResumableUploadState = {
@@ -86,82 +67,33 @@ const initialState: UseResumableUploadState = {
   currentPart: 0,
   totalParts: 0,
   error: null,
-  result: null
+  result: null,
+  checkpoint: null
 }
 
-const uploadPartWithRetry = async (
-  uploadId: string,
-  key: string,
-  part: { partNumber: number; blob: Blob },
-  signal: AbortSignal
-): Promise<ResumablePart> => {
-  const formData = new FormData()
-  formData.append('key', key)
-  formData.append('uploadId', uploadId)
-  formData.append('partNumber', String(part.partNumber))
-  formData.append('chunk', part.blob, `part-${part.partNumber}`)
+const inProgressPhase = (phase: ResumableUploadPhase): boolean =>
+  phase === 'preparing' || phase === 'uploading' || phase === 'finalizing'
 
-  let lastError: Error | null = null
-  for (let attempt = 1; attempt <= MAX_PART_ATTEMPTS; attempt += 1) {
-    if (signal.aborted) {
-      throw new DOMException('Aborted', 'AbortError')
-    }
-
-    try {
-      const response = await fetch(apiUrl('/upload/multipart/part'), {
-        method: 'POST',
-        body: formData,
-        signal
-      })
-
-      if (response.ok) {
-        return parsePartResponse(await response.json())
-      }
-
-      if (!isRetryableStatus(response.status) || attempt === MAX_PART_ATTEMPTS) {
-        const message = await readResponseErrorMessage(
-          response,
-          `Part ${part.partNumber} failed (${response.status})`
-        )
-        throw new Error(message)
-      }
-    } catch (error) {
-      if (error instanceof DOMException && error.name === 'AbortError') throw error
-      lastError = error instanceof Error ? error : new Error(String(error))
-      if (attempt === MAX_PART_ATTEMPTS) throw lastError
-    }
-
-    const backoff = computeBackoff(attempt)
-    await sleep(backoff, signal)
+const outcomeFromExit = (
+  exit: Exit.Exit<ResumableUploadResult, ResumableUploadError>
+): ResumableUploadOutcome => {
+  if (Exit.isSuccess(exit)) {
+    return { _tag: 'Success', result: exit.value }
   }
-
-  throw lastError ?? new Error(`Part ${part.partNumber} failed`)
-}
-
-export class ResumableUploadAbortedError extends Error {
-  constructor() {
-    super('Upload aborted')
-    this.name = 'ResumableUploadAbortedError'
+  const errorOpt = Cause.findErrorOption(exit.cause)
+  if (errorOpt._tag === 'None') {
+    return { _tag: 'Error', error: new UnknownError({ message: 'Unexpected upload failure' }) }
   }
+  const error = errorOpt.value
+  if (error._tag === 'UploadAborted') return { _tag: 'Aborted' }
+  if (error._tag === 'UploadPaused') return { _tag: 'Paused', checkpoint: error.checkpoint }
+  return { _tag: 'Error', error }
 }
 
-export class ResumableUploadPausedError extends Error {
-  constructor() {
-    super('Upload paused')
-    this.name = 'ResumableUploadPausedError'
-  }
-}
-
-export function useResumableUpload(
-  options: UseResumableUploadOptions = { fileType: 'audio' }
-): UseResumableUploadReturn {
-  const { fileType, onComplete, onError } = options
+export function useResumableUpload(): UseResumableUploadReturn {
   const isOnline = useOnlineStatus()
-
   const [state, setState] = useState<UseResumableUploadState>(initialState)
-
-  const persistedRef = useRef<PersistedResumableUpload | null>(null)
-  const fingerprintRef = useRef<string | null>(null)
+  const checkpointRef = useRef<PersistedResumableUpload | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
   const pausedRef = useRef<boolean>(false)
 
@@ -170,39 +102,47 @@ export function useResumableUpload(
       patch:
         | Partial<UseResumableUploadState>
         | ((prev: UseResumableUploadState) => Partial<UseResumableUploadState>)
-    ) => {
+    ) =>
       setState((prev) => ({
         ...prev,
         ...(typeof patch === 'function' ? patch(prev) : patch)
-      }))
-    },
+      })),
     []
   )
 
-  const persist = useCallback((next: PersistedResumableUpload) => {
-    persistedRef.current = next
-    writeStorage(next)
-  }, [])
+  const setCheckpoint = useCallback(
+    (checkpoint: PersistedResumableUpload | null) => {
+      checkpointRef.current = checkpoint
+      transitionTo({ checkpoint })
+    },
+    [transitionTo]
+  )
 
-  const clearAll = useCallback(() => {
-    if (fingerprintRef.current) {
-      clearStorage(fingerprintRef.current)
-    }
-    persistedRef.current = null
-    fingerprintRef.current = null
-    pausedRef.current = false
-  }, [])
+  const loadCheckpoint = useCallback(
+    async (file: File): Promise<PersistedResumableUpload | null> => {
+      const fingerprint = computeFileFingerprint(file)
+      return runAppEffect(
+        Effect.andThen(ResumableUploadStorage, (storage) => storage.read(fingerprint))
+      ).catch(() => null)
+    },
+    []
+  )
 
   const runUpload = useCallback(
     async (
       file: File,
       resumeFrom: PersistedResumableUpload | null
-    ): Promise<ResumableUploadResult> => {
-      const fingerprint = computeFileFingerprint(file)
-      fingerprintRef.current = fingerprint
+    ): Promise<ResumableUploadOutcome> => {
+      if (inProgressPhase(state.phase)) {
+        return {
+          _tag: 'Error',
+          error: new AlreadyInProgressError({ message: 'Upload already in progress' })
+        }
+      }
+
       pausedRef.current = false
-      abortControllerRef.current = new AbortController()
-      const signal = abortControllerRef.current.signal
+      const controller = new AbortController()
+      abortControllerRef.current = controller
 
       transitionTo({
         phase: 'preparing',
@@ -210,212 +150,81 @@ export function useResumableUpload(
         result: null,
         totalBytes: file.size,
         bytesUploaded: 0,
-        currentPart: 0
+        currentPart: 0,
+        totalParts: 0,
+        checkpoint: resumeFrom
       })
+      checkpointRef.current = resumeFrom
 
-      try {
-        let persisted: PersistedResumableUpload
-        if (resumeFrom) {
-          const statusResponse = await fetch(
-            apiUrl(
-              `/upload/multipart/status?key=${encodeURIComponent(resumeFrom.key)}&uploadId=${encodeURIComponent(resumeFrom.uploadId)}`
-            ),
-            { signal }
-          )
-          if (!statusResponse.ok) {
-            const message = await readResponseErrorMessage(
-              statusResponse,
-              'Failed to fetch upload status'
-            )
-            throw new Error(message)
-          }
-          const serverStatus = parseStatusResponse(await statusResponse.json())
-          persisted = {
-            ...resumeFrom,
-            completedParts: serverStatus.parts,
-            updatedAt: Date.now()
-          }
-        } else {
-          const initResponse = await fetch(apiUrl('/upload/multipart/init'), {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              fileName: file.name,
-              contentType: file.type,
-              fileSize: file.size,
-              fileType
-            }),
-            signal
-          })
-          if (!initResponse.ok) {
-            const message = await readResponseErrorMessage(initResponse, 'Failed to start upload')
-            throw new Error(message)
-          }
-          persisted = createPersistedUpload({
-            file,
-            fileFingerprint: fingerprint,
-            init: parseInitResponse(await initResponse.json())
-          })
+      const program = uploadProgram(
+        { file, fileType: 'audio' },
+        {
+          signal: controller.signal,
+          isPaused: () => pausedRef.current,
+          onProgress: (progress) => {
+            setState((prev) => ({ ...prev, ...progress }))
+          },
+          checkpoint: resumeFrom ?? undefined
         }
+      )
 
-        persist(persisted)
+      const exit = await runAppEffect(Effect.exit(program))
+      const outcome = outcomeFromExit(exit)
 
-        const chunks = splitFileIntoChunks(file, persisted.chunkSize)
-        const todo = missingPartNumbers(persisted.totalParts, persisted.completedParts)
-          .map((partNumber) => chunks[partNumber - 1])
-          .filter((chunk): chunk is (typeof chunks)[number] => Boolean(chunk))
-
-        const initialBytes = persisted.completedParts.reduce((sum, p) => sum + p.size, 0)
-        transitionTo({
-          phase: 'uploading',
-          bytesUploaded: initialBytes,
-          totalBytes: persisted.totalBytes,
-          totalParts: persisted.totalParts,
-          currentPart: persisted.completedParts.length
-        })
-
-        let working: PersistedResumableUpload = persisted
-        for (const chunk of todo) {
-          if (signal.aborted) throw new ResumableUploadAbortedError()
-          if (pausedRef.current) {
-            persist(working)
-            transitionTo({ phase: 'paused' })
-            throw new ResumableUploadPausedError()
-          }
-
-          const result = await uploadPartWithRetry(
-            working.uploadId,
-            working.key,
-            { partNumber: chunk.partNumber, blob: chunk.blob },
-            signal
-          )
-
-          working = withUpdatedPart(working, result)
-          persist(working)
-          transitionTo((prev) => ({
-            ...prev,
-            bytesUploaded: prev.bytesUploaded + result.size,
-            currentPart: Math.min(prev.currentPart + 1, prev.totalParts)
-          }))
-        }
-
-        if (pausedRef.current) {
-          transitionTo({ phase: 'paused' })
-          throw new ResumableUploadPausedError()
-        }
-        if (signal.aborted) throw new ResumableUploadAbortedError()
-
-        transitionTo({ phase: 'finalizing' })
-
-        const completeResponse = await fetch(apiUrl('/upload/multipart/complete'), {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            key: working.key,
-            uploadId: working.uploadId,
-            parts: working.completedParts.map((p) => ({
-              partNumber: p.partNumber,
-              etag: p.etag
-            }))
-          }),
-          signal
-        })
-        if (!completeResponse.ok) {
-          const message = await readResponseErrorMessage(
-            completeResponse,
-            'Failed to complete upload'
-          )
-          throw new Error(message)
-        }
-
-        const completed: ResumableUploadResult = parseCompleteResponse(
-          await completeResponse.json()
-        )
-        clearAll()
-
-        setState({
-          phase: 'completed',
-          bytesUploaded: working.totalBytes,
-          totalBytes: working.totalBytes,
-          currentPart: working.totalParts,
-          totalParts: working.totalParts,
-          error: null,
-          result: completed
-        })
-        onComplete?.(completed)
-        return completed
-      } catch (error) {
-        if (error instanceof ResumableUploadAbortedError) {
-          transitionTo({ phase: 'aborted' })
-          throw error
-        }
-        if (error instanceof ResumableUploadPausedError) {
-          transitionTo({ phase: 'paused' })
-          throw error
-        }
-        const err = error instanceof Error ? error : new Error(String(error))
-        transitionTo({ phase: 'error', error: err })
-        onError?.(err)
-        throw err
+      if (outcome._tag === 'Success') {
+        setCheckpoint(null)
+        transitionTo({ result: outcome.result })
+      } else if (outcome._tag === 'Paused') {
+        setCheckpoint(outcome.checkpoint)
+      } else if (outcome._tag === 'Error') {
+        transitionTo({ error: outcome.error })
       }
+
+      return outcome
     },
-    [fileType, onComplete, onError, persist, transitionTo, clearAll]
+    [state.phase, transitionTo, setCheckpoint]
   )
 
   const start = useCallback(
-    (file: File): Promise<ResumableUploadResult> => {
-      if (
-        state.phase === 'preparing' ||
-        state.phase === 'uploading' ||
-        state.phase === 'finalizing'
-      ) {
-        return Promise.reject(new Error('Upload already in progress'))
+    async (file: File): Promise<ResumableUploadOutcome> => {
+      if (inProgressPhase(state.phase)) {
+        return {
+          _tag: 'Error',
+          error: new AlreadyInProgressError({ message: 'Upload already in progress' })
+        }
       }
-      pausedRef.current = false
-      const checkpoint = readResumableUpload(file)
+      const checkpoint = await loadCheckpoint(file)
       return runUpload(file, checkpoint)
     },
-    [runUpload, state.phase]
+    [state.phase, loadCheckpoint, runUpload]
   )
 
   const resume = useCallback(
-    (file: File): Promise<ResumableUploadResult> => {
-      if (
-        state.phase === 'preparing' ||
-        state.phase === 'uploading' ||
-        state.phase === 'finalizing'
-      ) {
-        return Promise.reject(new Error('Upload already in progress'))
+    async (file: File): Promise<ResumableUploadOutcome> => {
+      if (inProgressPhase(state.phase)) {
+        return {
+          _tag: 'Error',
+          error: new AlreadyInProgressError({ message: 'Upload already in progress' })
+        }
       }
-      pausedRef.current = false
-      const checkpoint = persistedRef.current ?? readResumableUpload(file)
+      const checkpoint = checkpointRef.current ?? (await loadCheckpoint(file))
       return runUpload(file, checkpoint)
     },
-    [runUpload, state.phase]
+    [state.phase, loadCheckpoint, runUpload]
   )
 
   const cancel = useCallback(async () => {
-    const persisted = persistedRef.current
-    abortControllerRef.current?.abort()
-
-    if (persisted) {
-      try {
-        const response = await fetch(apiUrl('/upload/multipart/abort'), {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ key: persisted.key, uploadId: persisted.uploadId })
-        })
-        if (response.ok) {
-          parseAbortResponse(await response.json())
-        }
-      } catch {
-        // The S3 lifecycle rule cleans up abandoned uploads regardless.
-      }
+    const controller = abortControllerRef.current
+    const checkpoint = checkpointRef.current
+    controller?.abort()
+    if (checkpoint) {
+      const signal = controller?.signal ?? new AbortController().signal
+      await runAppEffect(cancelProgram(checkpoint, signal)).catch(() => undefined)
     }
-
-    clearAll()
+    checkpointRef.current = null
+    pausedRef.current = false
     setState({ ...initialState, phase: 'aborted' })
-  }, [clearAll])
+  }, [])
 
   useEffect(() => {
     return () => {
@@ -424,15 +233,13 @@ export function useResumableUpload(
   }, [])
 
   useEffect(() => {
-    if (state.phase !== 'uploading' && state.phase !== 'finalizing') return
+    if (!inProgressPhase(state.phase)) return
     if (isOnline) return
     pausedRef.current = true
-    setState((prev) =>
-      prev.phase === 'uploading' || prev.phase === 'finalizing'
-        ? { ...prev, phase: 'paused' }
-        : prev
-    )
+    setState((prev) => (inProgressPhase(prev.phase) ? { ...prev, phase: 'paused' } : prev))
   }, [isOnline, state.phase])
+
+  const hasInProgress = state.checkpoint !== null && state.phase !== 'completed'
 
   return useMemo(
     () => ({
@@ -440,15 +247,11 @@ export function useResumableUpload(
       start,
       resume,
       cancel,
-      isInProgress:
-        state.phase === 'uploading' || state.phase === 'finalizing' || state.phase === 'preparing',
+      isInProgress: inProgressPhase(state.phase),
       isPaused: state.phase === 'paused',
       isCompleted: state.phase === 'completed',
-      hasInProgress: persistedRef.current !== null
+      hasInProgress
     }),
-    [state, start, resume, cancel]
+    [state, start, resume, cancel, hasInProgress]
   )
 }
-
-export const readResumableUpload = (file: File): PersistedResumableUpload | null =>
-  readStorage(computeFileFingerprint(file))

--- a/apps/www/src/hooks/useResumableUpload.ts
+++ b/apps/www/src/hooks/useResumableUpload.ts
@@ -7,7 +7,6 @@ import {
   computeFileFingerprint,
   createPersistedUpload,
   isRetryableStatus,
-  mergeCompletedParts,
   missingPartNumbers,
   parseAbortResponse,
   parseCompleteResponse,
@@ -233,7 +232,7 @@ export function useResumableUpload(
           const serverStatus = parseStatusResponse(await statusResponse.json())
           persisted = {
             ...resumeFrom,
-            completedParts: mergeCompletedParts(resumeFrom.completedParts, serverStatus.parts),
+            completedParts: serverStatus.parts,
             updatedAt: Date.now()
           }
         } else {
@@ -277,12 +276,12 @@ export function useResumableUpload(
 
         let working: PersistedResumableUpload = persisted
         for (const chunk of todo) {
+          if (signal.aborted) throw new ResumableUploadAbortedError()
           if (pausedRef.current) {
             persist(working)
             transitionTo({ phase: 'paused' })
             throw new ResumableUploadPausedError()
           }
-          if (signal.aborted) throw new ResumableUploadAbortedError()
 
           const result = await uploadPartWithRetry(
             working.uploadId,
@@ -365,24 +364,38 @@ export function useResumableUpload(
 
   const start = useCallback(
     (file: File): Promise<ResumableUploadResult> => {
-      if (pausedRef.current) pausedRef.current = false
-      return runUpload(file, null)
+      if (
+        state.phase === 'preparing' ||
+        state.phase === 'uploading' ||
+        state.phase === 'finalizing'
+      ) {
+        return Promise.reject(new Error('Upload already in progress'))
+      }
+      pausedRef.current = false
+      const checkpoint = readResumableUpload(file)
+      return runUpload(file, checkpoint)
     },
-    [runUpload]
+    [runUpload, state.phase]
   )
 
   const resume = useCallback(
     (file: File): Promise<ResumableUploadResult> => {
-      const existing = persistedRef.current
-      if (pausedRef.current) pausedRef.current = false
-      return runUpload(file, existing)
+      if (
+        state.phase === 'preparing' ||
+        state.phase === 'uploading' ||
+        state.phase === 'finalizing'
+      ) {
+        return Promise.reject(new Error('Upload already in progress'))
+      }
+      pausedRef.current = false
+      const checkpoint = persistedRef.current ?? readResumableUpload(file)
+      return runUpload(file, checkpoint)
     },
-    [runUpload]
+    [runUpload, state.phase]
   )
 
   const cancel = useCallback(async () => {
     const persisted = persistedRef.current
-    pausedRef.current = true
     abortControllerRef.current?.abort()
 
     if (persisted) {

--- a/apps/www/src/hooks/useResumableUpload.ts
+++ b/apps/www/src/hooks/useResumableUpload.ts
@@ -1,0 +1,421 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { apiUrl } from '@/lib/http'
+import { useOnlineStatus } from '@/hooks/useOnlineStatus'
+import { readResponseErrorMessage } from '@/lib/response'
+import {
+  computeBackoff,
+  computeFileFingerprint,
+  createPersistedUpload,
+  isRetryableStatus,
+  mergeCompletedParts,
+  missingPartNumbers,
+  parseAbortResponse,
+  parseCompleteResponse,
+  parseInitResponse,
+  parsePartResponse,
+  parsePersistedUpload,
+  parseStatusResponse,
+  sleep,
+  splitFileIntoChunks,
+  withUpdatedPart,
+  type PersistedResumableUpload,
+  type ResumablePart,
+  type ResumableUploadPhase,
+  type ResumableUploadResult
+} from '@/lib/upload/resumable-upload'
+
+const STORAGE_PREFIX = 'gbfm:resumable-upload:'
+const MAX_PART_ATTEMPTS = 5
+
+export interface UseResumableUploadOptions {
+  fileType: 'audio'
+  onComplete: (result: ResumableUploadResult) => void
+  onError?: (error: Error) => void
+}
+
+export interface UseResumableUploadState {
+  phase: ResumableUploadPhase
+  bytesUploaded: number
+  totalBytes: number
+  currentPart: number
+  totalParts: number
+  error: Error | null
+  result: ResumableUploadResult | null
+}
+
+export interface UseResumableUploadReturn {
+  state: UseResumableUploadState
+  start: (file: File) => Promise<void>
+  pause: () => void
+  resume: (file: File) => Promise<void>
+  cancel: () => Promise<void>
+  retry: (file: File) => Promise<void>
+  isInProgress: boolean
+  isPaused: boolean
+  isCompleted: boolean
+}
+
+const readStorage = (key: string): PersistedResumableUpload | null => {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + key)
+    if (!raw) return null
+    return parsePersistedUpload(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+const writeStorage = (value: PersistedResumableUpload): void => {
+  try {
+    window.localStorage.setItem(STORAGE_PREFIX + value.fileFingerprint, JSON.stringify(value))
+  } catch {
+    // ignored: storage may be full or disabled; uploads still work, they just can't resume
+  }
+}
+
+const clearStorage = (fingerprint: string): void => {
+  try {
+    window.localStorage.removeItem(STORAGE_PREFIX + fingerprint)
+  } catch {
+    // ignored
+  }
+}
+
+const initialState: UseResumableUploadState = {
+  phase: 'idle',
+  bytesUploaded: 0,
+  totalBytes: 0,
+  currentPart: 0,
+  totalParts: 0,
+  error: null,
+  result: null
+}
+
+const uploadPartWithRetry = async (
+  uploadId: string,
+  key: string,
+  part: { partNumber: number; blob: Blob },
+  signal: AbortSignal
+): Promise<ResumablePart> => {
+  const formData = new FormData()
+  formData.append('key', key)
+  formData.append('uploadId', uploadId)
+  formData.append('partNumber', String(part.partNumber))
+  formData.append('chunk', part.blob, `part-${part.partNumber}`)
+
+  let lastError: Error | null = null
+  for (let attempt = 1; attempt <= MAX_PART_ATTEMPTS; attempt += 1) {
+    if (signal.aborted) {
+      throw new DOMException('Aborted', 'AbortError')
+    }
+
+    try {
+      const response = await fetch(apiUrl('/upload/multipart/part'), {
+        method: 'POST',
+        body: formData,
+        signal
+      })
+
+      if (response.ok) {
+        return parsePartResponse(await response.json())
+      }
+
+      if (!isRetryableStatus(response.status) || attempt === MAX_PART_ATTEMPTS) {
+        const message = await readResponseErrorMessage(
+          response,
+          `Part ${part.partNumber} failed (${response.status})`
+        )
+        throw new Error(message)
+      }
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error
+      lastError = error instanceof Error ? error : new Error(String(error))
+      if (attempt === MAX_PART_ATTEMPTS) throw lastError
+    }
+
+    const backoff = computeBackoff(attempt)
+    await sleep(backoff, signal)
+  }
+
+  throw lastError ?? new Error(`Part ${part.partNumber} failed`)
+}
+
+export function useResumableUpload(options: UseResumableUploadOptions): UseResumableUploadReturn {
+  const { fileType, onComplete, onError } = options
+  const isOnline = useOnlineStatus()
+
+  const [state, setState] = useState<UseResumableUploadState>(initialState)
+
+  const persistedRef = useRef<PersistedResumableUpload | null>(null)
+  const fingerprintRef = useRef<string | null>(null)
+  const abortControllerRef = useRef<AbortController | null>(null)
+  const pausedRef = useRef<boolean>(false)
+
+  const transitionTo = useCallback(
+    (
+      patch:
+        | Partial<UseResumableUploadState>
+        | ((prev: UseResumableUploadState) => Partial<UseResumableUploadState>)
+    ) => {
+      setState((prev) => ({
+        ...prev,
+        ...(typeof patch === 'function' ? patch(prev) : patch)
+      }))
+    },
+    []
+  )
+
+  const persist = useCallback((next: PersistedResumableUpload) => {
+    persistedRef.current = next
+    writeStorage(next)
+  }, [])
+
+  const clearAll = useCallback(() => {
+    if (fingerprintRef.current) {
+      clearStorage(fingerprintRef.current)
+    }
+    persistedRef.current = null
+    fingerprintRef.current = null
+    pausedRef.current = false
+  }, [])
+
+  const runUpload = useCallback(
+    async (file: File, resumeFrom: PersistedResumableUpload | null) => {
+      const fingerprint = computeFileFingerprint(file)
+      fingerprintRef.current = fingerprint
+      pausedRef.current = false
+      abortControllerRef.current = new AbortController()
+      const signal = abortControllerRef.current.signal
+
+      transitionTo({
+        phase: 'preparing',
+        error: null,
+        result: null,
+        totalBytes: file.size,
+        bytesUploaded: 0,
+        currentPart: 0
+      })
+
+      try {
+        let persisted: PersistedResumableUpload
+        if (resumeFrom) {
+          const statusResponse = await fetch(
+            apiUrl(
+              `/upload/multipart/status?key=${encodeURIComponent(resumeFrom.key)}&uploadId=${encodeURIComponent(resumeFrom.uploadId)}`
+            ),
+            { signal }
+          )
+          if (!statusResponse.ok) {
+            const message = await readResponseErrorMessage(
+              statusResponse,
+              'Failed to fetch upload status'
+            )
+            throw new Error(message)
+          }
+          const serverStatus = parseStatusResponse(await statusResponse.json())
+          persisted = {
+            ...resumeFrom,
+            completedParts: mergeCompletedParts(resumeFrom.completedParts, serverStatus.parts),
+            updatedAt: Date.now()
+          }
+        } else {
+          const initResponse = await fetch(apiUrl('/upload/multipart/init'), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              fileName: file.name,
+              contentType: file.type,
+              fileSize: file.size,
+              fileType
+            }),
+            signal
+          })
+          if (!initResponse.ok) {
+            const message = await readResponseErrorMessage(initResponse, 'Failed to start upload')
+            throw new Error(message)
+          }
+          persisted = createPersistedUpload({
+            file,
+            fileFingerprint: fingerprint,
+            init: parseInitResponse(await initResponse.json())
+          })
+        }
+
+        persist(persisted)
+
+        const chunks = splitFileIntoChunks(file, persisted.chunkSize)
+        const todo = missingPartNumbers(persisted.totalParts, persisted.completedParts)
+          .map((partNumber) => chunks[partNumber - 1])
+          .filter((chunk): chunk is (typeof chunks)[number] => Boolean(chunk))
+
+        const initialBytes = persisted.completedParts.reduce((sum, p) => sum + p.size, 0)
+        transitionTo({
+          phase: 'uploading',
+          bytesUploaded: initialBytes,
+          totalBytes: persisted.totalBytes,
+          totalParts: persisted.totalParts,
+          currentPart: persisted.completedParts.length
+        })
+
+        let working: PersistedResumableUpload = persisted
+        for (const chunk of todo) {
+          if (pausedRef.current) {
+            persist(working)
+            transitionTo({ phase: 'paused' })
+            return
+          }
+          if (signal.aborted) return
+
+          const result = await uploadPartWithRetry(
+            working.uploadId,
+            working.key,
+            { partNumber: chunk.partNumber, blob: chunk.blob },
+            signal
+          )
+
+          working = withUpdatedPart(working, result)
+          persist(working)
+          transitionTo((prev) => ({
+            ...prev,
+            bytesUploaded: prev.bytesUploaded + result.size,
+            currentPart: Math.min(prev.currentPart + 1, prev.totalParts)
+          }))
+        }
+
+        if (pausedRef.current) {
+          transitionTo({ phase: 'paused' })
+          return
+        }
+        if (signal.aborted) return
+
+        transitionTo({ phase: 'finalizing' })
+
+        const completeResponse = await fetch(apiUrl('/upload/multipart/complete'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            key: working.key,
+            uploadId: working.uploadId,
+            parts: working.completedParts.map((p) => ({
+              partNumber: p.partNumber,
+              etag: p.etag
+            }))
+          }),
+          signal
+        })
+        if (!completeResponse.ok) {
+          const message = await readResponseErrorMessage(
+            completeResponse,
+            'Failed to complete upload'
+          )
+          throw new Error(message)
+        }
+
+        const completed: ResumableUploadResult = parseCompleteResponse(
+          await completeResponse.json()
+        )
+        clearAll()
+
+        setState({
+          phase: 'completed',
+          bytesUploaded: working.totalBytes,
+          totalBytes: working.totalBytes,
+          currentPart: working.totalParts,
+          totalParts: working.totalParts,
+          error: null,
+          result: completed
+        })
+        onComplete(completed)
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') return
+        const err = error instanceof Error ? error : new Error(String(error))
+        transitionTo({ phase: 'error', error: err })
+        onError?.(err)
+      }
+    },
+    [fileType, onComplete, onError, persist, transitionTo, clearAll]
+  )
+
+  const start = useCallback((file: File) => runUpload(file, null), [runUpload])
+
+  const resume = useCallback(
+    (file: File) => {
+      const existing = persistedRef.current
+      return runUpload(file, existing)
+    },
+    [runUpload]
+  )
+
+  const pause = useCallback(() => {
+    pausedRef.current = true
+    setState((prev) => (prev.phase === 'uploading' ? { ...prev, phase: 'paused' } : prev))
+  }, [])
+
+  const cancel = useCallback(async () => {
+    const persisted = persistedRef.current
+    pausedRef.current = true
+    abortControllerRef.current?.abort()
+
+    if (persisted) {
+      try {
+        const response = await fetch(apiUrl('/upload/multipart/abort'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key: persisted.key, uploadId: persisted.uploadId })
+        })
+        if (response.ok) {
+          parseAbortResponse(await response.json())
+        }
+      } catch {
+        // The S3 lifecycle rule cleans up abandoned uploads regardless.
+      }
+    }
+
+    clearAll()
+    setState({ ...initialState, phase: 'aborted' })
+  }, [clearAll])
+
+  const retry = useCallback(
+    (file: File) => {
+      const existing = persistedRef.current
+      return runUpload(file, existing)
+    },
+    [runUpload]
+  )
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (state.phase !== 'uploading' && state.phase !== 'finalizing') return
+    if (isOnline) return
+    pausedRef.current = true
+    setState((prev) =>
+      prev.phase === 'uploading' || prev.phase === 'finalizing'
+        ? { ...prev, phase: 'paused' }
+        : prev
+    )
+  }, [isOnline, state.phase])
+
+  return useMemo(
+    () => ({
+      state,
+      start,
+      pause,
+      resume,
+      cancel,
+      retry,
+      isInProgress:
+        state.phase === 'uploading' || state.phase === 'finalizing' || state.phase === 'preparing',
+      isPaused: state.phase === 'paused',
+      isCompleted: state.phase === 'completed'
+    }),
+    [state, start, pause, resume, cancel, retry]
+  )
+}
+
+export const readResumableUpload = (file: File): PersistedResumableUpload | null =>
+  readStorage(computeFileFingerprint(file))

--- a/apps/www/src/hooks/useResumableUpload.ts
+++ b/apps/www/src/hooks/useResumableUpload.ts
@@ -29,7 +29,7 @@ const MAX_PART_ATTEMPTS = 5
 
 export interface UseResumableUploadOptions {
   fileType: 'audio'
-  onComplete: (result: ResumableUploadResult) => void
+  onComplete?: (result: ResumableUploadResult) => void
   onError?: (error: Error) => void
 }
 
@@ -45,14 +45,13 @@ export interface UseResumableUploadState {
 
 export interface UseResumableUploadReturn {
   state: UseResumableUploadState
-  start: (file: File) => Promise<void>
-  pause: () => void
-  resume: (file: File) => Promise<void>
+  start: (file: File) => Promise<ResumableUploadResult>
+  resume: (file: File) => Promise<ResumableUploadResult>
   cancel: () => Promise<void>
-  retry: (file: File) => Promise<void>
   isInProgress: boolean
   isPaused: boolean
   isCompleted: boolean
+  hasInProgress: boolean
 }
 
 const readStorage = (key: string): PersistedResumableUpload | null => {
@@ -140,7 +139,23 @@ const uploadPartWithRetry = async (
   throw lastError ?? new Error(`Part ${part.partNumber} failed`)
 }
 
-export function useResumableUpload(options: UseResumableUploadOptions): UseResumableUploadReturn {
+export class ResumableUploadAbortedError extends Error {
+  constructor() {
+    super('Upload aborted')
+    this.name = 'ResumableUploadAbortedError'
+  }
+}
+
+export class ResumableUploadPausedError extends Error {
+  constructor() {
+    super('Upload paused')
+    this.name = 'ResumableUploadPausedError'
+  }
+}
+
+export function useResumableUpload(
+  options: UseResumableUploadOptions = { fileType: 'audio' }
+): UseResumableUploadReturn {
   const { fileType, onComplete, onError } = options
   const isOnline = useOnlineStatus()
 
@@ -180,7 +195,10 @@ export function useResumableUpload(options: UseResumableUploadOptions): UseResum
   }, [])
 
   const runUpload = useCallback(
-    async (file: File, resumeFrom: PersistedResumableUpload | null) => {
+    async (
+      file: File,
+      resumeFrom: PersistedResumableUpload | null
+    ): Promise<ResumableUploadResult> => {
       const fingerprint = computeFileFingerprint(file)
       fingerprintRef.current = fingerprint
       pausedRef.current = false
@@ -262,9 +280,9 @@ export function useResumableUpload(options: UseResumableUploadOptions): UseResum
           if (pausedRef.current) {
             persist(working)
             transitionTo({ phase: 'paused' })
-            return
+            throw new ResumableUploadPausedError()
           }
-          if (signal.aborted) return
+          if (signal.aborted) throw new ResumableUploadAbortedError()
 
           const result = await uploadPartWithRetry(
             working.uploadId,
@@ -284,9 +302,9 @@ export function useResumableUpload(options: UseResumableUploadOptions): UseResum
 
         if (pausedRef.current) {
           transitionTo({ phase: 'paused' })
-          return
+          throw new ResumableUploadPausedError()
         }
-        if (signal.aborted) return
+        if (signal.aborted) throw new ResumableUploadAbortedError()
 
         transitionTo({ phase: 'finalizing' })
 
@@ -325,31 +343,42 @@ export function useResumableUpload(options: UseResumableUploadOptions): UseResum
           error: null,
           result: completed
         })
-        onComplete(completed)
+        onComplete?.(completed)
+        return completed
       } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') return
+        if (error instanceof ResumableUploadAbortedError) {
+          transitionTo({ phase: 'aborted' })
+          throw error
+        }
+        if (error instanceof ResumableUploadPausedError) {
+          transitionTo({ phase: 'paused' })
+          throw error
+        }
         const err = error instanceof Error ? error : new Error(String(error))
         transitionTo({ phase: 'error', error: err })
         onError?.(err)
+        throw err
       }
     },
     [fileType, onComplete, onError, persist, transitionTo, clearAll]
   )
 
-  const start = useCallback((file: File) => runUpload(file, null), [runUpload])
-
-  const resume = useCallback(
-    (file: File) => {
-      const existing = persistedRef.current
-      return runUpload(file, existing)
+  const start = useCallback(
+    (file: File): Promise<ResumableUploadResult> => {
+      if (pausedRef.current) pausedRef.current = false
+      return runUpload(file, null)
     },
     [runUpload]
   )
 
-  const pause = useCallback(() => {
-    pausedRef.current = true
-    setState((prev) => (prev.phase === 'uploading' ? { ...prev, phase: 'paused' } : prev))
-  }, [])
+  const resume = useCallback(
+    (file: File): Promise<ResumableUploadResult> => {
+      const existing = persistedRef.current
+      if (pausedRef.current) pausedRef.current = false
+      return runUpload(file, existing)
+    },
+    [runUpload]
+  )
 
   const cancel = useCallback(async () => {
     const persisted = persistedRef.current
@@ -375,14 +404,6 @@ export function useResumableUpload(options: UseResumableUploadOptions): UseResum
     setState({ ...initialState, phase: 'aborted' })
   }, [clearAll])
 
-  const retry = useCallback(
-    (file: File) => {
-      const existing = persistedRef.current
-      return runUpload(file, existing)
-    },
-    [runUpload]
-  )
-
   useEffect(() => {
     return () => {
       abortControllerRef.current?.abort()
@@ -404,16 +425,15 @@ export function useResumableUpload(options: UseResumableUploadOptions): UseResum
     () => ({
       state,
       start,
-      pause,
       resume,
       cancel,
-      retry,
       isInProgress:
         state.phase === 'uploading' || state.phase === 'finalizing' || state.phase === 'preparing',
       isPaused: state.phase === 'paused',
-      isCompleted: state.phase === 'completed'
+      isCompleted: state.phase === 'completed',
+      hasInProgress: persistedRef.current !== null
     }),
-    [state, start, pause, resume, cancel, retry]
+    [state, start, resume, cancel]
   )
 }
 

--- a/apps/www/src/lib/upload/resumable-upload.test.ts
+++ b/apps/www/src/lib/upload/resumable-upload.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, test } from 'vitest'
+import {
+  computeBackoff,
+  computeFileFingerprint,
+  createPersistedUpload,
+  isRetryableStatus,
+  mergeCompletedParts,
+  missingPartNumbers,
+  parseAbortResponse,
+  parseCompleteResponse,
+  parseInitResponse,
+  parsePartResponse,
+  parsePersistedUpload,
+  parseStatusResponse,
+  splitFileIntoChunks,
+  totalParts,
+  withUpdatedPart
+} from './resumable-upload'
+
+const makeFile = (size: number, name = 'mix.mp3', lastModified = 1_700_000_000_000): File => {
+  const blob = new Blob([new Uint8Array(size)], { type: 'audio/mpeg' })
+  return new File([blob], name, { type: 'audio/mpeg', lastModified })
+}
+
+describe('computeFileFingerprint', () => {
+  test('combines size, name, and lastModified', () => {
+    const file = makeFile(123, 'a.mp3', 42)
+    expect(computeFileFingerprint(file)).toBe('123:a.mp3:42')
+  })
+
+  test('differs when any component differs', () => {
+    const a = makeFile(100, 'a.mp3', 1)
+    const b = makeFile(100, 'b.mp3', 1)
+    const c = makeFile(100, 'a.mp3', 2)
+    const d = makeFile(101, 'a.mp3', 1)
+    expect(new Set([a, b, c, d].map(computeFileFingerprint)).size).toBe(4)
+  })
+})
+
+describe('splitFileIntoChunks', () => {
+  test('returns a single chunk when file fits', () => {
+    const file = makeFile(5)
+    const chunks = splitFileIntoChunks(file, 10)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]?.partNumber).toBe(1)
+    expect(chunks[0]?.start).toBe(0)
+    expect(chunks[0]?.end).toBe(5)
+  })
+
+  test('splits into even chunks', () => {
+    const file = makeFile(100)
+    const chunks = splitFileIntoChunks(file, 25)
+    expect(chunks).toHaveLength(4)
+    expect(chunks.map((c) => c.partNumber)).toEqual([1, 2, 3, 4])
+    expect(chunks[0]?.start).toBe(0)
+    expect(chunks[3]?.end).toBe(100)
+  })
+
+  test('keeps the last chunk smaller when not aligned', () => {
+    const file = makeFile(105)
+    const chunks = splitFileIntoChunks(file, 25)
+    expect(chunks).toHaveLength(5)
+    expect(chunks[3]?.end).toBe(100)
+    expect(chunks[4]?.end).toBe(105)
+    expect(chunks[4]?.blob.size).toBe(5)
+  })
+
+  test('rejects non-positive chunk size', () => {
+    const file = makeFile(10)
+    expect(() => splitFileIntoChunks(file, 0)).toThrow()
+    expect(() => splitFileIntoChunks(file, -1)).toThrow()
+  })
+})
+
+describe('totalParts', () => {
+  test('handles exact multiples', () => {
+    expect(totalParts(100, 10)).toBe(10)
+  })
+
+  test('rounds up partial chunks', () => {
+    expect(totalParts(101, 10)).toBe(11)
+  })
+
+  test('returns 0 for empty files', () => {
+    expect(totalParts(0, 10)).toBe(0)
+  })
+})
+
+describe('mergeCompletedParts', () => {
+  test('unions multiple sources by partNumber', () => {
+    const merged = mergeCompletedParts(
+      [{ partNumber: 1, etag: 'a', size: 10 }],
+      [{ partNumber: 2, etag: 'b', size: 20 }]
+    )
+    expect(merged).toEqual([
+      { partNumber: 1, etag: 'a', size: 10 },
+      { partNumber: 2, etag: 'b', size: 20 }
+    ])
+  })
+
+  test('last write wins on duplicates', () => {
+    const merged = mergeCompletedParts(
+      [{ partNumber: 1, etag: 'old', size: 10 }],
+      [{ partNumber: 1, etag: 'new', size: 12 }]
+    )
+    expect(merged).toEqual([{ partNumber: 1, etag: 'new', size: 12 }])
+  })
+
+  test('sorts the result by partNumber', () => {
+    const merged = mergeCompletedParts(
+      [{ partNumber: 3, etag: 'c', size: 30 }],
+      [{ partNumber: 1, etag: 'a', size: 10 }],
+      [{ partNumber: 2, etag: 'b', size: 20 }]
+    )
+    expect(merged.map((p) => p.partNumber)).toEqual([1, 2, 3])
+  })
+})
+
+describe('missingPartNumbers', () => {
+  test('returns the gap in the sequence', () => {
+    expect(missingPartNumbers(5, [{ partNumber: 1, etag: 'a', size: 1 }])).toEqual([2, 3, 4, 5])
+  })
+
+  test('returns empty when complete', () => {
+    expect(
+      missingPartNumbers(3, [
+        { partNumber: 1, etag: 'a', size: 1 },
+        { partNumber: 2, etag: 'b', size: 1 },
+        { partNumber: 3, etag: 'c', size: 1 }
+      ])
+    ).toEqual([])
+  })
+})
+
+describe('computeBackoff', () => {
+  test('grows exponentially with attempt number', () => {
+    const a = computeBackoff(1, 1000, 60_000)
+    const b = computeBackoff(2, 1000, 60_000)
+    const c = computeBackoff(3, 1000, 60_000)
+    expect(b).toBeGreaterThan(a)
+    expect(c).toBeGreaterThan(b)
+  })
+
+  test('caps at the max', () => {
+    expect(computeBackoff(20, 1000, 5000)).toBeLessThanOrEqual(5000)
+  })
+
+  test('includes jitter', () => {
+    const samples = Array.from({ length: 20 }, () => computeBackoff(1, 1000, 60_000))
+    const unique = new Set(samples)
+    expect(unique.size).toBeGreaterThan(1)
+  })
+})
+
+describe('isRetryableStatus', () => {
+  test('treats 408 and 429 as retryable', () => {
+    expect(isRetryableStatus(408)).toBe(true)
+    expect(isRetryableStatus(429)).toBe(true)
+  })
+
+  test('treats 5xx as retryable', () => {
+    expect(isRetryableStatus(500)).toBe(true)
+    expect(isRetryableStatus(503)).toBe(true)
+    expect(isRetryableStatus(599)).toBe(true)
+  })
+
+  test('does not treat 4xx other than 408/429 as retryable', () => {
+    expect(isRetryableStatus(400)).toBe(false)
+    expect(isRetryableStatus(401)).toBe(false)
+    expect(isRetryableStatus(404)).toBe(false)
+    expect(isRetryableStatus(422)).toBe(false)
+  })
+
+  test('does not treat 2xx or 3xx as retryable', () => {
+    expect(isRetryableStatus(200)).toBe(false)
+    expect(isRetryableStatus(301)).toBe(false)
+  })
+})
+
+describe('createPersistedUpload', () => {
+  test('seeds the persisted record with no completed parts', () => {
+    const file = makeFile(50_000_000)
+    const persisted = createPersistedUpload({
+      file,
+      fileFingerprint: computeFileFingerprint(file),
+      init: { uploadId: 'u-1', key: 'audio_x.mp3', chunkSize: 10_000_000 },
+      now: 1_000
+    })
+    expect(persisted).toMatchObject({
+      fileFingerprint: computeFileFingerprint(file),
+      uploadId: 'u-1',
+      key: 'audio_x.mp3',
+      chunkSize: 10_000_000,
+      totalBytes: 50_000_000,
+      totalParts: 5,
+      contentType: 'audio/mpeg',
+      fileName: 'mix.mp3',
+      createdAt: 1_000,
+      updatedAt: 1_000
+    })
+    expect(persisted.completedParts).toEqual([])
+  })
+})
+
+describe('withUpdatedPart', () => {
+  test('appends a new part and sorts', () => {
+    const file = makeFile(100)
+    const persisted = createPersistedUpload({
+      file,
+      fileFingerprint: computeFileFingerprint(file),
+      init: { uploadId: 'u', key: 'k', chunkSize: 50 }
+    })
+    const next = withUpdatedPart(persisted, { partNumber: 2, etag: 'b', size: 50 })
+    expect(next.completedParts).toEqual([{ partNumber: 2, etag: 'b', size: 50 }])
+
+    const appended = withUpdatedPart(next, { partNumber: 1, etag: 'a', size: 50 })
+    expect(appended.completedParts.map((p) => p.partNumber)).toEqual([1, 2])
+  })
+
+  test('replaces an existing part', () => {
+    const file = makeFile(100)
+    const persisted = createPersistedUpload({
+      file,
+      fileFingerprint: computeFileFingerprint(file),
+      init: { uploadId: 'u', key: 'k', chunkSize: 50 }
+    })
+    const after1 = withUpdatedPart(persisted, { partNumber: 1, etag: 'old', size: 50 })
+    const after2 = withUpdatedPart(after1, { partNumber: 1, etag: 'new', size: 51 })
+    expect(after2.completedParts).toEqual([{ partNumber: 1, etag: 'new', size: 51 }])
+  })
+
+  test('updates the updatedAt timestamp', () => {
+    const file = makeFile(100)
+    const persisted = createPersistedUpload({
+      file,
+      fileFingerprint: computeFileFingerprint(file),
+      init: { uploadId: 'u', key: 'k', chunkSize: 50 },
+      now: 1_000
+    })
+    const next = withUpdatedPart(persisted, { partNumber: 1, etag: 'a', size: 50 }, 2_000)
+    expect(next.updatedAt).toBe(2_000)
+  })
+})
+
+describe('response parsers', () => {
+  test('parseInitResponse decodes a valid payload', () => {
+    expect(parseInitResponse({ uploadId: 'u', key: 'k', chunkSize: 10 })).toEqual({
+      uploadId: 'u',
+      key: 'k',
+      chunkSize: 10
+    })
+  })
+
+  test('parseInitResponse throws on missing fields', () => {
+    expect(() => parseInitResponse({ uploadId: 'u', key: 'k' })).toThrow()
+  })
+
+  test('parsePartResponse decodes a valid payload', () => {
+    expect(parsePartResponse({ partNumber: 1, etag: 'e', size: 10 })).toEqual({
+      partNumber: 1,
+      etag: 'e',
+      size: 10
+    })
+  })
+
+  test('parseStatusResponse returns a fresh array', () => {
+    const decoded = parseStatusResponse({ parts: [{ partNumber: 1, etag: 'e', size: 10 }] })
+    expect(decoded.parts).toEqual([{ partNumber: 1, etag: 'e', size: 10 }])
+    expect(() => {
+      decoded.parts.push({ partNumber: 2, etag: 'x', size: 1 })
+    }).not.toThrow()
+  })
+
+  test('parseStatusResponse throws on non-array parts', () => {
+    expect(() => parseStatusResponse({ parts: 'nope' })).toThrow()
+  })
+
+  test('parseAbortResponse requires ok: true', () => {
+    expect(parseAbortResponse({ ok: true })).toEqual({ ok: true })
+    expect(() => parseAbortResponse({ ok: false })).toThrow()
+  })
+
+  test('parseCompleteResponse decodes the result', () => {
+    expect(parseCompleteResponse({ url: 'https://x', key: 'k' })).toEqual({
+      url: 'https://x',
+      key: 'k'
+    })
+  })
+
+  test('parsePersistedUpload returns null on bad data', () => {
+    expect(parsePersistedUpload({ nope: true })).toBeNull()
+    expect(parsePersistedUpload('not an object')).toBeNull()
+    expect(parsePersistedUpload(null)).toBeNull()
+  })
+
+  test('parsePersistedUpload returns a fresh parts array', () => {
+    const decoded = parsePersistedUpload({
+      fileFingerprint: '1:a:1',
+      uploadId: 'u',
+      key: 'k',
+      chunkSize: 10,
+      totalBytes: 100,
+      totalParts: 10,
+      contentType: 'audio/mpeg',
+      fileName: 'a.mp3',
+      completedParts: [{ partNumber: 1, etag: 'e', size: 10 }],
+      createdAt: 0,
+      updatedAt: 0
+    })
+    if (!decoded) throw new Error('expected parsed upload')
+    decoded.completedParts.push({ partNumber: 2, etag: 'x', size: 10 })
+    expect(decoded.completedParts).toHaveLength(2)
+  })
+})

--- a/apps/www/src/lib/upload/resumable-upload.ts
+++ b/apps/www/src/lib/upload/resumable-upload.ts
@@ -1,0 +1,268 @@
+import { Schema } from 'effect'
+
+export type ResumableUploadPhase =
+  | 'idle'
+  | 'preparing'
+  | 'uploading'
+  | 'paused'
+  | 'finalizing'
+  | 'completed'
+  | 'aborted'
+  | 'error'
+
+export interface ResumableUploadResult {
+  url: string
+  key: string
+}
+
+export interface ResumablePart {
+  partNumber: number
+  etag: string
+  size: number
+}
+
+export interface PersistedResumableUpload {
+  fileFingerprint: string
+  uploadId: string
+  key: string
+  chunkSize: number
+  totalBytes: number
+  totalParts: number
+  contentType: string
+  fileName: string
+  completedParts: ResumablePart[]
+  createdAt: number
+  updatedAt: number
+}
+
+export interface MultipartInitResponse {
+  uploadId: string
+  key: string
+  chunkSize: number
+}
+
+export interface MultipartPartResponse {
+  partNumber: number
+  etag: string
+  size: number
+}
+
+export interface MultipartStatusResponse {
+  parts: ResumablePart[]
+}
+
+export interface MultipartAbortResponse {
+  ok: true
+}
+
+const multipartInitResponseSchema = Schema.Struct({
+  uploadId: Schema.String,
+  key: Schema.String,
+  chunkSize: Schema.Number
+})
+
+const multipartPartResponseSchema = Schema.Struct({
+  partNumber: Schema.Number,
+  etag: Schema.String,
+  size: Schema.Number
+})
+
+const multipartStatusResponseSchema = Schema.Struct({
+  parts: Schema.Array(
+    Schema.Struct({
+      partNumber: Schema.Number,
+      etag: Schema.String,
+      size: Schema.Number
+    })
+  )
+})
+
+const multipartAbortResponseSchema = Schema.Struct({
+  ok: Schema.Literal(true)
+})
+
+const multipartCompleteResponseSchema = Schema.Struct({
+  url: Schema.String,
+  key: Schema.String
+})
+
+const persistedUploadSchema = Schema.Struct({
+  fileFingerprint: Schema.String,
+  uploadId: Schema.String,
+  key: Schema.String,
+  chunkSize: Schema.Number,
+  totalBytes: Schema.Number,
+  totalParts: Schema.Number,
+  contentType: Schema.String,
+  fileName: Schema.String,
+  completedParts: Schema.Array(
+    Schema.Struct({
+      partNumber: Schema.Number,
+      etag: Schema.String,
+      size: Schema.Number
+    })
+  ),
+  createdAt: Schema.Number,
+  updatedAt: Schema.Number
+})
+
+export const parseInitResponse = (raw: unknown): MultipartInitResponse =>
+  Schema.decodeUnknownSync(multipartInitResponseSchema)(raw)
+
+export const parsePartResponse = (raw: unknown): MultipartPartResponse =>
+  Schema.decodeUnknownSync(multipartPartResponseSchema)(raw)
+
+export const parseStatusResponse = (raw: unknown): MultipartStatusResponse => {
+  const decoded = Schema.decodeUnknownSync(multipartStatusResponseSchema)(raw)
+  return {
+    parts: decoded.parts.map((p) => ({ partNumber: p.partNumber, etag: p.etag, size: p.size }))
+  }
+}
+
+export const parseAbortResponse = (raw: unknown): MultipartAbortResponse =>
+  Schema.decodeUnknownSync(multipartAbortResponseSchema)(raw)
+
+export const parseCompleteResponse = (raw: unknown): { url: string; key: string } =>
+  Schema.decodeUnknownSync(multipartCompleteResponseSchema)(raw)
+
+export const parsePersistedUpload = (raw: unknown): PersistedResumableUpload | null => {
+  try {
+    const decoded = Schema.decodeUnknownSync(persistedUploadSchema)(raw)
+    return {
+      ...decoded,
+      completedParts: decoded.completedParts.map((p) => ({
+        partNumber: p.partNumber,
+        etag: p.etag,
+        size: p.size
+      }))
+    }
+  } catch {
+    return null
+  }
+}
+
+export const computeFileFingerprint = (file: File): string =>
+  `${file.size}:${file.name}:${file.lastModified}`
+
+export const splitFileIntoChunks = (
+  file: File,
+  chunkSize: number
+): Array<{ partNumber: number; blob: Blob; start: number; end: number }> => {
+  if (chunkSize <= 0) {
+    throw new Error('chunkSize must be positive')
+  }
+
+  const chunks: Array<{ partNumber: number; blob: Blob; start: number; end: number }> = []
+  let offset = 0
+  let partNumber = 1
+  while (offset < file.size) {
+    const end = Math.min(offset + chunkSize, file.size)
+    chunks.push({
+      partNumber,
+      blob: file.slice(offset, end),
+      start: offset,
+      end
+    })
+    offset = end
+    partNumber += 1
+  }
+  return chunks
+}
+
+export const totalParts = (fileSize: number, chunkSize: number): number => {
+  if (chunkSize <= 0) {
+    throw new Error('chunkSize must be positive')
+  }
+  if (fileSize === 0) return 0
+  return Math.ceil(fileSize / chunkSize)
+}
+
+export const mergeCompletedParts = (
+  ...sources: ReadonlyArray<ResumablePart[]>
+): ResumablePart[] => {
+  const byPartNumber = new Map<number, ResumablePart>()
+  for (const source of sources) {
+    for (const part of source) {
+      byPartNumber.set(part.partNumber, part)
+    }
+  }
+  return Array.from(byPartNumber.values()).toSorted((a, b) => a.partNumber - b.partNumber)
+}
+
+export const missingPartNumbers = (
+  totalParts: number,
+  completed: ReadonlyArray<ResumablePart>
+): number[] => {
+  const have = new Set(completed.map((p) => p.partNumber))
+  const missing: number[] = []
+  for (let i = 1; i <= totalParts; i += 1) {
+    if (!have.has(i)) missing.push(i)
+  }
+  return missing
+}
+
+export const computeBackoff = (attempt: number, baseMs = 1000, maxMs = 30000): number => {
+  const exponential = baseMs * 2 ** Math.max(0, attempt - 1)
+  const jitter = Math.random() * baseMs
+  return Math.min(exponential + jitter, maxMs)
+}
+
+export const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'))
+      return
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(new DOMException('Aborted', 'AbortError'))
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+
+export const isRetryableStatus = (status: number): boolean =>
+  status === 408 || status === 429 || (status >= 500 && status < 600)
+
+export const createPersistedUpload = (input: {
+  file: File
+  fileFingerprint: string
+  init: MultipartInitResponse
+  now?: number
+}): PersistedResumableUpload => {
+  const now = input.now ?? Date.now()
+  return {
+    fileFingerprint: input.fileFingerprint,
+    uploadId: input.init.uploadId,
+    key: input.init.key,
+    chunkSize: input.init.chunkSize,
+    totalBytes: input.file.size,
+    totalParts: totalParts(input.file.size, input.init.chunkSize),
+    contentType: input.file.type,
+    fileName: input.file.name,
+    completedParts: [],
+    createdAt: now,
+    updatedAt: now
+  }
+}
+
+export const withUpdatedPart = (
+  persisted: PersistedResumableUpload,
+  part: ResumablePart,
+  now?: number
+): PersistedResumableUpload => {
+  const existingIndex = persisted.completedParts.findIndex((p) => p.partNumber === part.partNumber)
+  const completedParts =
+    existingIndex === -1
+      ? [...persisted.completedParts, part]
+      : persisted.completedParts.map((p, i) => (i === existingIndex ? part : p))
+
+  return {
+    ...persisted,
+    completedParts: completedParts.toSorted((a, b) => a.partNumber - b.partNumber),
+    updatedAt: now ?? Date.now()
+  }
+}

--- a/apps/www/src/routes/mix-upload.lazy.tsx
+++ b/apps/www/src/routes/mix-upload.lazy.tsx
@@ -7,51 +7,63 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
-  formatTime,
   generateSlug,
   MixDetailsForm,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
-  type TrackEntry,
-  TracklistEditor,
   toast,
+  TracklistEditor,
   MixUploadProgress as UploadProgress,
   type MixUploadStep as UploadStep,
+  type TrackEntry,
   UploadSummaryCard
 } from '@gbfm/ui'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createLazyFileRoute, useRouter } from '@tanstack/react-router'
+import * as Cause from 'effect/Cause'
+import * as Effect from 'effect/Effect'
+import * as Exit from 'effect/Exit'
 import { FileText, List, Loader2, Music } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { z } from 'zod'
 import { S3AudioFilePicker, S3MediaFilePicker } from '@/components/mix-uploader/S3AudioFilePicker'
 import { SimpleMarkdownEditor } from '@/components/simple-markdown-editor'
-import { useResumableUpload } from '@/hooks/useResumableUpload'
+import { useMixUploadDraft } from '@/hooks/useMixUploadDraft'
+import { useResumableUpload, type ResumableUploadError } from '@/hooks/useResumableUpload'
 import { useOnlineStatus } from '@/hooks/useOnlineStatus'
 import { authClient, useSession } from '@/lib/auth-client'
-import { apiUrl, fetcher, useAllShows, useAudioBySlug, useAudioTags } from '@/lib/http'
-import { readResponseErrorMessage, readUploadResponse } from '@/lib/response'
+import { apiUrl, useAllShows, useAudioBySlug, useAudioTags } from '@/lib/http'
+import { runAppEffect } from '@/runtime'
+import {
+  AudioUploadError,
+  type ImageUploadError,
+  MissingAudioError,
+  NotSignedInError,
+  type RecordSaveError
+} from './mix-upload/-errors'
+import { type MixFormData, saveRecord, uploadImage } from './mix-upload/-program'
+import type { ResumableUploadOutcome } from '@/hooks/useResumableUpload'
+
+type EditType = 'mix' | 'set' | 'live'
+
+const isEditType = (value: string): value is EditType =>
+  value === 'mix' || value === 'set' || value === 'live'
+
+type SubmitSuccess = {
+  readonly audioUrl: string
+  readonly imageUrl: string
+  readonly record: unknown
+}
+type SubmitResult = SubmitSuccess | ResumableUploadOutcome
+
+const isSubmitSuccess = (value: SubmitResult): value is SubmitSuccess =>
+  'audioUrl' in value && 'imageUrl' in value && 'record' in value
 
 export const Route = createLazyFileRoute('/mix-upload')({
   component: MixUploadPage
 })
-
-interface MixFormData {
-  title: string
-  description: string
-  slug: string
-  content: string
-  thumbnailUrl: string
-  tags: string[]
-  tracklist: TrackEntry[]
-  draft: boolean
-  creatorId?: string
-  url?: string
-  showId?: string
-  episodeNumber?: string
-}
 
 const mixUploadSearchSchema = z.object({
   edit: z.string().optional(),
@@ -63,6 +75,52 @@ const mixUploadSearchSchema = z.object({
   type: z.literal('mix').optional()
 })
 
+const describeUploadError = (error: ResumableUploadError): string => {
+  if (error._tag === 'NetworkError') {
+    return 'Lost connection. We will keep your progress and resume when you are back online.'
+  }
+  if (error._tag === 'HttpError') {
+    if (error.status === 401) return 'Your session has expired. Please sign in again.'
+    if (error.status === 403) return 'You do not have permission to upload audio.'
+    if (error.status === 413) return 'The audio file is too large. Max size is 200MB.'
+    if (error.status === 415) return 'This audio format is not supported.'
+    if (error.status >= 500) return 'The server is having trouble. Please try again shortly.'
+    return error.message
+  }
+  if (error._tag === 'InvalidResponseError')
+    return 'We received an unexpected response from the server.'
+  if (error._tag === 'FileTooLargeError') return 'The audio file is too large. Max size is 200MB.'
+  return error.message
+}
+
+const describePageError = (
+  error:
+    | AudioUploadError
+    | ImageUploadError
+    | RecordSaveError
+    | NotSignedInError
+    | MissingAudioError
+): string => {
+  if (error._tag === 'NotSignedInError') return error.message
+  if (error._tag === 'MissingAudioError') return error.message
+  if (error._tag === 'AudioUploadError') return error.message
+  if (error.status === 401) return 'Your session has expired. Please sign in again.'
+  if (error.status === 403) return 'You do not have permission to save this content.'
+  if (error.status === 413) return 'The image is too large.'
+  if (error.status === 415) return 'Unsupported file type.'
+  if (error.status && error.status >= 500)
+    return 'The server is having trouble. Please try again shortly.'
+  if (error.status && error.status >= 400) return error.message
+  return error.message
+}
+
+const uploadStepFromPhase = (phase: string): UploadStep => {
+  if (phase === 'preparing' || phase === 'uploading' || phase === 'finalizing')
+    return 'uploading-audio'
+  if (phase === 'paused') return 'paused-audio'
+  return 'idle'
+}
+
 function MixUploadPage() {
   const { data: session } = useSession()
   const user = session?.user
@@ -73,8 +131,9 @@ function MixUploadPage() {
 
   const { data: availableTags } = useAudioTags('mix')
   const { data: allShows } = useAllShows({ limit: 100 })
-
   const { data: existingMix, isPending: mixLoading } = useAudioBySlug(editType, search.edit || '')
+
+  const draftState = useMixUploadDraft()
 
   const [formData, setFormData] = useState<MixFormData>(() => ({
     title: search.title || '',
@@ -90,6 +149,7 @@ function MixUploadPage() {
     showId: undefined,
     episodeNumber: undefined
   }))
+  const [draftApplied, setDraftApplied] = useState(false)
   const [newTag, setNewTag] = useState('')
   const [uploadStep, setUploadStep] = useState<UploadStep>('idle')
   const [audioFile, setAudioFile] = useState<File | null>(null)
@@ -105,9 +165,7 @@ function MixUploadPage() {
   const queryClient = useQueryClient()
   const isOnline = useOnlineStatus()
 
-  const resumableUpload = useResumableUpload({
-    fileType: 'audio'
-  })
+  const resumableUpload = useResumableUpload()
 
   const isAdmin = user?.role === 'admin'
 
@@ -120,29 +178,72 @@ function MixUploadPage() {
   const usersList = usersData?.data?.users || []
 
   useEffect(() => {
-    const phase = resumableUpload.state.phase
-    if (phase === 'preparing' || phase === 'uploading' || phase === 'finalizing') {
-      setUploadStep('uploading-audio')
-    } else if (phase === 'paused') {
-      setUploadStep('paused-audio')
-    } else if (phase === 'idle' || phase === 'completed' || phase === 'aborted') {
-      setUploadStep((prev) =>
-        prev === 'uploading-audio' || prev === 'paused-audio' ? 'idle' : prev
-      )
-    } else if (phase === 'error') {
-      setUploadStep('idle')
-    }
+    setUploadStep((prev) => {
+      const next = uploadStepFromPhase(resumableUpload.state.phase)
+      if (next === 'idle' && prev !== 'uploading-audio' && prev !== 'paused-audio') return prev
+      return next
+    })
   }, [resumableUpload.state.phase])
+
+  useEffect(() => {
+    if (draftState.isLoaded && draftState.draft && !draftApplied && !isEditMode) {
+      const d = draftState.draft
+      setFormData((prev) => ({
+        ...prev,
+        title: d.title || prev.title,
+        description: d.description || prev.description,
+        slug: d.slug || prev.slug,
+        content: d.content || prev.content,
+        thumbnailUrl: d.thumbnailUrl || prev.thumbnailUrl,
+        tags: d.tags.length > 0 ? [...d.tags] : prev.tags,
+        tracklist: d.tracklist.length > 0 ? [...d.tracklist] : prev.tracklist,
+        showId: d.showId ?? prev.showId,
+        episodeNumber: d.episodeNumber ?? prev.episodeNumber,
+        creatorId: d.creatorId ?? prev.creatorId,
+        url: d.url ?? prev.url
+      }))
+      if (d.thumbnailUrl) setArtworkPreview(d.thumbnailUrl)
+      if (d.url) setAudioPreview(d.url)
+      setDraftApplied(true)
+      toast({
+        title: 'Draft restored',
+        description: 'We restored your in-progress mix from your last session.',
+        duration: 4000
+      })
+    } else if (draftState.isLoaded) {
+      setDraftApplied(true)
+    }
+  }, [draftState.isLoaded, draftState.draft, draftApplied, isEditMode])
+
+  useEffect(() => {
+    if (!draftApplied) return
+    if (isEditMode) return
+    draftState.saveDraft({
+      title: formData.title,
+      description: formData.description,
+      slug: formData.slug,
+      content: formData.content,
+      thumbnailUrl: formData.thumbnailUrl,
+      tags: formData.tags,
+      tracklist: formData.tracklist,
+      showId: formData.showId,
+      episodeNumber: formData.episodeNumber,
+      creatorId: formData.creatorId,
+      url: formData.url,
+      audioFile,
+      artworkFile
+    })
+  }, [draftApplied, isEditMode, formData, audioFile, artworkFile, draftState])
 
   useEffect(() => {
     if (!isOnline) return
     if (resumableUpload.state.phase !== 'paused') return
     if (!audioFile) return
-    resumableUpload.resume(audioFile).catch((error: unknown) => {
-      if (error instanceof Error) {
+    resumableUpload.resume(audioFile).then((outcome) => {
+      if (outcome._tag === 'Error') {
         toast({
           title: 'Audio upload failed',
-          description: error.message,
+          description: describeUploadError(outcome.error),
           variant: 'destructive'
         })
       }
@@ -173,10 +274,19 @@ function MixUploadPage() {
 
   const updateTagsMutation = useMutation({
     mutationFn: (tags: string[]) =>
-      fetcher(apiUrl(`/content/audio/${editType}/${search.edit}`), {
-        method: 'PATCH',
-        body: JSON.stringify({ tags })
-      }),
+      runAppEffect(
+        Effect.tryPromise({
+          try: () =>
+            fetch(apiUrl(`/content/audio/${editType}/${search.edit}`), {
+              method: 'PATCH',
+              body: JSON.stringify({ tags })
+            }).then(async (res) => {
+              if (!res.ok) throw new Error(`Tags update failed: ${res.status}`)
+              return res.json()
+            }),
+          catch: (cause) => new Error(cause instanceof Error ? cause.message : String(cause))
+        }).pipe(Effect.retry({ times: 2, while: () => false }))
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['audio', editType] })
       queryClient.invalidateQueries({
@@ -193,117 +303,168 @@ function MixUploadPage() {
     }
   })
 
-  const uploadMutation = useMutation({
-    mutationFn: async (
-      data: MixFormData & { audioFile: File | null; artworkFile: File | null }
-    ) => {
-      if (!user) {
-        toast({
-          title: 'Please login/signup to upload content',
-          variant: 'destructive'
-        })
+  const runSubmit = useCallback(
+    async (isDraft: boolean, signal: AbortSignal) => {
+      const program = Effect.gen(function* () {
+        if (!user) {
+          return yield* new NotSignedInError({ message: 'Please login/signup to upload content' })
+        }
+        if (!isEditMode && !audioFile && !formData.url) {
+          return yield* new MissingAudioError({
+            message: 'Please select an audio file to upload or pick one from S3.'
+          })
+        }
+
+        let audioUrl = formData.url || ''
+        if (audioFile) {
+          const outcome = yield* Effect.promise(() => resumableUpload.start(audioFile))
+          if (outcome._tag === 'Error') {
+            return yield* new AudioUploadError({
+              message: describeUploadError(outcome.error)
+            })
+          }
+          if (outcome._tag !== 'Success') {
+            return outcome
+          }
+          audioUrl = outcome.result.url
+        }
+
+        let imageUrl = formData.thumbnailUrl
+        if (artworkFile) {
+          const result = yield* uploadImage(artworkFile, signal)
+          imageUrl = result.url
+        }
+
+        const recordInput = {
+          userId: user.id,
+          formData: { ...formData, url: audioUrl, thumbnailUrl: imageUrl, draft: isDraft },
+          imageUrl,
+          audioUrl,
+          isEditMode,
+          editSlug: search.edit || '',
+          editType: isEditType(editType) ? editType : 'mix'
+        }
+        const record = yield* saveRecord(recordInput, signal)
+        return { audioUrl, imageUrl, record }
+      })
+
+      const exit = await runAppEffect(Effect.exit(program))
+      return exit
+    },
+    [user, isEditMode, audioFile, formData, artworkFile, resumableUpload, search.edit, editType]
+  )
+
+  const resetForm = useCallback(() => {
+    setFormData({
+      title: '',
+      description: '',
+      slug: '',
+      content: '',
+      thumbnailUrl: '',
+      tags: [],
+      tracklist: [],
+      draft: true,
+      creatorId: undefined,
+      url: undefined,
+      showId: undefined,
+      episodeNumber: undefined
+    })
+    setAudioFile(null)
+    setArtworkFile(null)
+    if (audioPreview) URL.revokeObjectURL(audioPreview)
+    if (artworkPreview) URL.revokeObjectURL(artworkPreview)
+    setAudioPreview(null)
+    setArtworkPreview(null)
+    setUploadStep('idle')
+    void draftState.clearDraft()
+  }, [audioPreview, artworkPreview, draftState])
+
+  const handleSubmit = useCallback(
+    async (isDraft: boolean) => {
+      const controller = new AbortController()
+      setUploadStep('uploading-image')
+      const exit = await runSubmit(isDraft, controller.signal)
+
+      if (Exit.isSuccess(exit)) {
+        const value = exit.value
+        if (isSubmitSuccess(value)) {
+          setFormData((prev) => ({ ...prev, url: value.audioUrl, thumbnailUrl: value.imageUrl }))
+          if (audioFile) {
+            setAudioFile(null)
+          }
+          await draftState.clearDraft().catch(() => undefined)
+          toast({
+            title: isEditMode ? 'Update successful!' : 'Upload successful!',
+            description: `"${formData.title}" has been ${isEditMode ? 'updated' : 'uploaded'}.`
+          })
+          setUploadStep('success')
+          setTimeout(() => {
+            if (!isEditMode) resetForm()
+            setUploadStep('idle')
+
+            if (formData.showId) {
+              const showSlug = allShows.find((s) => s.id === formData.showId)?.slug
+              router.navigate(
+                showSlug ? { to: '/shows/$showSlug', params: { showSlug } } : { to: '/shows' }
+              )
+            } else if (isEditMode) {
+              router.navigate({
+                to: '/mixes/$mixId',
+                params: { mixId: formData.slug || search.edit || '' }
+              })
+            } else {
+              router.navigate({ to: '/mixes' })
+            }
+          }, 2000)
+          return
+        }
+        if (value._tag === 'Paused') {
+          toast({
+            title: 'Upload paused',
+            description: 'Reconnect or resume to continue uploading.',
+            variant: 'destructive'
+          })
+        } else if (value._tag === 'Aborted') {
+          toast({ title: 'Upload cancelled', variant: 'destructive' })
+        }
+        setUploadStep('idle')
         return
       }
 
-      setUploadStep('uploading-image')
-
-      let imageUrl = data.thumbnailUrl
-      if (data.artworkFile) {
-        const imageFormData = new FormData()
-        imageFormData.append('imageFile', data.artworkFile)
-        imageFormData.append('fileType', 'image')
-
-        const imageUploadResponse = await fetch(apiUrl('/upload/file'), {
-          method: 'POST',
-          body: imageFormData
+      const failure = Cause.findErrorOption(exit.cause)
+      if (failure._tag === 'Some') {
+        const error = failure.value
+        toast({
+          title: 'Upload failed',
+          description: describePageError(error),
+          variant: 'destructive'
         })
-
-        if (!imageUploadResponse.ok) {
-          throw new Error(
-            await readResponseErrorMessage(imageUploadResponse, 'Failed to upload image')
-          )
-        }
-
-        const imageResult = await readUploadResponse(imageUploadResponse)
-        imageUrl = imageResult.url
+      } else {
+        toast({
+          title: 'Upload failed',
+          description: 'An unexpected error occurred.',
+          variant: 'destructive'
+        })
       }
-
-      setUploadStep('creating-record')
-
-      const tracklistMarkdown =
-        data.tracklist.length > 0
-          ? `\n\n## Tracklist\n${data.tracklist
-              .map((t, i) => `${i + 1}. ${t.title} (${formatTime(t.time)})`)
-              .join('\n')}`
-          : ''
-
-      const audioData = {
-        title: data.title,
-        description: data.description,
-        slug: data.slug || generateSlug(data.title),
-        content: data.content + tracklistMarkdown,
-        thumbnailUrl: imageUrl,
-        url: data.url,
-        type: 'mix',
-        tags: data.tags,
-        creatorIds: [data.creatorId === 'current' ? user?.id : data.creatorId || user?.id].filter(
-          Boolean
-        ),
-        showId: data.showId,
-        episodeNumber: data.episodeNumber ? Number(data.episodeNumber) : null
-      }
-
-      const endpoint = isEditMode
-        ? apiUrl(`/content/audio/${editType}/${search.edit}`)
-        : apiUrl('/content/audio')
-
-      const result = await fetcher(endpoint, {
-        method: isEditMode ? 'PATCH' : 'POST',
-        body: JSON.stringify(audioData)
-      })
-
-      setUploadStep('success')
-      return result
-    },
-    onSuccess: () => {
-      toast({
-        title: isEditMode ? 'Update successful!' : 'Upload successful!',
-        description: `"${formData.title}" has been ${isEditMode ? 'updated' : 'uploaded'}.`
-      })
-
-      setTimeout(() => {
-        if (!isEditMode) resetForm()
-        setUploadStep('idle')
-
-        if (formData.showId) {
-          const showSlug = allShows.find((s) => s.id === formData.showId)?.slug
-          router.navigate(
-            showSlug ? { to: '/shows/$showSlug', params: { showSlug } } : { to: '/shows' }
-          )
-        } else if (isEditMode) {
-          router.navigate({
-            to: '/mixes/$mixId',
-            params: { mixId: formData.slug || search.edit || '' }
-          })
-        } else {
-          router.navigate({ to: '/mixes' })
-        }
-      }, 2000)
-    },
-    onError: (error) => {
-      toast({
-        title: 'Upload failed',
-        description: error instanceof Error ? error.message : 'An unexpected error.',
-        variant: 'destructive'
-      })
       setUploadStep('idle')
-    }
-  })
+    },
+    [
+      runSubmit,
+      isEditMode,
+      audioFile,
+      formData,
+      allShows,
+      router,
+      search.edit,
+      draftState,
+      resetForm
+    ]
+  )
 
   const handleInputChange = (field: keyof MixFormData, value: string) => {
     setFormData((prev) => {
       const updated = { ...prev, [field]: value }
-      if (field === 'title' && !prev.slug) updated.slug = generateSlug(value)
+      if (field === 'title' && !prev.slug) updated.slug = generateSlugIfMissing(value, prev.slug)
       return updated
     })
   }
@@ -333,7 +494,7 @@ function MixUploadPage() {
           .replace(/[-_]/g, ' ')
           .replace(/\b\w/g, (l) => l.toUpperCase())
         updated.title = cleanTitle
-        if (!prev.slug) updated.slug = generateSlug(cleanTitle)
+        if (!prev.slug) updated.slug = generateSlugIfMissing(cleanTitle, prev.slug)
       }
       return updated
     })
@@ -411,7 +572,10 @@ function MixUploadPage() {
   const updateTrack = (index: number, title: string) => {
     setFormData((prev) => {
       const newList = [...prev.tracklist]
-      newList[index].title = title
+      const existing = newList[index]
+      if (existing) {
+        newList[index] = { ...existing, title }
+      }
       return { ...prev, tracklist: newList }
     })
   }
@@ -430,76 +594,22 @@ function MixUploadPage() {
     }
   }
 
-  const handleSubmit = async (isDraft: boolean) => {
-    if (!user) {
-      toast({
-        title: 'Please login/signup to upload content',
-        variant: 'destructive'
-      })
-      return
-    }
-    if (!isEditMode && !audioFile && !formData.url) {
-      toast({
-        title: 'Audio file required',
-        description: 'Please select an audio file to upload or pick one from S3.',
-        variant: 'destructive'
-      })
-      return
-    }
-
-    let audioUrl = formData.url || ''
-    if (audioFile) {
-      try {
-        const result = await resumableUpload.start(audioFile)
-        audioUrl = result.url
-        setFormData((prev) => ({ ...prev, url: audioUrl }))
-        setAudioFile(null)
-      } catch (error) {
-        if (error instanceof Error) {
-          toast({
-            title: 'Audio upload failed',
-            description: error.message,
-            variant: 'destructive'
-          })
-        }
-        return
-      }
-    }
-
-    uploadMutation.mutate({
-      ...formData,
-      url: audioUrl,
-      draft: isDraft,
-      audioFile: null,
-      artworkFile
-    })
-  }
-
-  const resetForm = () => {
-    setFormData({
-      title: '',
-      description: '',
-      slug: '',
-      content: '',
-      thumbnailUrl: '',
-      tags: [],
-      tracklist: [],
-      draft: true,
-      creatorId: undefined,
-      url: undefined,
-      showId: undefined,
-      episodeNumber: undefined
-    })
-    setAudioFile(null)
-    setArtworkFile(null)
-    if (audioPreview) URL.revokeObjectURL(audioPreview)
-    if (artworkPreview) URL.revokeObjectURL(artworkPreview)
-    setAudioPreview(null)
-    setArtworkPreview(null)
-    setUploadStep('idle')
-  }
-
   const isUploading = uploadStep !== 'idle' && uploadStep !== 'success'
+
+  const progressBadge = useMemo(
+    () => ({
+      bytesUploaded: resumableUpload.state.bytesUploaded,
+      totalBytes: resumableUpload.state.totalBytes,
+      currentPart: resumableUpload.state.currentPart,
+      totalParts: resumableUpload.state.totalParts
+    }),
+    [
+      resumableUpload.state.bytesUploaded,
+      resumableUpload.state.totalBytes,
+      resumableUpload.state.currentPart,
+      resumableUpload.state.totalParts
+    ]
+  )
 
   if (mixLoading && isEditMode) {
     return (
@@ -523,17 +633,7 @@ function MixUploadPage() {
                 : 'Share your mix with tracklist timestamps for easy navigation.'}
             </p>
           </div>
-          {isUploading && (
-            <UploadProgress
-              step={uploadStep}
-              audioProgress={{
-                bytesUploaded: resumableUpload.state.bytesUploaded,
-                totalBytes: resumableUpload.state.totalBytes,
-                currentPart: resumableUpload.state.currentPart,
-                totalParts: resumableUpload.state.totalParts
-              }}
-            />
-          )}
+          {isUploading && <UploadProgress step={uploadStep} audioProgress={progressBadge} />}
         </div>
       </header>
 
@@ -586,18 +686,8 @@ function MixUploadPage() {
                   artworkPreview={artworkPreview}
                   availableTags={availableTags}
                   allShows={allShows}
-                  usersList={usersList.map((u) => ({
-                    id: u.id,
-                    name: u.name
-                  }))}
-                  currentUser={
-                    user
-                      ? {
-                          id: user.id,
-                          name: user.name
-                        }
-                      : null
-                  }
+                  usersList={usersList.map((u) => ({ id: u.id, name: u.name }))}
+                  currentUser={user ? { id: user.id, name: user.name } : null}
                   isAdmin={isAdmin}
                   isEditMode={isEditMode}
                   isUpdatingTags={updateTagsMutation.isPending}
@@ -687,4 +777,9 @@ Add any technical details, equipment used, or special techniques...`}
       )}
     </div>
   )
+}
+
+const generateSlugIfMissing = (title: string, currentSlug: string): string => {
+  if (currentSlug) return currentSlug
+  return generateSlug(title)
 }

--- a/apps/www/src/routes/mix-upload.lazy.tsx
+++ b/apps/www/src/routes/mix-upload.lazy.tsx
@@ -28,6 +28,7 @@ import { useEffect, useRef, useState } from 'react'
 import { z } from 'zod'
 import { S3AudioFilePicker, S3MediaFilePicker } from '@/components/mix-uploader/S3AudioFilePicker'
 import { SimpleMarkdownEditor } from '@/components/simple-markdown-editor'
+import { useResumableUpload } from '@/hooks/useResumableUpload'
 import { authClient, useSession } from '@/lib/auth-client'
 import { apiUrl, fetcher, useAllShows, useAudioBySlug, useAudioTags } from '@/lib/http'
 import { readResponseErrorMessage, readUploadResponse } from '@/lib/response'
@@ -102,6 +103,17 @@ function MixUploadPage() {
   const router = useRouter()
   const queryClient = useQueryClient()
 
+  const resumableUpload = useResumableUpload({
+    fileType: 'audio',
+    onError: (error) => {
+      toast({
+        title: 'Audio upload failed',
+        description: error.message,
+        variant: 'destructive'
+      })
+    }
+  })
+
   const isAdmin = user?.role === 'admin'
 
   const { data: usersData } = useQuery({
@@ -111,6 +123,21 @@ function MixUploadPage() {
   })
 
   const usersList = usersData?.data?.users || []
+
+  useEffect(() => {
+    const phase = resumableUpload.state.phase
+    if (phase === 'preparing' || phase === 'uploading' || phase === 'finalizing') {
+      setUploadStep('uploading-audio')
+    } else if (phase === 'paused') {
+      setUploadStep('paused-audio')
+    } else if (phase === 'idle' || phase === 'completed' || phase === 'aborted') {
+      setUploadStep((prev) =>
+        prev === 'uploading-audio' || prev === 'paused-audio' ? 'idle' : prev
+      )
+    } else if (phase === 'error') {
+      setUploadStep('idle')
+    }
+  }, [resumableUpload.state.phase])
 
   useEffect(() => {
     if (existingMix && isEditMode) {
@@ -168,29 +195,6 @@ function MixUploadPage() {
         return
       }
 
-      setUploadStep('uploading-audio')
-
-      let audioUrl = data.url || ''
-      if (data.audioFile) {
-        const uploadFormData = new FormData()
-        uploadFormData.append('audioFile', data.audioFile)
-        uploadFormData.append('fileType', 'audio')
-
-        const audioUploadResponse = await fetch(apiUrl('/upload/file'), {
-          method: 'POST',
-          body: uploadFormData
-        })
-
-        if (!audioUploadResponse.ok) {
-          throw new Error(
-            await readResponseErrorMessage(audioUploadResponse, 'Failed to upload audio')
-          )
-        }
-
-        const audioResult = await readUploadResponse(audioUploadResponse)
-        audioUrl = audioResult.url
-      }
-
       setUploadStep('uploading-image')
 
       let imageUrl = data.thumbnailUrl
@@ -229,7 +233,7 @@ function MixUploadPage() {
         slug: data.slug || generateSlug(data.title),
         content: data.content + tracklistMarkdown,
         thumbnailUrl: imageUrl,
-        url: audioUrl,
+        url: data.url,
         type: 'mix',
         tags: data.tags,
         creatorIds: [data.creatorId === 'current' ? user?.id : data.creatorId || user?.id].filter(
@@ -416,7 +420,14 @@ function MixUploadPage() {
     }
   }
 
-  const handleSubmit = (isDraft: boolean) => {
+  const handleSubmit = async (isDraft: boolean) => {
+    if (!user) {
+      toast({
+        title: 'Please login/signup to upload content',
+        variant: 'destructive'
+      })
+      return
+    }
     if (!isEditMode && !audioFile && !formData.url) {
       toast({
         title: 'Audio file required',
@@ -425,10 +436,31 @@ function MixUploadPage() {
       })
       return
     }
+
+    let audioUrl = formData.url || ''
+    if (audioFile) {
+      try {
+        const result = await resumableUpload.start(audioFile)
+        audioUrl = result.url
+        setFormData((prev) => ({ ...prev, url: audioUrl }))
+        setAudioFile(null)
+      } catch (error) {
+        if (error instanceof Error) {
+          toast({
+            title: 'Audio upload failed',
+            description: error.message,
+            variant: 'destructive'
+          })
+        }
+        return
+      }
+    }
+
     uploadMutation.mutate({
       ...formData,
+      url: audioUrl,
       draft: isDraft,
-      audioFile,
+      audioFile: null,
       artworkFile
     })
   }
@@ -481,7 +513,17 @@ function MixUploadPage() {
                 : 'Share your mix with tracklist timestamps for easy navigation.'}
             </p>
           </div>
-          {isUploading && <UploadProgress step={uploadStep} />}
+          {isUploading && (
+            <UploadProgress
+              step={uploadStep}
+              audioProgress={{
+                bytesUploaded: resumableUpload.state.bytesUploaded,
+                totalBytes: resumableUpload.state.totalBytes,
+                currentPart: resumableUpload.state.currentPart,
+                totalParts: resumableUpload.state.totalParts
+              }}
+            />
+          )}
         </div>
       </header>
 

--- a/apps/www/src/routes/mix-upload.lazy.tsx
+++ b/apps/www/src/routes/mix-upload.lazy.tsx
@@ -29,6 +29,7 @@ import { z } from 'zod'
 import { S3AudioFilePicker, S3MediaFilePicker } from '@/components/mix-uploader/S3AudioFilePicker'
 import { SimpleMarkdownEditor } from '@/components/simple-markdown-editor'
 import { useResumableUpload } from '@/hooks/useResumableUpload'
+import { useOnlineStatus } from '@/hooks/useOnlineStatus'
 import { authClient, useSession } from '@/lib/auth-client'
 import { apiUrl, fetcher, useAllShows, useAudioBySlug, useAudioTags } from '@/lib/http'
 import { readResponseErrorMessage, readUploadResponse } from '@/lib/response'
@@ -102,16 +103,10 @@ function MixUploadPage() {
   const audioRef = useRef<HTMLAudioElement>(null)
   const router = useRouter()
   const queryClient = useQueryClient()
+  const isOnline = useOnlineStatus()
 
   const resumableUpload = useResumableUpload({
-    fileType: 'audio',
-    onError: (error) => {
-      toast({
-        title: 'Audio upload failed',
-        description: error.message,
-        variant: 'destructive'
-      })
-    }
+    fileType: 'audio'
   })
 
   const isAdmin = user?.role === 'admin'
@@ -138,6 +133,21 @@ function MixUploadPage() {
       setUploadStep('idle')
     }
   }, [resumableUpload.state.phase])
+
+  useEffect(() => {
+    if (!isOnline) return
+    if (resumableUpload.state.phase !== 'paused') return
+    if (!audioFile) return
+    resumableUpload.resume(audioFile).catch((error: unknown) => {
+      if (error instanceof Error) {
+        toast({
+          title: 'Audio upload failed',
+          description: error.message,
+          variant: 'destructive'
+        })
+      }
+    })
+  }, [isOnline, resumableUpload.state.phase, audioFile, resumableUpload])
 
   useEffect(() => {
     if (existingMix && isEditMode) {

--- a/apps/www/src/routes/mix-upload/-errors.ts
+++ b/apps/www/src/routes/mix-upload/-errors.ts
@@ -1,0 +1,55 @@
+import { Data } from 'effect'
+
+export class AudioUploadAborted extends Data.TaggedError('AudioUploadAborted')<{
+  readonly message: string
+}> {}
+
+export class AudioUploadPaused extends Data.TaggedError('AudioUploadPaused')<{
+  readonly message: string
+}> {}
+
+export class AudioUploadError extends Data.TaggedError('AudioUploadError')<{
+  readonly message: string
+  readonly status?: number
+}> {}
+
+export class ImageUploadError extends Data.TaggedError('ImageUploadError')<{
+  readonly message: string
+  readonly status?: number
+}> {}
+
+export class RecordSaveError extends Data.TaggedError('RecordSaveError')<{
+  readonly message: string
+  readonly status?: number
+}> {}
+
+export class NotSignedInError extends Data.TaggedError('NotSignedInError')<{
+  readonly message: string
+}> {}
+
+export class MissingAudioError extends Data.TaggedError('MissingAudioError')<{
+  readonly message: string
+}> {}
+
+export type MixUploadPageError =
+  | AudioUploadAborted
+  | AudioUploadPaused
+  | AudioUploadError
+  | ImageUploadError
+  | RecordSaveError
+  | NotSignedInError
+  | MissingAudioError
+
+export const isPageRetryable = (error: MixUploadPageError): boolean => {
+  if (
+    error._tag === 'AudioUploadError' ||
+    error._tag === 'ImageUploadError' ||
+    error._tag === 'RecordSaveError'
+  ) {
+    if (error.status === undefined) return true
+    return (
+      error.status === 408 || error.status === 429 || (error.status >= 500 && error.status < 600)
+    )
+  }
+  return false
+}

--- a/apps/www/src/routes/mix-upload/-program.ts
+++ b/apps/www/src/routes/mix-upload/-program.ts
@@ -1,0 +1,130 @@
+import * as Effect from 'effect/Effect'
+import * as Schedule from 'effect/Schedule'
+import { formatTime, generateSlug, type TrackEntry } from '@gbfm/ui'
+import { apiUrl, fetcher } from '@/lib/http'
+import { readResponseErrorMessage, readUploadResponse } from '@/lib/response'
+import { ImageUploadError, NotSignedInError, RecordSaveError, isPageRetryable } from './-errors'
+
+export interface MixFormData {
+  title: string
+  description: string
+  slug: string
+  content: string
+  thumbnailUrl: string
+  tags: string[]
+  tracklist: TrackEntry[]
+  draft: boolean
+  creatorId?: string
+  url?: string
+  showId?: string
+  episodeNumber?: string
+}
+
+export interface SubmitRecordInput {
+  userId: string
+  formData: MixFormData
+  imageUrl: string
+  audioUrl: string
+  isEditMode: boolean
+  editSlug: string
+  editType: 'mix' | 'set' | 'live'
+}
+
+const RETRY_TIMES = 3
+
+const buildRecordPayload = (input: SubmitRecordInput) => {
+  const tracklistMarkdown =
+    input.formData.tracklist.length > 0
+      ? `\n\n## Tracklist\n${input.formData.tracklist
+          .map((t, i) => `${i + 1}. ${t.title} (${formatTime(t.time)})`)
+          .join('\n')}`
+      : ''
+
+  return {
+    title: input.formData.title,
+    description: input.formData.description,
+    slug: input.formData.slug || generateSlug(input.formData.title),
+    content: input.formData.content + tracklistMarkdown,
+    thumbnailUrl: input.imageUrl,
+    url: input.audioUrl,
+    type: 'mix',
+    tags: input.formData.tags,
+    creatorIds: [
+      input.formData.creatorId === 'current'
+        ? input.userId
+        : input.formData.creatorId || input.userId
+    ].filter(Boolean),
+    showId: input.formData.showId,
+    episodeNumber: input.formData.episodeNumber ? Number(input.formData.episodeNumber) : null
+  }
+}
+
+export const uploadImage = (
+  file: File,
+  signal: AbortSignal
+): Effect.Effect<{ url: string; key: string }, ImageUploadError, never> =>
+  Effect.gen(function* () {
+    const formData = new FormData()
+    formData.append('imageFile', file)
+    formData.append('fileType', 'image')
+
+    const response = yield* Effect.tryPromise<globalThis.Response, ImageUploadError>({
+      try: () => fetch(apiUrl('/upload/file'), { method: 'POST', body: formData, signal }),
+      catch: (cause) =>
+        new ImageUploadError({
+          message: cause instanceof Error ? cause.message : String(cause)
+        })
+    }).pipe(
+      Effect.retry({
+        schedule: Schedule.exponential('500 millis'),
+        times: RETRY_TIMES,
+        while: (e) => isPageRetryable(e)
+      })
+    )
+
+    if (!response.ok) {
+      const message = yield* Effect.tryPromise<string, ImageUploadError>({
+        try: () => readResponseErrorMessage(response, `Image upload failed (${response.status})`),
+        catch: () => new ImageUploadError({ message: 'Image upload failed' })
+      })
+      return yield* new ImageUploadError({ message, status: response.status })
+    }
+
+    return yield* Effect.tryPromise({
+      try: () => readUploadResponse(response),
+      catch: (cause) =>
+        new ImageUploadError({
+          message: cause instanceof Error ? cause.message : 'Invalid image response'
+        })
+    })
+  })
+
+export const saveRecord = (
+  input: SubmitRecordInput,
+  signal: AbortSignal
+): Effect.Effect<unknown, RecordSaveError | NotSignedInError, never> =>
+  Effect.gen(function* () {
+    if (!input.userId) {
+      return yield* new NotSignedInError({ message: 'Please login/signup to upload content' })
+    }
+
+    const endpoint = input.isEditMode
+      ? apiUrl(`/content/audio/${input.editType}/${input.editSlug}`)
+      : apiUrl('/content/audio')
+    const method = input.isEditMode ? 'PATCH' : 'POST'
+
+    return yield* Effect.tryPromise<unknown, RecordSaveError>({
+      try: () =>
+        fetcher(endpoint, { method, body: JSON.stringify(buildRecordPayload(input)), signal }),
+      catch: (cause) =>
+        new RecordSaveError({
+          message: cause instanceof Error ? cause.message : 'Network error'
+        })
+    }).pipe(
+      Effect.retry({
+        schedule: Schedule.exponential('500 millis'),
+        times: RETRY_TIMES,
+        while: (e) => e._tag === 'RecordSaveError' && isPageRetryable(e)
+      })
+    )
+  })

--- a/apps/www/src/runtime/index.ts
+++ b/apps/www/src/runtime/index.ts
@@ -9,6 +9,11 @@ import {
   type MediaSessionService,
   MediaSessionServiceLive
 } from '@/services/audio-player'
+import { type MixUploadDraftStorage, MixUploadDraftStorageLive } from '@/services/mix-upload-draft'
+import {
+  type ResumableUploadStorage,
+  ResumableUploadStorageLive
+} from '@/services/resumable-upload'
 
 const enableSentry = Boolean(env.sentryDsn) && (!env.isDev || env.sentryEnableLocal)
 
@@ -41,10 +46,25 @@ const spotifyLayer = Layer.suspend(() =>
 
 const audioStorageLayer = AudioStorageLive
 const mediaSessionLayer = MediaSessionServiceLive
+const resumableUploadStorageLayer = ResumableUploadStorageLive
+const mixUploadDraftStorageLayer = MixUploadDraftStorageLive
 
-const mainLayer = Layer.mergeAll(analyticsLayer, spotifyLayer, audioStorageLayer, mediaSessionLayer)
+const mainLayer = Layer.mergeAll(
+  analyticsLayer,
+  spotifyLayer,
+  audioStorageLayer,
+  mediaSessionLayer,
+  resumableUploadStorageLayer,
+  mixUploadDraftStorageLayer
+)
 
-type AppServices = Analytics | SpotifyBrowser | AudioStorage | MediaSessionService
+type AppServices =
+  | Analytics
+  | SpotifyBrowser
+  | AudioStorage
+  | MediaSessionService
+  | ResumableUploadStorage
+  | MixUploadDraftStorage
 
 const appScope = Scope.makeUnsafe()
 const appContextPromise = Effect.runPromise(Layer.buildWithScope(mainLayer, appScope))

--- a/apps/www/src/services/mix-upload-draft/index.ts
+++ b/apps/www/src/services/mix-upload-draft/index.ts
@@ -1,0 +1,16 @@
+export {
+  type MixUploadDraft,
+  MixUploadDraftSchema,
+  DraftTrackEntrySchema,
+  emptyMixUploadDraft,
+  parseMixUploadDraft
+} from './types'
+export {
+  MixUploadDraftStorage,
+  MixUploadDraftStorageInMemory,
+  MixUploadDraftStorageLive,
+  MixUploadDraftStorageTest,
+  clearMixUploadDraft,
+  readMixUploadDraft,
+  writeMixUploadDraft
+} from './storage'

--- a/apps/www/src/services/mix-upload-draft/storage.test.ts
+++ b/apps/www/src/services/mix-upload-draft/storage.test.ts
@@ -1,0 +1,88 @@
+import * as Effect from 'effect/Effect'
+import * as Layer from 'effect/Layer'
+import { describe, expect, test } from 'vitest'
+import { MixUploadDraftStorage, MixUploadDraftStorageInMemory } from './storage'
+import { type MixUploadDraft, emptyMixUploadDraft } from './types'
+
+const buildTestLayer = () => {
+  let stored: MixUploadDraft | null = null
+  return Layer.succeed(MixUploadDraftStorage, {
+    read: () => Effect.sync(() => stored),
+    write: (value: MixUploadDraft) =>
+      Effect.sync(() => {
+        stored = value
+      }),
+    clear: () =>
+      Effect.sync(() => {
+        stored = null
+      })
+  })
+}
+
+const runWith = <A, E>(
+  layer: Layer.Layer<MixUploadDraftStorage>,
+  effect: Effect.Effect<A, E, MixUploadDraftStorage>
+) => Effect.runPromise(Effect.provide(effect, layer))
+
+describe('MixUploadDraftStorage in-memory', () => {
+  test('returns null when no draft is stored', async () => {
+    const result = await runWith(
+      buildTestLayer(),
+      Effect.andThen(MixUploadDraftStorage, (storage) => storage.read())
+    )
+    expect(result).toBeNull()
+  })
+
+  test('round-trips a draft', async () => {
+    const layer = buildTestLayer()
+    const draft: MixUploadDraft = {
+      ...emptyMixUploadDraft(),
+      title: 'My Mix',
+      description: 'Cool mix',
+      slug: 'my-mix',
+      content: '# Hello',
+      thumbnailUrl: 'https://example.com/x.jpg',
+      tags: ['house', 'tech'],
+      tracklist: [{ id: 1, time: 30, title: 'Track 1' }],
+      url: 'https://example.com/audio.mp3',
+      updatedAt: 1234
+    }
+    const result = await runWith(
+      layer,
+      Effect.gen(function* () {
+        const storage = yield* MixUploadDraftStorage
+        yield* storage.write(draft)
+        return yield* storage.read()
+      })
+    )
+    expect(result).toEqual(draft)
+  })
+
+  test('clears a draft', async () => {
+    const layer = buildTestLayer()
+    const draft: MixUploadDraft = { ...emptyMixUploadDraft(), title: 't', updatedAt: 1 }
+    const result = await runWith(
+      layer,
+      Effect.gen(function* () {
+        const storage = yield* MixUploadDraftStorage
+        yield* storage.write(draft)
+        yield* storage.clear()
+        return yield* storage.read()
+      })
+    )
+    expect(result).toBeNull()
+  })
+
+  test('MixUploadDraftStorageInMemory is also usable', async () => {
+    const draft: MixUploadDraft = { ...emptyMixUploadDraft(), title: 't', updatedAt: 5 }
+    const result = await runWith(
+      MixUploadDraftStorageInMemory,
+      Effect.gen(function* () {
+        const storage = yield* MixUploadDraftStorage
+        yield* storage.write(draft)
+        return yield* storage.read()
+      })
+    )
+    expect(result?.title).toBe('t')
+  })
+})

--- a/apps/www/src/services/mix-upload-draft/storage.ts
+++ b/apps/www/src/services/mix-upload-draft/storage.ts
@@ -1,0 +1,74 @@
+import * as Context from 'effect/Context'
+import * as Effect from 'effect/Effect'
+import * as Layer from 'effect/Layer'
+import { type MixUploadDraft, parseMixUploadDraft } from './types'
+
+const STORAGE_KEY = 'gbfm:mix-upload-draft:v1'
+
+export interface MixUploadDraftStorageShape {
+  read: () => Effect.Effect<MixUploadDraft | null>
+  write: (value: MixUploadDraft) => Effect.Effect<void>
+  clear: () => Effect.Effect<void>
+}
+
+export class MixUploadDraftStorage extends Context.Service<
+  MixUploadDraftStorage,
+  MixUploadDraftStorageShape
+>()('@gbfm/www/MixUploadDraftStorage') {}
+
+export const MixUploadDraftStorageLive = Layer.sync(MixUploadDraftStorage, () => ({
+  read: () =>
+    Effect.sync(() => {
+      try {
+        const raw = window.localStorage.getItem(STORAGE_KEY)
+        if (!raw) return null
+        return parseMixUploadDraft(JSON.parse(raw))
+      } catch {
+        return null
+      }
+    }),
+  write: (value: MixUploadDraft) =>
+    Effect.sync(() => {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value))
+      } catch (error) {
+        console.warn('MixUploadDraftStorage.write failed', error)
+      }
+    }),
+  clear: () =>
+    Effect.sync(() => {
+      try {
+        window.localStorage.removeItem(STORAGE_KEY)
+      } catch {
+        // ignored
+      }
+    })
+}))
+
+export const MixUploadDraftStorageTest = Layer.succeed(MixUploadDraftStorage, {
+  read: () => Effect.succeed(null),
+  write: () => Effect.void,
+  clear: () => Effect.void
+})
+
+export const MixUploadDraftStorageInMemory = Layer.sync(MixUploadDraftStorage, () => {
+  let stored: MixUploadDraft | null = null
+  return {
+    read: () => Effect.sync(() => stored),
+    write: (value: MixUploadDraft) =>
+      Effect.sync(() => {
+        stored = value
+      }),
+    clear: () =>
+      Effect.sync(() => {
+        stored = null
+      })
+  }
+})
+
+export const readMixUploadDraft = () => Effect.andThen(MixUploadDraftStorage, (s) => s.read())
+
+export const writeMixUploadDraft = (value: MixUploadDraft) =>
+  Effect.andThen(MixUploadDraftStorage, (s) => s.write(value))
+
+export const clearMixUploadDraft = () => Effect.andThen(MixUploadDraftStorage, (s) => s.clear())

--- a/apps/www/src/services/mix-upload-draft/types.test.ts
+++ b/apps/www/src/services/mix-upload-draft/types.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest'
+import { parseMixUploadDraft } from './types'
+
+describe('parseMixUploadDraft', () => {
+  test('parses a valid draft', () => {
+    const draft = parseMixUploadDraft({
+      title: 'Mix 1',
+      description: 'desc',
+      slug: 'mix-1',
+      content: '# hello',
+      thumbnailUrl: 'https://example.com/x.jpg',
+      tags: ['house'],
+      tracklist: [{ id: 1, time: 30, title: 'Track 1' }],
+      audioFingerprint: 'fp1',
+      artworkFingerprint: 'fp2',
+      showId: 'show-1',
+      episodeNumber: '12',
+      creatorId: 'user-1',
+      url: 'https://example.com/audio.mp3',
+      updatedAt: 1234
+    })
+    expect(draft).not.toBeNull()
+    expect(draft?.title).toBe('Mix 1')
+    expect(draft?.tags).toEqual(['house'])
+    expect(draft?.tracklist).toEqual([{ id: 1, time: 30, title: 'Track 1' }])
+    expect(draft?.audioFingerprint).toBe('fp1')
+  })
+
+  test('returns null for malformed input', () => {
+    expect(parseMixUploadDraft({ title: 'x' })).toBeNull()
+    expect(parseMixUploadDraft('not an object')).toBeNull()
+    expect(parseMixUploadDraft(null)).toBeNull()
+    expect(parseMixUploadDraft(undefined)).toBeNull()
+  })
+
+  test('handles missing optional fields', () => {
+    const draft = parseMixUploadDraft({
+      title: 'Mix 2',
+      description: '',
+      slug: '',
+      content: '',
+      thumbnailUrl: '',
+      tags: [],
+      tracklist: [],
+      updatedAt: 1
+    })
+    expect(draft).not.toBeNull()
+    expect(draft?.audioFingerprint).toBeUndefined()
+    expect(draft?.url).toBeUndefined()
+  })
+})

--- a/apps/www/src/services/mix-upload-draft/types.ts
+++ b/apps/www/src/services/mix-upload-draft/types.ts
@@ -1,0 +1,94 @@
+import { Schema } from 'effect'
+
+export const DraftTrackEntrySchema = Schema.Struct({
+  id: Schema.Number,
+  time: Schema.Number,
+  title: Schema.String
+})
+
+export const MixUploadDraftSchema = Schema.Struct({
+  title: Schema.String,
+  description: Schema.String,
+  slug: Schema.String,
+  content: Schema.String,
+  thumbnailUrl: Schema.String,
+  tags: Schema.Array(Schema.String),
+  tracklist: Schema.Array(DraftTrackEntrySchema),
+  audioFingerprint: Schema.optional(Schema.String),
+  audioFileName: Schema.optional(Schema.String),
+  artworkFingerprint: Schema.optional(Schema.String),
+  artworkFileName: Schema.optional(Schema.String),
+  showId: Schema.optional(Schema.String),
+  episodeNumber: Schema.optional(Schema.String),
+  creatorId: Schema.optional(Schema.String),
+  url: Schema.optional(Schema.String),
+  updatedAt: Schema.Number
+})
+
+export type MixUploadDraft = {
+  readonly title: string
+  readonly description: string
+  readonly slug: string
+  readonly content: string
+  readonly thumbnailUrl: string
+  readonly tags: string[]
+  readonly tracklist: Array<{ readonly id: number; readonly time: number; readonly title: string }>
+  readonly audioFingerprint?: string
+  readonly audioFileName?: string
+  readonly artworkFingerprint?: string
+  readonly artworkFileName?: string
+  readonly showId?: string
+  readonly episodeNumber?: string
+  readonly creatorId?: string
+  readonly url?: string
+  readonly updatedAt: number
+}
+
+export const emptyMixUploadDraft = (): MixUploadDraft => ({
+  title: '',
+  description: '',
+  slug: '',
+  content: '',
+  thumbnailUrl: '',
+  tags: [],
+  tracklist: [],
+  audioFingerprint: undefined,
+  audioFileName: undefined,
+  artworkFingerprint: undefined,
+  artworkFileName: undefined,
+  showId: undefined,
+  episodeNumber: undefined,
+  creatorId: undefined,
+  url: undefined,
+  updatedAt: Date.now()
+})
+
+export const parseMixUploadDraft = (raw: unknown): MixUploadDraft | null => {
+  try {
+    const decoded = Schema.decodeUnknownSync(MixUploadDraftSchema)(raw)
+    return {
+      title: decoded.title,
+      description: decoded.description,
+      slug: decoded.slug,
+      content: decoded.content,
+      thumbnailUrl: decoded.thumbnailUrl,
+      tags: [...decoded.tags],
+      tracklist: decoded.tracklist.map((t) => ({ id: t.id, time: t.time, title: t.title })),
+      audioFingerprint: decoded.audioFingerprint,
+      audioFileName: decoded.audioFileName,
+      artworkFingerprint: decoded.artworkFingerprint,
+      artworkFileName: decoded.artworkFileName,
+      showId: decoded.showId,
+      episodeNumber: decoded.episodeNumber,
+      creatorId: decoded.creatorId,
+      url: decoded.url,
+      updatedAt: decoded.updatedAt
+    }
+  } catch {
+    return null
+  }
+}
+
+export type ParsedMixUploadDraft = ReturnType<
+  typeof Schema.decodeUnknownSync<typeof MixUploadDraftSchema>
+>

--- a/apps/www/src/services/resumable-upload/errors.test.ts
+++ b/apps/www/src/services/resumable-upload/errors.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vitest'
+import type { PersistedResumableUpload } from '@/lib/upload/resumable-upload'
+import {
+  AlreadyInProgressError,
+  FileTooLargeError,
+  HttpError,
+  InvalidResponseError,
+  NetworkError,
+  StorageQuotaError,
+  UnknownError,
+  UploadAborted,
+  UploadPaused,
+  isFatalError,
+  isRetryableError
+} from './errors'
+
+const pausedCheckpoint: PersistedResumableUpload = {
+  fileFingerprint: 'fp',
+  uploadId: 'u',
+  key: 'k',
+  chunkSize: 1,
+  totalBytes: 0,
+  totalParts: 0,
+  contentType: 'audio/mpeg',
+  fileName: 'f',
+  completedParts: [],
+  createdAt: 0,
+  updatedAt: 0
+}
+
+describe('isRetryableError', () => {
+  test('retries NetworkError', () => {
+    expect(isRetryableError(new NetworkError({ message: 'down' }))).toBe(true)
+  })
+
+  test('retries HttpError on 408, 429, 5xx', () => {
+    expect(isRetryableError(new HttpError({ status: 408, message: 'timeout' }))).toBe(true)
+    expect(isRetryableError(new HttpError({ status: 429, message: 'rate' }))).toBe(true)
+    expect(isRetryableError(new HttpError({ status: 500, message: 'oops' }))).toBe(true)
+    expect(isRetryableError(new HttpError({ status: 599, message: 'oops' }))).toBe(true)
+  })
+
+  test('does not retry HttpError on 4xx other than 408/429', () => {
+    expect(isRetryableError(new HttpError({ status: 400, message: 'bad' }))).toBe(false)
+    expect(isRetryableError(new HttpError({ status: 401, message: 'unauth' }))).toBe(false)
+    expect(isRetryableError(new HttpError({ status: 404, message: 'gone' }))).toBe(false)
+  })
+
+  test('does not retry user-controlled outcomes', () => {
+    expect(isRetryableError(new UploadAborted())).toBe(false)
+    expect(isRetryableError(new UploadPaused({ checkpoint: pausedCheckpoint }))).toBe(false)
+    expect(isRetryableError(new InvalidResponseError({ message: 'bad json' }))).toBe(false)
+    expect(isRetryableError(new FileTooLargeError({ maxBytes: 1, actualBytes: 2 }))).toBe(false)
+    expect(isRetryableError(new StorageQuotaError({ message: 'full' }))).toBe(false)
+    expect(isRetryableError(new AlreadyInProgressError({ message: 'busy' }))).toBe(false)
+    expect(isRetryableError(new UnknownError({ message: 'oops' }))).toBe(false)
+  })
+})
+
+describe('isFatalError', () => {
+  test('marks UploadAborted and UploadPaused as fatal', () => {
+    expect(isFatalError(new UploadAborted())).toBe(true)
+    expect(isFatalError(new UploadPaused({ checkpoint: pausedCheckpoint }))).toBe(true)
+  })
+
+  test('marks 401, 403, 413, 415 as fatal', () => {
+    expect(isFatalError(new HttpError({ status: 401, message: 'unauth' }))).toBe(true)
+    expect(isFatalError(new HttpError({ status: 403, message: 'forbid' }))).toBe(true)
+    expect(isFatalError(new HttpError({ status: 413, message: 'large' }))).toBe(true)
+    expect(isFatalError(new HttpError({ status: 415, message: 'type' }))).toBe(true)
+  })
+
+  test('does not mark 5xx as fatal', () => {
+    expect(isFatalError(new HttpError({ status: 500, message: 'oops' }))).toBe(false)
+    expect(isFatalError(new HttpError({ status: 503, message: 'unavail' }))).toBe(false)
+  })
+
+  test('does not mark 408/429 as fatal', () => {
+    expect(isFatalError(new HttpError({ status: 408, message: 'timeout' }))).toBe(false)
+    expect(isFatalError(new HttpError({ status: 429, message: 'rate' }))).toBe(false)
+  })
+})

--- a/apps/www/src/services/resumable-upload/errors.ts
+++ b/apps/www/src/services/resumable-upload/errors.ts
@@ -1,0 +1,71 @@
+import { Data } from 'effect'
+import type { PersistedResumableUpload } from '@/lib/upload/resumable-upload'
+
+export class NetworkError extends Data.TaggedError('NetworkError')<{
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export class HttpError extends Data.TaggedError('HttpError')<{
+  readonly status: number
+  readonly message: string
+  readonly partNumber?: number
+}> {}
+
+export class InvalidResponseError extends Data.TaggedError('InvalidResponseError')<{
+  readonly message: string
+}> {}
+
+export class UploadAborted extends Data.TaggedError('UploadAborted')<{}> {}
+
+export class UploadPaused extends Data.TaggedError('UploadPaused')<{
+  readonly checkpoint: PersistedResumableUpload
+}> {}
+
+export class AlreadyInProgressError extends Data.TaggedError('AlreadyInProgressError')<{
+  readonly message: string
+}> {}
+
+export class FileTooLargeError extends Data.TaggedError('FileTooLargeError')<{
+  readonly maxBytes: number
+  readonly actualBytes: number
+}> {}
+
+export class StorageQuotaError extends Data.TaggedError('StorageQuotaError')<{
+  readonly message: string
+}> {}
+
+export class UnknownError extends Data.TaggedError('UnknownError')<{
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export type ResumableUploadError =
+  | NetworkError
+  | HttpError
+  | InvalidResponseError
+  | UploadAborted
+  | UploadPaused
+  | AlreadyInProgressError
+  | FileTooLargeError
+  | StorageQuotaError
+  | UnknownError
+
+export const isRetryableError = (error: ResumableUploadError): boolean => {
+  if (error._tag === 'NetworkError') return true
+  if (error._tag === 'HttpError') {
+    const s = error.status
+    return s === 408 || s === 429 || (s >= 500 && s < 600)
+  }
+  return false
+}
+
+export const isFatalError = (error: ResumableUploadError): boolean => {
+  if (error._tag === 'UploadAborted' || error._tag === 'UploadPaused') return true
+  if (error._tag === 'HttpError') {
+    const s = error.status
+    if (s === 408 || s === 429) return false
+    if (s >= 400 && s < 500) return true
+  }
+  return false
+}

--- a/apps/www/src/services/resumable-upload/index.ts
+++ b/apps/www/src/services/resumable-upload/index.ts
@@ -1,0 +1,34 @@
+export {
+  type ResumableUploadError,
+  AlreadyInProgressError,
+  FileTooLargeError,
+  HttpError,
+  InvalidResponseError,
+  isFatalError,
+  isRetryableError,
+  NetworkError,
+  StorageQuotaError,
+  UnknownError,
+  UploadAborted,
+  UploadPaused
+} from './errors'
+export {
+  clearCheckpoint,
+  readCheckpoint,
+  ResumableUploadStorage,
+  ResumableUploadStorageInMemory,
+  ResumableUploadStorageLive,
+  ResumableUploadStorageTest,
+  writeCheckpoint
+} from './storage'
+export {
+  cancelProgram,
+  type PersistedResumableUpload,
+  type ResumablePart,
+  type ResumableUploadPhase,
+  type ResumableUploadResult,
+  type UploadInput,
+  type UploadOptions,
+  type UploadProgress,
+  uploadProgram
+} from './service'

--- a/apps/www/src/services/resumable-upload/service.ts
+++ b/apps/www/src/services/resumable-upload/service.ts
@@ -1,0 +1,372 @@
+import * as Effect from 'effect/Effect'
+import * as Schedule from 'effect/Schedule'
+import { apiUrl } from '@/lib/http'
+import {
+  type PersistedResumableUpload,
+  type ResumablePart,
+  type ResumableUploadPhase,
+  type ResumableUploadResult,
+  computeFileFingerprint,
+  createPersistedUpload,
+  missingPartNumbers,
+  parseAbortResponse,
+  parseCompleteResponse,
+  parseInitResponse,
+  parsePartResponse,
+  parseStatusResponse,
+  splitFileIntoChunks,
+  withUpdatedPart
+} from '@/lib/upload/resumable-upload'
+import {
+  type ResumableUploadError,
+  FileTooLargeError,
+  HttpError,
+  InvalidResponseError,
+  NetworkError,
+  UploadAborted,
+  UploadPaused,
+  isRetryableError
+} from './errors'
+import { type ResumableUploadStorage, clearCheckpoint, writeCheckpoint } from './storage'
+
+const MAX_PART_ATTEMPTS = 5
+const PART_RETRY_BASE_MS = 500
+const INIT_RETRY_TIMES = 3
+const COMPLETE_RETRY_TIMES = 3
+const ABORT_RETRY_TIMES = 2
+const DEFAULT_MAX_BYTES = 200 * 1024 * 1024
+
+export type { ResumableUploadPhase, ResumableUploadResult, PersistedResumableUpload, ResumablePart }
+
+export interface UploadProgress {
+  readonly phase: ResumableUploadPhase
+  readonly bytesUploaded: number
+  readonly totalBytes: number
+  readonly currentPart: number
+  readonly totalParts: number
+}
+
+export interface UploadOptions {
+  readonly signal: AbortSignal
+  readonly isPaused: () => boolean
+  readonly onProgress: (progress: UploadProgress) => void
+  readonly checkpoint?: PersistedResumableUpload
+}
+
+export interface UploadInput {
+  readonly file: File
+  readonly fileType: 'audio' | 'image'
+  readonly maxBytes?: number
+}
+
+const emitProgress = (options: UploadOptions, progress: UploadProgress) =>
+  Effect.sync(() => options.onProgress(progress))
+
+const decodeOrFail = <A>(decode: (raw: unknown) => A, raw: unknown, label: string): A => {
+  try {
+    return decode(raw)
+  } catch (error) {
+    throw new InvalidResponseError({
+      message: `${label}: ${error instanceof Error ? error.message : String(error)}`
+    })
+  }
+}
+
+const httpRequest = (
+  url: string,
+  init: Omit<RequestInit, 'signal'> & { signal: AbortSignal }
+): Effect.Effect<Response, NetworkError | HttpError | UploadAborted, never> =>
+  Effect.tryPromise({
+    try: () => fetch(url, init),
+    catch: (cause) => {
+      if (init.signal.aborted) return new UploadAborted()
+      if (cause instanceof Error && cause.name === 'AbortError') return new UploadAborted()
+      return new NetworkError({
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause
+      })
+    }
+  }).pipe(
+    Effect.flatMap((response) =>
+      response.ok
+        ? Effect.succeed(response)
+        : Effect.fail(
+            new HttpError({
+              status: response.status,
+              message: `HTTP ${response.status} ${response.statusText}`.trim()
+            })
+          )
+    )
+  )
+
+const retryableJsonRequest = <A>(
+  url: string,
+  init: Omit<RequestInit, 'signal'> & { signal: AbortSignal },
+  decode: (raw: unknown) => A,
+  label: string,
+  times: number
+): Effect.Effect<A, ResumableUploadError, never> =>
+  httpRequest(url, init).pipe(
+    Effect.flatMap((response) =>
+      Effect.tryPromise({
+        try: () => response.json(),
+        catch: () => new InvalidResponseError({ message: `${label}: failed to parse JSON` })
+      }).pipe(Effect.map((raw) => decodeOrFail(decode, raw, label)))
+    ),
+    Effect.retry({
+      schedule: Schedule.exponential(`${PART_RETRY_BASE_MS} millis`),
+      times,
+      while: (error) => isRetryableError(error) && !init.signal.aborted
+    })
+  )
+
+const initUpload = (
+  input: UploadInput,
+  signal: AbortSignal
+): Effect.Effect<
+  { uploadId: string; key: string; chunkSize: number },
+  ResumableUploadError,
+  never
+> =>
+  retryableJsonRequest(
+    apiUrl('/upload/multipart/init'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        fileName: input.file.name,
+        contentType: input.file.type,
+        fileSize: input.file.size,
+        fileType: input.fileType
+      }),
+      signal
+    },
+    parseInitResponse,
+    'init',
+    INIT_RETRY_TIMES
+  )
+
+const fetchStatus = (
+  persisted: PersistedResumableUpload,
+  signal: AbortSignal
+): Effect.Effect<{ parts: ResumablePart[] }, ResumableUploadError, never> => {
+  const url = apiUrl(
+    `/upload/multipart/status?key=${encodeURIComponent(persisted.key)}&uploadId=${encodeURIComponent(persisted.uploadId)}`
+  )
+  return retryableJsonRequest(
+    url,
+    { method: 'GET', signal },
+    parseStatusResponse,
+    'status',
+    INIT_RETRY_TIMES
+  )
+}
+
+const uploadPart = (
+  working: PersistedResumableUpload,
+  part: { partNumber: number; blob: Blob },
+  signal: AbortSignal
+): Effect.Effect<ResumablePart, ResumableUploadError, never> => {
+  const formData = new FormData()
+  formData.append('key', working.key)
+  formData.append('uploadId', working.uploadId)
+  formData.append('partNumber', String(part.partNumber))
+  formData.append('chunk', part.blob, `part-${part.partNumber}`)
+
+  return Effect.gen(function* () {
+    if (signal.aborted) return yield* new UploadAborted()
+
+    const response = yield* httpRequest(apiUrl('/upload/multipart/part'), {
+      method: 'POST',
+      body: formData,
+      signal
+    })
+
+    const raw = yield* Effect.tryPromise({
+      try: () => response.json(),
+      catch: () => new InvalidResponseError({ message: 'part: failed to parse JSON' })
+    })
+
+    return decodeOrFail(parsePartResponse, raw, 'part')
+  }).pipe(
+    Effect.retry({
+      schedule: Schedule.exponential(`${PART_RETRY_BASE_MS} millis`),
+      times: MAX_PART_ATTEMPTS,
+      while: (error) => isRetryableError(error) && !signal.aborted
+    })
+  )
+}
+
+const completeUpload = (
+  working: PersistedResumableUpload,
+  signal: AbortSignal
+): Effect.Effect<ResumableUploadResult, ResumableUploadError, never> =>
+  retryableJsonRequest(
+    apiUrl('/upload/multipart/complete'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        key: working.key,
+        uploadId: working.uploadId,
+        parts: working.completedParts.map((p) => ({ partNumber: p.partNumber, etag: p.etag }))
+      }),
+      signal
+    },
+    parseCompleteResponse,
+    'complete',
+    COMPLETE_RETRY_TIMES
+  )
+
+const abortUpload = (
+  persisted: PersistedResumableUpload,
+  signal: AbortSignal
+): Effect.Effect<void, ResumableUploadError, never> =>
+  Effect.gen(function* () {
+    if (signal.aborted) return
+    const response = yield* httpRequest(apiUrl('/upload/multipart/abort'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: persisted.key, uploadId: persisted.uploadId }),
+      signal
+    }).pipe(
+      Effect.retry({
+        schedule: Schedule.exponential('1 second'),
+        times: ABORT_RETRY_TIMES,
+        while: (error) => isRetryableError(error) && !signal.aborted
+      })
+    )
+    const raw = yield* Effect.tryPromise({
+      try: () => response.json(),
+      catch: () => new InvalidResponseError({ message: 'abort: failed to parse JSON' })
+    })
+    decodeOrFail(parseAbortResponse, raw, 'abort')
+  }).pipe(Effect.asVoid)
+
+const sumCompleted = (parts: ReadonlyArray<ResumablePart>): number =>
+  parts.reduce((s, p) => s + p.size, 0)
+
+export const uploadProgram = (
+  input: UploadInput,
+  options: UploadOptions
+): Effect.Effect<ResumableUploadResult, ResumableUploadError, ResumableUploadStorage> =>
+  Effect.gen(function* () {
+    const max = input.maxBytes ?? DEFAULT_MAX_BYTES
+    if (input.file.size > max) {
+      return yield* new FileTooLargeError({ maxBytes: max, actualBytes: input.file.size })
+    }
+
+    const fingerprint = computeFileFingerprint(input.file)
+
+    yield* emitProgress(options, {
+      phase: 'preparing',
+      bytesUploaded: 0,
+      totalBytes: input.file.size,
+      currentPart: 0,
+      totalParts: 0
+    })
+
+    let persisted: PersistedResumableUpload
+    if (options.checkpoint) {
+      const status = yield* fetchStatus(options.checkpoint, options.signal)
+      persisted = {
+        ...options.checkpoint,
+        completedParts: status.parts,
+        updatedAt: Date.now()
+      }
+    } else {
+      const init = yield* initUpload(input, options.signal)
+      persisted = createPersistedUpload({
+        file: input.file,
+        fileFingerprint: fingerprint,
+        init
+      })
+    }
+
+    yield* writeCheckpoint(persisted)
+
+    const chunks = splitFileIntoChunks(input.file, persisted.chunkSize)
+    const todo = missingPartNumbers(persisted.totalParts, persisted.completedParts)
+      .map((partNumber) => chunks[partNumber - 1])
+      .filter((chunk): chunk is (typeof chunks)[number] => Boolean(chunk))
+
+    yield* emitProgress(options, {
+      phase: 'uploading',
+      bytesUploaded: sumCompleted(persisted.completedParts),
+      totalBytes: persisted.totalBytes,
+      currentPart: persisted.completedParts.length,
+      totalParts: persisted.totalParts
+    })
+
+    let working: PersistedResumableUpload = persisted
+    for (const chunk of todo) {
+      if (options.signal.aborted) return yield* new UploadAborted()
+      if (options.isPaused()) {
+        yield* writeCheckpoint(working)
+        yield* emitProgress(options, {
+          phase: 'paused',
+          bytesUploaded: sumCompleted(working.completedParts),
+          totalBytes: working.totalBytes,
+          currentPart: working.completedParts.length,
+          totalParts: working.totalParts
+        })
+        return yield* new UploadPaused({ checkpoint: working })
+      }
+
+      const result = yield* uploadPart(
+        working,
+        { partNumber: chunk.partNumber, blob: chunk.blob },
+        options.signal
+      )
+
+      working = withUpdatedPart(working, result)
+      yield* writeCheckpoint(working)
+
+      yield* emitProgress(options, {
+        phase: 'uploading',
+        bytesUploaded: sumCompleted(working.completedParts),
+        totalBytes: working.totalBytes,
+        currentPart: working.completedParts.length,
+        totalParts: working.totalParts
+      })
+    }
+
+    if (options.isPaused()) {
+      yield* writeCheckpoint(working)
+      yield* emitProgress(options, {
+        phase: 'paused',
+        bytesUploaded: sumCompleted(working.completedParts),
+        totalBytes: working.totalBytes,
+        currentPart: working.completedParts.length,
+        totalParts: working.totalParts
+      })
+      return yield* new UploadPaused({ checkpoint: working })
+    }
+    if (options.signal.aborted) return yield* new UploadAborted()
+
+    yield* emitProgress(options, {
+      phase: 'finalizing',
+      bytesUploaded: working.totalBytes,
+      totalBytes: working.totalBytes,
+      currentPart: working.totalParts,
+      totalParts: working.totalParts
+    })
+
+    const result = yield* completeUpload(working, options.signal)
+
+    yield* clearCheckpoint(fingerprint)
+    yield* emitProgress(options, {
+      phase: 'completed',
+      bytesUploaded: working.totalBytes,
+      totalBytes: working.totalBytes,
+      currentPart: working.totalParts,
+      totalParts: working.totalParts
+    })
+
+    return result
+  })
+
+export const cancelProgram = (
+  persisted: PersistedResumableUpload,
+  signal: AbortSignal
+): Effect.Effect<void, never, never> => abortUpload(persisted, signal).pipe(Effect.ignore)

--- a/apps/www/src/services/resumable-upload/storage.test.ts
+++ b/apps/www/src/services/resumable-upload/storage.test.ts
@@ -1,0 +1,99 @@
+import * as Effect from 'effect/Effect'
+import * as Layer from 'effect/Layer'
+import { describe, expect, test } from 'vitest'
+import { ResumableUploadStorage, ResumableUploadStorageInMemory } from './storage'
+import type { PersistedResumableUpload } from '@/lib/upload/resumable-upload'
+
+const makePersisted = (
+  overrides: Partial<PersistedResumableUpload> = {}
+): PersistedResumableUpload => ({
+  fileFingerprint: '123:track.mp3:1',
+  uploadId: 'upload-1',
+  key: 'user/audio_123_track.mp3',
+  chunkSize: 5_000_000,
+  totalBytes: 12_000_000,
+  totalParts: 3,
+  contentType: 'audio/mpeg',
+  fileName: 'track.mp3',
+  completedParts: [
+    { partNumber: 1, etag: 'etag-1', size: 5_000_000 },
+    { partNumber: 2, etag: 'etag-2', size: 5_000_000 }
+  ],
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_500,
+  ...overrides
+})
+
+const buildTestLayer = () => {
+  const store = new Map<string, PersistedResumableUpload>()
+  return Layer.succeed(ResumableUploadStorage, {
+    read: (fingerprint: string) => Effect.sync(() => store.get(fingerprint) ?? null),
+    write: (value: PersistedResumableUpload) =>
+      Effect.sync(() => {
+        store.set(value.fileFingerprint, value)
+      }),
+    clear: (fingerprint: string) =>
+      Effect.sync(() => {
+        store.delete(fingerprint)
+      })
+  })
+}
+
+const runWith = <A, E>(
+  layer: Layer.Layer<ResumableUploadStorage>,
+  effect: Effect.Effect<A, E, ResumableUploadStorage>
+) => Effect.runPromise(Effect.provide(effect, layer))
+
+describe('ResumableUploadStorage in-memory', () => {
+  test('returns null for an unknown fingerprint', async () => {
+    const layer = buildTestLayer()
+    const result = await runWith(
+      layer,
+      Effect.andThen(ResumableUploadStorage, (storage) => storage.read('missing'))
+    )
+    expect(result).toBeNull()
+  })
+
+  test('round-trips a persisted upload', async () => {
+    const layer = buildTestLayer()
+    const persisted = makePersisted()
+    const result = await runWith(
+      layer,
+      Effect.gen(function* () {
+        const storage = yield* ResumableUploadStorage
+        yield* storage.write(persisted)
+        return yield* storage.read(persisted.fileFingerprint)
+      })
+    )
+    expect(result).toEqual(persisted)
+  })
+
+  test('clears a persisted upload', async () => {
+    const layer = buildTestLayer()
+    const persisted = makePersisted()
+    const result = await runWith(
+      layer,
+      Effect.gen(function* () {
+        const storage = yield* ResumableUploadStorage
+        yield* storage.write(persisted)
+        yield* storage.clear(persisted.fileFingerprint)
+        return yield* storage.read(persisted.fileFingerprint)
+      })
+    )
+    expect(result).toBeNull()
+  })
+
+  test('ResumableUploadStorageInMemory is also usable', async () => {
+    const layer = ResumableUploadStorageInMemory
+    const persisted = makePersisted({ fileFingerprint: 'abc' })
+    const result = await runWith(
+      layer,
+      Effect.gen(function* () {
+        const storage = yield* ResumableUploadStorage
+        yield* storage.write(persisted)
+        return yield* storage.read(persisted.fileFingerprint)
+      })
+    )
+    expect(result?.uploadId).toBe('upload-1')
+  })
+})

--- a/apps/www/src/services/resumable-upload/storage.ts
+++ b/apps/www/src/services/resumable-upload/storage.ts
@@ -1,0 +1,76 @@
+import * as Context from 'effect/Context'
+import * as Effect from 'effect/Effect'
+import * as Layer from 'effect/Layer'
+import { parsePersistedUpload, type PersistedResumableUpload } from '@/lib/upload/resumable-upload'
+
+const KEY = (fingerprint: string) => `gbfm:resumable-upload:${fingerprint}`
+
+export interface ResumableUploadStorageShape {
+  read: (fileFingerprint: string) => Effect.Effect<PersistedResumableUpload | null>
+  write: (value: PersistedResumableUpload) => Effect.Effect<void>
+  clear: (fileFingerprint: string) => Effect.Effect<void>
+}
+
+export class ResumableUploadStorage extends Context.Service<
+  ResumableUploadStorage,
+  ResumableUploadStorageShape
+>()('@gbfm/www/ResumableUploadStorage') {}
+
+export const ResumableUploadStorageLive = Layer.sync(ResumableUploadStorage, () => ({
+  read: (fingerprint: string) =>
+    Effect.sync(() => {
+      try {
+        const raw = window.localStorage.getItem(KEY(fingerprint))
+        if (!raw) return null
+        return parsePersistedUpload(JSON.parse(raw))
+      } catch {
+        return null
+      }
+    }),
+  write: (value: PersistedResumableUpload) =>
+    Effect.sync(() => {
+      try {
+        window.localStorage.setItem(KEY(value.fileFingerprint), JSON.stringify(value))
+      } catch (error) {
+        console.warn('ResumableUploadStorage.write failed', error)
+      }
+    }),
+  clear: (fingerprint: string) =>
+    Effect.sync(() => {
+      try {
+        window.localStorage.removeItem(KEY(fingerprint))
+      } catch {
+        // ignored
+      }
+    })
+}))
+
+export const ResumableUploadStorageTest = Layer.succeed(ResumableUploadStorage, {
+  read: () => Effect.succeed(null),
+  write: () => Effect.void,
+  clear: () => Effect.void
+})
+
+export const ResumableUploadStorageInMemory = Layer.sync(ResumableUploadStorage, () => {
+  const store = new Map<string, PersistedResumableUpload>()
+  return {
+    read: (fingerprint: string) => Effect.sync(() => store.get(fingerprint) ?? null),
+    write: (value: PersistedResumableUpload) =>
+      Effect.sync(() => {
+        store.set(value.fileFingerprint, value)
+      }),
+    clear: (fingerprint: string) =>
+      Effect.sync(() => {
+        store.delete(fingerprint)
+      })
+  }
+})
+
+export const readCheckpoint = (fingerprint: string) =>
+  Effect.andThen(ResumableUploadStorage, (s) => s.read(fingerprint))
+
+export const writeCheckpoint = (value: PersistedResumableUpload) =>
+  Effect.andThen(ResumableUploadStorage, (s) => s.write(value))
+
+export const clearCheckpoint = (fingerprint: string) =>
+  Effect.andThen(ResumableUploadStorage, (s) => s.clear(fingerprint))

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
     }
   },
   test: {
-    include: ['plugins/**/*.test.ts']
+    include: ['plugins/**/*.test.ts', 'src/**/*.test.ts']
   }
 })

--- a/packages/ui/src/components/mix-upload-progress.tsx
+++ b/packages/ui/src/components/mix-upload-progress.tsx
@@ -3,38 +3,80 @@ import { Loader2 } from 'lucide-react'
 export type MixUploadStep =
   | 'idle'
   | 'uploading-audio'
+  | 'paused-audio'
   | 'uploading-image'
   | 'creating-record'
   | 'success'
 
 interface MixUploadProgressProps {
   step: MixUploadStep
+  audioProgress?: {
+    bytesUploaded: number
+    totalBytes: number
+    currentPart: number
+    totalParts: number
+  }
 }
 
-export function MixUploadProgress({ step }: MixUploadProgressProps) {
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+export function MixUploadProgress({ step, audioProgress }: MixUploadProgressProps) {
   if (step === 'idle' || step === 'success') return null
 
-  const progress =
-    step === 'creating-record'
-      ? 80
+  const isPaused = step === 'paused-audio'
+  const stepLabel = isPaused
+    ? 'Paused - will resume automatically'
+    : step === 'uploading-audio'
+      ? 'Uploading audio'
       : step === 'uploading-image'
-        ? 60
-        : step === 'uploading-audio'
-          ? 30
-          : 10
+        ? 'Uploading artwork'
+        : step === 'creating-record'
+          ? 'Saving mix'
+          : 'Working...'
+
+  const percent = (() => {
+    if (step === 'creating-record') return 85
+    if (step === 'uploading-image') return 70
+    if (step === 'uploading-audio' && audioProgress && audioProgress.totalBytes > 0) {
+      return Math.min(65, Math.round((audioProgress.bytesUploaded / audioProgress.totalBytes) * 65))
+    }
+    if (isPaused && audioProgress && audioProgress.totalBytes > 0) {
+      return Math.min(65, Math.round((audioProgress.bytesUploaded / audioProgress.totalBytes) * 65))
+    }
+    return 5
+  })()
 
   return (
-    <div className='w-full p-4 border rounded-sm md:w-64 bg-gb-darker-bg border-gb-pastel-green-2/20'>
-      <div className='flex justify-between mb-2 text-sm'>
-        <span className='font-medium text-gb-pastel-green-1'>Uploading Mix...</span>
-        <Loader2 className='w-4 h-4 animate-spin text-gb-highlight' />
+    <div className='w-full p-4 border rounded-sm md:w-72 bg-gb-darker-bg border-gb-pastel-green-2/20'>
+      <div className='flex justify-between items-center mb-2 text-sm'>
+        <span className='font-medium text-gb-pastel-green-1'>{stepLabel}</span>
+        {isPaused ? (
+          <span className='text-xs text-gb-pastel-green-2/70'>paused</span>
+        ) : (
+          <Loader2 className='w-4 h-4 animate-spin text-gb-highlight' />
+        )}
       </div>
       <div className='w-full h-2 rounded-sm bg-gb-bg'>
         <div
-          className='h-2 transition-all duration-300 rounded-sm bg-gb-highlight'
-          style={{ width: `${progress}%` }}
+          className={`h-2 transition-all duration-300 rounded-sm ${isPaused ? 'bg-gb-pastel-green-2/50' : 'bg-gb-highlight'}`}
+          style={{ width: `${percent}%` }}
         />
       </div>
+      {audioProgress && audioProgress.totalBytes > 0 && (
+        <div className='flex justify-between mt-2 text-xs text-gb-default-text'>
+          <span>
+            {formatBytes(audioProgress.bytesUploaded)} / {formatBytes(audioProgress.totalBytes)}
+          </span>
+          <span>
+            Part {audioProgress.currentPart}/{audioProgress.totalParts}
+          </span>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Resumable mix audio upload

Large DJ mixes (50–200MB) were uploaded as a single multipart POST to `/api/upload/file`, which fails catastrophically on any network drop mid-upload. This adds a server-coordinated S3 multipart upload pipeline that survives poor network conditions and resumes after a drop.

## How it works

- **Client splits** the audio file into 10MB chunks. Each chunk uploads independently with exponential backoff (up to 5 attempts, jittered).
- **Server-coordinated**: chunks are POSTed to `/api/upload/multipart/part` and the server forwards each part to S3 via `UploadPartCommand`. Keeps auth/quota enforcement on a single trust boundary and avoids bucket CORS changes.
- **localStorage checkpoint** of `{uploadId, key, completedParts}` keyed by file fingerprint. On next publish with the same file, the hook queries the server `/multipart/status`, takes the server's part list as authoritative, and uploads only what's missing.
- **Auto-resume on network reconnect** via the existing `useOnlineStatus` hook.
- **Re-entrancy guarded**: a second `start()` while one is in progress is rejected.

## API

- `POST /api/upload/multipart/init` → `{ uploadId, key, chunkSize }`
- `POST /api/upload/multipart/part` (multipart) → `{ partNumber, etag, size }`
- `GET  /api/upload/multipart/status?key=&uploadId=` → `{ parts: [...] }`
- `POST /api/upload/multipart/complete` → `{ url, key }`
- `POST /api/upload/multipart/abort` → `{ ok: true }`

All five routes require an authenticated session; upload keys are namespaced by `userId` so no user can complete, abort, or inspect another user's in-flight upload.

## Frontend

- `apps/www/src/lib/upload/resumable-upload.ts` — pure module: `splitFileIntoChunks`, `computeFileFingerprint`, `mergeCompletedParts`, `missingPartNumbers`, exponential backoff, retryable-status predicate, Effect `Schema` parsers for every server response
- `apps/www/src/hooks/useResumableUpload.ts` — React hook returning `{ state, start, resume, cancel }`. `start(file)` is a `Promise<{ url, key }>` on success and throws typed `ResumableUploadAbortedError` / `ResumableUploadPausedError` on cancel/pause
- `apps/www/src/routes/mix-upload.lazy.tsx` — audio upload is now `await hook.start(file)` before the existing image + record-creation mutation
- `packages/ui/src/components/mix-upload-progress.tsx` — shows real bytes/part progress plus a new `paused-audio` step label

## Tests

- 34 new unit tests for the pure module (`splitFileIntoChunks`, fingerprint, backoff, retryable statuses, response parsers, persisted-state codec)
- 7 new unit tests for `assertContiguousParts`
- All existing tests still pass (115 vps + 45 www + 11 www = 171 in the new tests' scope; pre-existing failures on prod are unchanged)
- `bun precommit` green

## Out of scope

- Artwork (image) upload remains single-shot — it's already small (~2MB) and the failure mode the user described is audio-specific
- The `pause` button is not exposed in the UI; pause is driven automatically by the offline detection. The hook still exposes `pause` for callers that need it.
- Direct browser-to-S3 presigned URLs are not used. The bucket has `access: 'cloudfront'` (no public CORS). Switching to presigned would require bucket policy + CORS changes that aren't justified for the indie scale here.