### PR TITLE
fix(www): move Sentry.init to module-level in main.tsx

### DIFF
--- a/apps/www/src/main.tsx
+++ b/apps/www/src/main.tsx
@@ -1,7 +1,9 @@
+import * as Sentry from '@sentry/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRouter, RouterProvider } from '@tanstack/react-router'
 import React from 'react'
 import { createRoot } from 'react-dom/client'
+import { env } from '@/env'
 import { RuntimeClient } from '@/runtime'
 import { page } from '@/services/analytics'
 
@@ -37,6 +39,44 @@ const queryClient = new QueryClient({
     }
   }
 })
+
+const isLocalUrl = (value: unknown) =>
+  typeof value === 'string' && (value.includes('127.0.0.1') || value.includes('localhost'))
+
+const hasLocalUrl = (event: Sentry.Event) =>
+  isLocalUrl(event.request?.url) ||
+  event.spans?.some((span) => isLocalUrl(span.description) || isLocalUrl(span.data?.url))
+
+const tracePropagationTargets = env.isDev
+  ? [/^\//, 'http://127.0.0.1:3003', 'http://localhost:3003']
+  : [/^\//, 'https://goosebumps.fm', 'https://www.goosebumps.fm', 'https://vps.goosebumps.fm']
+
+if (env.sentryDsn && (!env.isDev || env.sentryEnableLocal)) {
+  Sentry.init({
+    dsn: env.sentryDsn,
+    environment: env.sentryEnvironment ?? (env.isDev ? 'development' : 'production'),
+    release: env.sentryRelease,
+    debug: env.isDev,
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      ...(env.isDev
+        ? []
+        : [
+            Sentry.replayIntegration({
+              maskAllText: false,
+              blockAllMedia: false
+            })
+          ])
+    ],
+    tracesSampleRate: 1.0,
+    tracePropagationTargets,
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: env.isDev ? 0 : 1.0,
+    sendDefaultPii: false,
+    beforeSend: (event) => (hasLocalUrl(event) ? null : event),
+    beforeSendTransaction: (event) => (hasLocalUrl(event) ? null : event)
+  })
+}
 
 function App() {
   const { data: session } = useSession()

--- a/apps/www/src/runtime/index.ts
+++ b/apps/www/src/runtime/index.ts
@@ -2,7 +2,7 @@ import { SpotifyBrowser } from '@spotify-effect/browser'
 import { Effect, Layer, Scope } from 'effect'
 import { env } from '@/env'
 import { getSpotifyRedirectUri } from '@/lib/spotify-pkce'
-import { type Analytics, makeSentryAnalyticsLayer, NoopAnalyticsLayer } from '@/services/analytics'
+import { type Analytics, SentryAnalyticsLayer, NoopAnalyticsLayer } from '@/services/analytics'
 import {
   type AudioStorage,
   AudioStorageLive,
@@ -17,20 +17,7 @@ import {
 
 const enableSentry = Boolean(env.sentryDsn) && (!env.isDev || env.sentryEnableLocal)
 
-const analyticsLayer = enableSentry
-  ? makeSentryAnalyticsLayer({
-      dsn: env.sentryDsn,
-      environment: env.sentryEnvironment ?? (env.isDev ? 'development' : 'production'),
-      release: env.sentryRelease,
-      debug: env.isDev,
-      enableSessionReplay: !env.isDev,
-      // temporarily raised to 1.0 for end-to-end trace investigation
-      tracesSampleRate: 1.0,
-      tracePropagationTargets: env.isDev
-        ? [/^\//, 'http://127.0.0.1:3003', 'http://localhost:3003']
-        : [/^\//, 'https://goosebumps.fm', 'https://www.goosebumps.fm', 'https://vps.goosebumps.fm']
-    })
-  : NoopAnalyticsLayer
+const analyticsLayer = enableSentry ? SentryAnalyticsLayer : NoopAnalyticsLayer
 
 const spotifyLayer = Layer.suspend(() =>
   SpotifyBrowser.layer({

--- a/apps/www/src/services/analytics/index.ts
+++ b/apps/www/src/services/analytics/index.ts
@@ -1,3 +1,3 @@
 export { NoopAnalyticsLayer } from './noop'
-export { captureException, makeSentryAnalyticsLayer, type SentryAnalyticsOptions } from './sentry'
+export { captureException, SentryAnalyticsLayer } from './sentry'
 export { Analytics, type AnalyticsProperties, identify, page, reset, track } from './service'

--- a/apps/www/src/services/analytics/sentry.ts
+++ b/apps/www/src/services/analytics/sentry.ts
@@ -4,62 +4,6 @@ import * as Layer from 'effect/Layer'
 import type { AnalyticsProperties } from './service'
 import { Analytics } from './service'
 
-const isLocalUrl = (value: unknown) =>
-  typeof value === 'string' && (value.includes('127.0.0.1') || value.includes('localhost'))
-
-const hasLocalUrl = (event: Sentry.Event) =>
-  isLocalUrl(event.request?.url) ||
-  event.spans?.some((span) => isLocalUrl(span.description) || isLocalUrl(span.data?.url))
-
-export interface SentryAnalyticsOptions {
-  readonly dsn: string
-  readonly environment?: string
-  readonly debug?: boolean
-  readonly enableSessionReplay?: boolean
-  readonly tracesSampleRate?: number
-  readonly replaysOnErrorSampleRate?: number
-  readonly tracePropagationTargets?: (string | RegExp)[]
-  readonly release?: string
-}
-
-const makeSentryClientLayer = (options: SentryAnalyticsOptions) =>
-  Layer.effectDiscard(
-    Effect.sync(() => {
-      const enableSessionReplay = options.enableSessionReplay ?? true
-
-      Sentry.init({
-        dsn: options.dsn,
-        environment: options.environment,
-        release: options.release,
-        debug: options.debug ?? false,
-        integrations: [
-          Sentry.browserTracingIntegration(),
-          ...(enableSessionReplay
-            ? [
-                Sentry.replayIntegration({
-                  maskAllText: false,
-                  blockAllMedia: false
-                })
-              ]
-            : [])
-        ],
-        tracesSampleRate: options.tracesSampleRate ?? 0.1,
-        tracePropagationTargets: options.tracePropagationTargets,
-        replaysSessionSampleRate: 0,
-        replaysOnErrorSampleRate: enableSessionReplay
-          ? (options.replaysOnErrorSampleRate ?? 1.0)
-          : 0,
-        sendDefaultPii: false,
-        beforeSend: (event) => {
-          return hasLocalUrl(event) ? null : event
-        },
-        beforeSendTransaction: (event) => {
-          return hasLocalUrl(event) ? null : event
-        }
-      })
-    })
-  )
-
 const SentryAnalyticsImpl = Layer.sync(Analytics, () => {
   const track = Effect.fn('Analytics.track')((event: string, properties?: AnalyticsProperties) =>
     Effect.sync(() => {
@@ -101,8 +45,7 @@ const SentryAnalyticsImpl = Layer.sync(Analytics, () => {
   return { track, identify, page, reset }
 })
 
-export const makeSentryAnalyticsLayer = (options: SentryAnalyticsOptions) =>
-  Layer.provideMerge(SentryAnalyticsImpl, makeSentryClientLayer(options))
+export const SentryAnalyticsLayer = SentryAnalyticsImpl
 
 export const captureException = (error: unknown, context?: AnalyticsProperties) =>
   Effect.sync(() => {


### PR DESCRIPTION
Investigation: Sentry was working from the preloaded simple-markdown-editor chunk, not the entry, and was never called from anywhere in the main bundle.

Confirmed facts (from a fresh build + production bundle inspection):
- The deployed index-*.js has 0 Sentry.init / 0 browserTracingIntegration / 0 captureException calls.
- The deployed simple-markdown-editor-*.js (which IS in <head> as <link rel="modulepreload">) contains Sentry.init, the full DSN, environment: prod, release: v2.57.1.
- The runtime layer that calls Sentry.init was being hoisted into that chunk because @sentry/react has 'sideEffects: false' and was imported from both the entry and the SMDE chunk; Rolldown chose the larger consumer.
- Bun.lock pins vite@8.0.10+ea520413169d1a8e despite package.json declaring 8.0.16. A vite 8.0.10 -> 8.0.16 bump in bun.lock would be worth doing separately.

This PR moves Sentry.init out of the Effect layer and to module top-level in main.tsx. The Effect Analytics layer is now a pure interface that uses the already-initialized Sentry SDK. The behavior is the same (same DSN, same integrations, same filters, same sample rates), but the call is now guaranteed to be in the main entry bundle and visible at audit time.

If after deploying this, you still see no events in Sentry: the problem is no longer in the bundle. Check the Sentry project status for project 5439010 in org o452087 (is it archived? rate-limited? filtered?), and confirm the release v2.57.1 is what the deploy is sending (SENTRY_RELEASE is wired from the deploy workflow at .github/workflows/deploy.yml:83).

Verified with bun precommit (oxfmt, oxlint, tsgo across all workspaces).