### PR TITLE
fix(vps): lower multipart chunk size under API Gateway 10MiB limit

### DIFF
--- a/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.ts
+++ b/apps/vps/src/routes/upload-multipart/upload-multipart.handlers.ts
@@ -16,9 +16,13 @@ import type {
 } from './upload-multipart.routes'
 import type { Context } from 'hono'
 
-const CHUNK_SIZE = 10 * 1024 * 1024
+const CHUNK_SIZE = 8 * 1024 * 1024
 const MAX_AUDIO_SIZE = 200 * 1024 * 1024
-const MAX_CHUNK_SIZE = CHUNK_SIZE * 2
+// API Gateway HTTP API v2 caps request bodies at 10 MiB. A multipart/form-data
+// request adds ~1 KiB of overhead on top of the file part, so the per-chunk
+// ceiling must stay well under 10 MiB. 9 MiB leaves room for the form fields
+// (key, uploadId, partNumber) and the boundary markers.
+const MAX_CHUNK_SIZE = 9 * 1024 * 1024
 
 const sanitizeKeySegment = (value: string): string => value.replace(/[^a-zA-Z0-9.-]/g, '_')
 


### PR DESCRIPTION
The VPS is fronted by sst.aws.ApiGatewayV2 (HTTP API v2), which has a hard 10 MiB request body limit. The 10 MiB chunk size + multipart form overhead hits that limit exactly, so the first part of any upload (e.g. the 150 MB mix) fails with 413 Content Too Large before reaching the Hono handler.

Drops CHUNK_SIZE from 10 MiB to 8 MiB and MAX_CHUNK_SIZE from CHUNK_SIZE * 2 to a hard 9 MiB. A 150 MB file now takes 19 chunks instead of 15. S3's multipart constraints (5 MiB min, 5 GiB max per part) are well outside the new range.

Long-term: switch to S3 presigned URLs so the browser uploads parts directly to S3 and the API only handles init/complete/abort/status. That removes the API Gateway from the heavy data path entirely and unblocks files of any size. Tracked in #131.

## How I tested

1. Confirmed the limit exists at API Gateway, not Bun. Bun's HTTP server is configured with `maxRequestBodySize: 1024 * 1024 * 1000` (1 GiB) in `apps/vps/src/index.ts`, so the 413 is not coming from Bun or Hono.

2. Probed the limit directly against `https://vps.goosebumps.fm/api/upload/multipart/part` with `curl`, no auth, just `-F chunk=@file;type=audio/mpeg`:
   ```
   8 MiB chunk  -> 401  (API Gateway forwarded; backend returned Unauthorized)
   9 MiB chunk  -> 401  (same)
   10 MiB chunk -> 413  (API Gateway rejected)
   12 MiB chunk -> 413
   ```
   The 401 vs 413 boundary is exactly at 10 MiB of file bytes. With `-F` overhead this matches the API Gateway HTTP API v2 hard cap.

3. Confirmed the 413 body matches API Gateway's shape, not the backend's. The backend's own 413 returns `{ error: 'File too large...' }` (see `uploadPart` handler). API Gateway returns the bare `{"message":"Request Entity Too Large"}` we saw.

4. Unit tests in `apps/vps/src/routes/upload-multipart/upload-multipart.handlers.test.ts` still pass: 7 pass, 0 fail, 7 expect() calls. None of the assertions were tied to the old 10 MiB CHUNK_SIZE.

5. `bun precommit` clean: oxfmt, oxlint, tsgo across all workspaces.

## Production verification

After merging and deploying, the simplest end-to-end check is: upload any file > 10 MiB via the mix-upload page and watch the network tab. Each part POST should be 200 and you should see ~ceil(fileSize / 8 MiB) part requests. Files under 8 MiB upload in a single part as before.
