### PR TITLE
fix(www): send credentials on resumable upload requests

### DIFF
--- a/apps/www/src/services/resumable-upload/service.ts
+++ b/apps/www/src/services/resumable-upload/service.ts
@@ -77,7 +77,11 @@ const httpRequest = (
   init: Omit<RequestInit, 'signal'> & { signal: AbortSignal }
 ): Effect.Effect<Response, NetworkError | HttpError | UploadAborted, never> =>
   Effect.tryPromise({
-    try: () => fetch(url, init),
+    try: () =>
+      fetch(url, {
+        ...init,
+        credentials: init.credentials ?? 'include'
+      }),
     catch: (cause) => {
       if (init.signal.aborted) return new UploadAborted()
       if (cause instanceof Error && cause.name === 'AbortError') return new UploadAborted()


### PR DESCRIPTION
Multipart init/part/complete/abort hit vps.goosebumps.fm cross-origin. The httpRequest helper in apps/www/src/services/resumable-upload/service.ts used bare fetch() without credentials, so the better-auth session cookie was never sent and the backend rejected every call with 401. Other API callers already go through fetcher (apps/www/src/lib/http-client.ts:63), which sets credentials: 'include'.

Fixes the 401 on POST /api/upload/multipart/init (and /part, /complete, /abort) when the user is logged in via the frontend.

Verified with bun precommit (oxfmt, oxlint, tsgo across all workspaces).