### PR TITLE
feat(www): shared logger writes to console and Sentry

### DIFF
--- a/apps/www/src/components/ErrorBoundary.tsx
+++ b/apps/www/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Button } from '@gbfm/ui'
 import { Component, type ReactNode } from 'react'
 import { RuntimeClient } from '@/runtime'
 import { captureException } from '@/services/analytics'
+import { log } from '@/services/logger'
 
 interface Props {
   children: ReactNode
@@ -24,7 +25,10 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error('ErrorBoundary caught an error:', error, errorInfo)
+    log('error', 'ErrorBoundary caught an error', {
+      error,
+      componentStack: errorInfo.componentStack
+    })
     void RuntimeClient.runPromise(
       captureException(error, {
         componentStack: errorInfo.componentStack

--- a/apps/www/src/components/FavoriteButton.tsx
+++ b/apps/www/src/components/FavoriteButton.tsx
@@ -8,6 +8,7 @@ import {
   useRemoveFavorite,
   useRemoveShowFavorite
 } from '@/lib/http'
+import { log } from '@/services/logger'
 import { cn } from '@/lib/utils'
 
 interface FavoriteButtonProps {
@@ -75,7 +76,7 @@ export function FavoriteButton({
         }
       }
     } catch (error) {
-      console.log('error:', error)
+      log('error', 'Favorite action failed', { contentType, contentId, error })
       const message = error instanceof Error ? error.message.toLowerCase() : ''
       if (message.includes('already favorited') || message.includes('409')) {
         toast({

--- a/apps/www/src/components/MDXRendrr.tsx
+++ b/apps/www/src/components/MDXRendrr.tsx
@@ -1,6 +1,7 @@
 import { run } from '@mdx-js/mdx'
 import { useEffect, useState } from 'react'
 import * as runtime from 'react/jsx-runtime'
+import { log } from '@/services/logger'
 import { CustomMDXComponents } from './mdx-components'
 
 type LoadedContentType = Awaited<ReturnType<typeof run>>['default']
@@ -25,7 +26,7 @@ export function MDXRendrr({ mdxString }: { mdxString: string }) {
         })
         setContent(() => loadedContent)
       } catch (err) {
-        console.error('MDX compilation error:', err)
+        log('error', 'MDX compilation error', { error: err })
         setError('Invalid MDX syntax. Please check your content.')
         setContent(null)
       }

--- a/apps/www/src/components/MixMenu.tsx
+++ b/apps/www/src/components/MixMenu.tsx
@@ -13,6 +13,7 @@ import { useAuthGuard } from '@/hooks/useAuthGuard'
 import { DEFAULT_IMAGE_URL } from '@/lib/constants'
 import { useAddFavorite, useFavorites, useRemoveFavorite } from '@/lib/http'
 import { getShareUrl } from '@/lib/share'
+import { log } from '@/services/logger'
 import { cn } from '@/lib/utils'
 import { useAudioPlayerActions } from '@/store/audioPlayer'
 
@@ -41,7 +42,7 @@ export function MixMenu({ mix }: MixMenuProps) {
         description: 'Share URL copied to clipboard'
       })
     } catch (error) {
-      console.error('Failed to copy link to clipboard:', error)
+      log('error', 'Failed to copy link to clipboard', { mix: mix.slug, error })
       toast({
         title: 'Failed to copy',
         description: 'Could not copy link to clipboard',

--- a/apps/www/src/components/RSS.tsx
+++ b/apps/www/src/components/RSS.tsx
@@ -4,6 +4,7 @@ import { CheckIcon } from '@radix-ui/react-icons'
 import { useState } from 'react'
 import { FaSquareRss } from 'react-icons/fa6'
 import { publicUrlObj } from '@/lib/http'
+import { log } from '@/services/logger'
 
 export const RSS = () => {
   const [isCopied, setIsCopied] = useState(false)
@@ -21,7 +22,7 @@ export const RSS = () => {
       navigator.clipboard.writeText(RSSurl)
       toggleIsCopiedForThreeSeconds()
     } catch (error) {
-      console.error('Failed to copy to clipboard', error)
+      log('error', 'Failed to copy RSS link to clipboard', { error })
     }
   }
 

--- a/apps/www/src/components/ShareButton.tsx
+++ b/apps/www/src/components/ShareButton.tsx
@@ -2,6 +2,7 @@ import { useFeatureFlag } from '@gbfm/core/feature-flags'
 import { Button, toast } from '@gbfm/ui'
 import { Share2 } from 'lucide-react'
 import { getShareUrl, type ShareContentType } from '@/lib/share'
+import { log } from '@/services/logger'
 
 interface ShareButtonProps {
   type: ShareContentType
@@ -32,7 +33,7 @@ export function ShareButton({
         description: 'Share URL copied to clipboard'
       })
     } catch (error) {
-      console.error('Failed to copy link to clipboard:', error)
+      log('error', 'Failed to copy link to clipboard', { type, slug, error })
       toast({
         title: 'Failed to copy',
         description: 'Could not copy link to clipboard',

--- a/apps/www/src/components/TrackContextMenu.tsx
+++ b/apps/www/src/components/TrackContextMenu.tsx
@@ -8,6 +8,7 @@ import {
   toast
 } from '@gbfm/ui'
 import type { SelectAudio } from '@gbfm/vps/schemas'
+import { log } from '@/services/logger'
 import { Heart, HeartOff, Play, Plus, Share2 } from 'lucide-react'
 import type React from 'react'
 import { useAuthGuard } from '@/hooks/useAuthGuard'
@@ -89,7 +90,7 @@ export const TrackContextMenu: React.FC<TrackContextMenuProps> = ({
         description: 'Share URL copied to clipboard'
       })
     } catch (error) {
-      console.error('Failed to copy link to clipboard:', error)
+      log('error', 'Failed to copy link to clipboard', { track: track.slug, error })
       toast({
         title: 'Failed to copy',
         description: 'Could not copy link to clipboard',

--- a/apps/www/src/components/common/MinimalCard.tsx
+++ b/apps/www/src/components/common/MinimalCard.tsx
@@ -5,6 +5,7 @@ import type React from 'react'
 import { MdOutlineDownloading } from 'react-icons/md'
 import { DEFAULT_IMAGE_URL } from '@/lib/constants'
 import { cn, copyToClipboard } from '@/lib/utils'
+import { log } from '@/services/logger'
 import { PlayPauseButton } from '../PlayPauseButton'
 
 // this component needs to support:
@@ -62,7 +63,7 @@ export const MinimalCard: React.FC<Props> = ({
         description: 'Share URL copied to clipboard'
       })
     } catch (error) {
-      console.error('Failed to copy link to clipboard:', error)
+      log('error', 'Failed to copy link to clipboard', { shareUrl, error })
       toast({
         title: 'Failed to copy',
         description: 'Could not copy link to clipboard',

--- a/apps/www/src/components/dashboard/EmailPreferencesCard.tsx
+++ b/apps/www/src/components/dashboard/EmailPreferencesCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle, Label } from '@gbfm/ui'
 import { useEffect, useState } from 'react'
 import { useEmailPreferences, useUpdateEmailPreferences } from '@/lib/http'
+import { log } from '@/services/logger'
 
 export function EmailPreferencesCard() {
   const { data: emailPreferences } = useEmailPreferences()
@@ -30,7 +31,7 @@ export function EmailPreferencesCard() {
     try {
       await updateEmailPreferences(newPrefs)
     } catch (error) {
-      console.error('Error updating email preferences:', error)
+      log('error', 'Error updating email preferences', { key, error })
       setEmailPrefs(emailPrefs)
     }
   }

--- a/apps/www/src/components/dashboard/ProfileCard.tsx
+++ b/apps/www/src/components/dashboard/ProfileCard.tsx
@@ -2,6 +2,7 @@ import { Button, Card, CardContent, CardHeader, CardTitle, Input, Label } from '
 import { useEffect, useId, useState } from 'react'
 import { useSession } from '@/lib/auth-client'
 import { useUpdateProfile } from '@/lib/http'
+import { log } from '@/services/logger'
 
 type SessionUser = NonNullable<ReturnType<typeof useSession>['data']>['user']
 
@@ -70,7 +71,7 @@ export function ProfileCard({ user }: ProfileCardProps) {
       setImagePreview(null)
       await refetchSession()
     } catch (error) {
-      console.error('Error updating profile:', error)
+      log('error', 'Error updating profile', { error })
     }
   }
 

--- a/apps/www/src/components/editor.tsx
+++ b/apps/www/src/components/editor.tsx
@@ -13,6 +13,7 @@ import { compile } from '@mdx-js/mdx'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { useSearch } from '@tanstack/react-router'
 import { useForm } from 'react-hook-form'
+import { log } from '@/services/logger'
 import { z } from 'zod/v4'
 import { apiUrl, fetcher } from '@/lib/http'
 
@@ -110,7 +111,7 @@ export function Editor() {
 
   // Update form with existing content when available
   useEffect(() => {
-    console.log('existingContent:', existingContent)
+    log('debug', 'existingContent', { existingContent })
     if (existingContent) {
       setValue(existingContent.content)
     }

--- a/apps/www/src/components/profile/ProfileSocialLinks.tsx
+++ b/apps/www/src/components/profile/ProfileSocialLinks.tsx
@@ -2,6 +2,7 @@ import { toast } from '@gbfm/ui'
 import { Share2 } from 'lucide-react'
 import type { PublicProfile } from '@/lib/http'
 import { getShareUrl } from '@/lib/share'
+import { log } from '@/services/logger'
 
 const BandcampIcon = () => (
   <svg
@@ -167,7 +168,7 @@ export function ProfileSocialLinks({ username, socialLinks }: ProfileSocialLinks
         description: 'Share URL copied to clipboard'
       })
     } catch (error) {
-      console.error('Failed to copy link to clipboard:', error)
+      log('error', 'Failed to copy share URL to clipboard', { shareUrl, error })
       toast({
         title: 'Failed to copy',
         description: 'Could not copy link to clipboard',

--- a/apps/www/src/components/queue/SharedQueueItem.tsx
+++ b/apps/www/src/components/queue/SharedQueueItem.tsx
@@ -6,6 +6,7 @@ import { Heart, MoreHorizontal, Play, Plus, Share2, X } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { DEFAULT_IMAGE_URL } from '@/lib/constants'
+import { log } from '@/services/logger'
 import { cn } from '@/lib/utils'
 import { useAudioPlayerActions } from '@/store/audioPlayer'
 
@@ -153,12 +154,12 @@ export const SharedQueueItem: React.FC<SharedQueueItemProps> = ({
   }
 
   const handleAddToFavorites = () => {
-    console.log('Add to favorites:', track.title)
+    log('debug', 'Add to favorites', { track: track.title })
     closeContextMenu()
   }
 
   const handleShare = () => {
-    console.log('Share:', track.title)
+    log('debug', 'Share', { track: track.title })
     closeContextMenu()
   }
 

--- a/apps/www/src/components/simple-markdown-editor.tsx
+++ b/apps/www/src/components/simple-markdown-editor.tsx
@@ -8,6 +8,7 @@ import 'react-mde/lib/styles/css/react-mde.css'
 import 'react-mde/lib/styles/css/react-mde-editor.css'
 import './editor.css'
 import { compile } from '@mdx-js/mdx'
+import { log } from '@/services/logger'
 
 interface SimpleMarkdownEditorProps {
   value: string
@@ -144,7 +145,7 @@ async function compileMdx(markdown: string) {
     })
     return compiled.toString()
   } catch (error) {
-    console.error('MDX compilation error:', error)
+    log('error', 'MDX compilation error', { error })
     return markdown // Return original markdown if compilation fails
   }
 }

--- a/apps/www/src/hooks/useMixUploadDraft.ts
+++ b/apps/www/src/hooks/useMixUploadDraft.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { computeFileFingerprint } from '@/lib/upload/resumable-upload'
 import { runAppEffect } from '@/runtime'
+import { log } from '@/services/logger'
 import {
   type MixUploadDraft,
   MixUploadDraftStorage,
@@ -95,7 +96,7 @@ export function useMixUploadDraft(): UseMixUploadDraftReturn {
       latestRef.current = next
       setDraft(next)
       runAppEffect(Effect.andThen(MixUploadDraftStorage, (s) => s.write(next))).catch((error) => {
-        console.warn('Failed to save mix upload draft', error)
+        log('warn', 'Failed to save mix upload draft', { error })
       })
     }, DEBOUNCE_MS)
   }, [])

--- a/apps/www/src/lib/http-client.test.ts
+++ b/apps/www/src/lib/http-client.test.ts
@@ -113,7 +113,10 @@ describe('createFetcher', () => {
     })
 
     await expect(fetcher('/api/boom')).rejects.toThrow('boom')
-    expect(logError).toHaveBeenCalledWith(error)
+    expect(logError).toHaveBeenCalledWith(error, {
+      url: '/api/boom',
+      method: 'GET'
+    })
   })
 })
 

--- a/apps/www/src/lib/http-client.ts
+++ b/apps/www/src/lib/http-client.ts
@@ -1,4 +1,5 @@
 import type * as Effect from 'effect/Effect'
+import { log as defaultLog } from '@/services/logger'
 
 export type HttpRequestInput = RequestInfo | URL
 
@@ -14,7 +15,7 @@ type FetcherOptions = {
   onUnauthorized?: () => void
   reportFailure?: (failure: ApiFailureInput) => Effect.Effect<void>
   runEffect?: (effect: Effect.Effect<void>) => Promise<void>
-  logError?: (error: unknown) => void
+  logError?: (error: unknown, context?: Record<string, unknown>) => void
 }
 
 export function getRequestUrl(input: HttpRequestInput) {
@@ -36,7 +37,7 @@ export function createFetcher({
   },
   reportFailure,
   runEffect,
-  logError = console.error
+  logError = (error, context) => defaultLog('error', 'HTTP request failed', { error, ...context })
 }: FetcherOptions = {}) {
   const runFailureReport = (
     error: unknown,
@@ -46,7 +47,9 @@ export function createFetcher({
   ) => {
     if (!reportFailure || !runEffect) return
 
-    void runEffect(reportFailure({ error, input, init, context })).catch(logError)
+    void runEffect(reportFailure({ error, input, init, context })).catch((reportError) =>
+      logError(reportError, { failureType: 'report_failure' })
+    )
   }
 
   return async function fetcher<T>(input: HttpRequestInput, init: RequestInit = {}): Promise<T> {
@@ -91,7 +94,7 @@ export function createFetcher({
         runFailureReport(error, input, init, { failureType: 'network' })
       }
 
-      logError(error)
+      logError(error, { url: getRequestUrl(input), method: getRequestMethod(input, init) })
       throw error
     }
   }

--- a/apps/www/src/lib/utils.ts
+++ b/apps/www/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import { log } from '@/services/logger'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -9,7 +10,7 @@ export function copyToClipboard(text: string) {
   try {
     navigator.clipboard.writeText(text)
   } catch (error) {
-    console.warn('Failed to copy text: ', error)
+    log('warn', 'Failed to copy text', { error })
   }
 }
 

--- a/apps/www/src/main.tsx
+++ b/apps/www/src/main.tsx
@@ -57,6 +57,7 @@ if (env.sentryDsn && (!env.isDev || env.sentryEnableLocal)) {
     environment: env.sentryEnvironment ?? (env.isDev ? 'development' : 'production'),
     release: env.sentryRelease,
     debug: env.isDev,
+    enableLogs: true,
     integrations: [
       Sentry.browserTracingIntegration(),
       ...(env.isDev

--- a/apps/www/src/routes/label-upload.lazy.tsx
+++ b/apps/www/src/routes/label-upload.lazy.tsx
@@ -20,6 +20,7 @@ import { SimpleMarkdownEditor } from '@/components/simple-markdown-editor'
 import { useSession } from '@/lib/auth-client'
 import { apiUrl, fetcher } from '@/lib/http'
 import { readResponseErrorMessage, readUploadResponse } from '@/lib/response'
+import { log } from '@/services/logger'
 
 export const Route = createLazyFileRoute('/label-upload')({
   component: LabelUploadPage
@@ -155,7 +156,7 @@ function LabelUploadPage() {
       }, 2000)
     },
     onError: (error) => {
-      console.error('Upload failed:', error)
+      log('error', 'Upload failed', { error })
       toast({
         title: 'Upload failed',
         description: error instanceof Error ? error.message : 'An unexpected error occurred.',

--- a/apps/www/src/routes/reminders.tsx
+++ b/apps/www/src/routes/reminders.tsx
@@ -5,6 +5,7 @@ import { CalendarClock } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useSession } from '@/lib/auth-client'
 import { apiUrl, fetcher, useEnrichTrackFromUrl } from '@/lib/http'
+import { log } from '@/services/logger'
 
 interface MusicReminder {
   id: string
@@ -46,7 +47,7 @@ const formatReminderDateValue = (value: string) => {
 function MusicReminders() {
   const { data: session } = useSession()
   const isAuthenticated = Boolean(session?.user)
-  console.log('isAuthenticated:', isAuthenticated)
+  log('debug', 'isAuthenticated', { isAuthenticated })
   const queryClient = useQueryClient()
   const [musicUrl, setMusicUrl] = useState('')
   const [musicTitle, setMusicTitle] = useState('')
@@ -116,7 +117,7 @@ function MusicReminders() {
       })
     },
     onError: (error) => {
-      console.error('Failed to create reminder:', error)
+      log('error', 'Failed to create reminder', { error })
       toast({
         variant: 'destructive',
         title: 'Failed to create reminder',

--- a/apps/www/src/runtime/index.ts
+++ b/apps/www/src/runtime/index.ts
@@ -9,6 +9,7 @@ import {
   type MediaSessionService,
   MediaSessionServiceLive
 } from '@/services/audio-player'
+import { log, type Logger, LoggerLive, NoopLogger } from '@/services/logger'
 import { type MixUploadDraftStorage, MixUploadDraftStorageLive } from '@/services/mix-upload-draft'
 import {
   type ResumableUploadStorage,
@@ -35,6 +36,7 @@ const audioStorageLayer = AudioStorageLive
 const mediaSessionLayer = MediaSessionServiceLive
 const resumableUploadStorageLayer = ResumableUploadStorageLive
 const mixUploadDraftStorageLayer = MixUploadDraftStorageLive
+const loggerLayer = enableSentry ? LoggerLive : NoopLogger
 
 const mainLayer = Layer.mergeAll(
   analyticsLayer,
@@ -42,7 +44,8 @@ const mainLayer = Layer.mergeAll(
   audioStorageLayer,
   mediaSessionLayer,
   resumableUploadStorageLayer,
-  mixUploadDraftStorageLayer
+  mixUploadDraftStorageLayer,
+  loggerLayer
 )
 
 type AppServices =
@@ -52,6 +55,7 @@ type AppServices =
   | MediaSessionService
   | ResumableUploadStorage
   | MixUploadDraftStorage
+  | Logger
 
 const appScope = Scope.makeUnsafe()
 const appContextPromise = Effect.runPromise(Layer.buildWithScope(mainLayer, appScope))
@@ -60,7 +64,7 @@ export const runAppEffect = <A, E>(effect: Effect.Effect<A, E, AppServices>) =>
   appContextPromise
     .then((context) => Effect.runPromiseWith(context)(effect))
     .catch((error) => {
-      console.error('App effect failed', error)
+      log('error', 'App effect failed', { error })
       throw error
     })
 

--- a/apps/www/src/services/analytics/noop.ts
+++ b/apps/www/src/services/analytics/noop.ts
@@ -1,10 +1,11 @@
 import * as Effect from 'effect/Effect'
 import * as Layer from 'effect/Layer'
+import { log } from '@/services/logger'
 import { Analytics } from './service'
 
 const logLocalOnly = (method: string) =>
   Effect.sync(() => {
-    console.info(`[analytics:no-op] analytics event captured locally only (${method})`)
+    log('debug', `[analytics:no-op] analytics event captured locally only (${method})`)
   })
 
 export const NoopAnalyticsLayer = Layer.succeed(Analytics, {

--- a/apps/www/src/services/logger/index.ts
+++ b/apps/www/src/services/logger/index.ts
@@ -1,0 +1,3 @@
+export { log, LoggerLive, dispatchLog } from './live'
+export { Logger, type LogAttributes, type LoggerShape, type LogSeverity } from './service'
+export { NoopLogger } from './noop'

--- a/apps/www/src/services/logger/live.ts
+++ b/apps/www/src/services/logger/live.ts
@@ -1,0 +1,66 @@
+import * as Effect from 'effect/Effect'
+import * as Layer from 'effect/Layer'
+import * as Sentry from '@sentry/react'
+import { Logger, type LogAttributes, type LogSeverity } from './service'
+
+const serializeError = (error: unknown): Record<string, unknown> =>
+  error instanceof Error
+    ? { name: error.name, message: error.message, stack: error.stack }
+    : { value: String(error) }
+
+const normalizeAttributes = (attributes?: LogAttributes): LogAttributes | undefined => {
+  if (attributes === undefined) return undefined
+  if (attributes.error === undefined) return attributes
+  const { error, ...rest } = attributes
+  return { ...rest, error: serializeError(error) }
+}
+
+const writeConsole = (severity: LogSeverity, message: string, attributes?: LogAttributes) => {
+  switch (severity) {
+    case 'debug':
+      attributes === undefined ? console.debug(message) : console.debug(message, attributes)
+      return
+    case 'info':
+      attributes === undefined ? console.info(message) : console.info(message, attributes)
+      return
+    case 'warn':
+      attributes === undefined ? console.warn(message) : console.warn(message, attributes)
+      return
+    case 'error':
+      attributes === undefined ? console.error(message) : console.error(message, attributes)
+      return
+  }
+}
+
+const writeSentry = (severity: LogSeverity, message: string, attributes?: LogAttributes) => {
+  switch (severity) {
+    case 'debug':
+      Sentry.logger.debug(message, attributes)
+      return
+    case 'info':
+      Sentry.logger.info(message, attributes)
+      return
+    case 'warn':
+      Sentry.logger.warn(message, attributes)
+      return
+    case 'error':
+      Sentry.logger.error(message, attributes)
+      return
+  }
+}
+
+export const dispatchLog = (
+  severity: LogSeverity,
+  message: string,
+  attributes?: LogAttributes
+) => {
+  writeConsole(severity, message, attributes)
+  writeSentry(severity, message, normalizeAttributes(attributes))
+}
+
+export const log = (severity: LogSeverity, message: string, attributes?: LogAttributes) =>
+  dispatchLog(severity, message, attributes)
+
+export const LoggerLive = Layer.sync(Logger, () => ({
+  log: (severity, message, attributes) => Effect.sync(() => log(severity, message, attributes))
+}))

--- a/apps/www/src/services/logger/live.ts
+++ b/apps/www/src/services/logger/live.ts
@@ -49,11 +49,7 @@ const writeSentry = (severity: LogSeverity, message: string, attributes?: LogAtt
   }
 }
 
-export const dispatchLog = (
-  severity: LogSeverity,
-  message: string,
-  attributes?: LogAttributes
-) => {
+export const dispatchLog = (severity: LogSeverity, message: string, attributes?: LogAttributes) => {
   writeConsole(severity, message, attributes)
   writeSentry(severity, message, normalizeAttributes(attributes))
 }
@@ -62,5 +58,6 @@ export const log = (severity: LogSeverity, message: string, attributes?: LogAttr
   dispatchLog(severity, message, attributes)
 
 export const LoggerLive = Layer.sync(Logger, () => ({
-  log: (severity, message, attributes) => Effect.sync(() => log(severity, message, attributes))
+  log: (severity: LogSeverity, message: string, attributes?: LogAttributes) =>
+    Effect.sync(() => log(severity, message, attributes))
 }))

--- a/apps/www/src/services/logger/noop.ts
+++ b/apps/www/src/services/logger/noop.ts
@@ -1,0 +1,9 @@
+import * as Effect from 'effect/Effect'
+import * as Layer from 'effect/Layer'
+import { Logger, type LogAttributes, type LogSeverity } from './service'
+
+const noop = (_severity: LogSeverity, _message: string, _attributes?: LogAttributes) => Effect.void
+
+export const NoopLogger = Layer.succeed(Logger, {
+  log: noop
+})

--- a/apps/www/src/services/logger/service.ts
+++ b/apps/www/src/services/logger/service.ts
@@ -1,0 +1,15 @@
+import * as Context from 'effect/Context'
+import type * as Effect from 'effect/Effect'
+
+export type LogAttributes = Record<string, unknown>
+export type LogSeverity = 'debug' | 'info' | 'warn' | 'error'
+
+export interface LoggerShape {
+  readonly log: (
+    severity: LogSeverity,
+    message: string,
+    attributes?: LogAttributes
+  ) => Effect.Effect<void>
+}
+
+export class Logger extends Context.Service<Logger, LoggerShape>()('@gbfm/www/Logger') {}

--- a/apps/www/src/services/mix-upload-draft/storage.ts
+++ b/apps/www/src/services/mix-upload-draft/storage.ts
@@ -1,6 +1,7 @@
 import * as Context from 'effect/Context'
 import * as Effect from 'effect/Effect'
 import * as Layer from 'effect/Layer'
+import { log } from '@/services/logger'
 import { type MixUploadDraft, parseMixUploadDraft } from './types'
 
 const STORAGE_KEY = 'gbfm:mix-upload-draft:v1'
@@ -32,7 +33,7 @@ export const MixUploadDraftStorageLive = Layer.sync(MixUploadDraftStorage, () =>
       try {
         window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value))
       } catch (error) {
-        console.warn('MixUploadDraftStorage.write failed', error)
+        log('warn', 'MixUploadDraftStorage.write failed', { error })
       }
     }),
   clear: () =>

--- a/apps/www/src/services/resumable-upload/storage.ts
+++ b/apps/www/src/services/resumable-upload/storage.ts
@@ -1,6 +1,7 @@
 import * as Context from 'effect/Context'
 import * as Effect from 'effect/Effect'
 import * as Layer from 'effect/Layer'
+import { log } from '@/services/logger'
 import { parsePersistedUpload, type PersistedResumableUpload } from '@/lib/upload/resumable-upload'
 
 const KEY = (fingerprint: string) => `gbfm:resumable-upload:${fingerprint}`
@@ -32,7 +33,7 @@ export const ResumableUploadStorageLive = Layer.sync(ResumableUploadStorage, () 
       try {
         window.localStorage.setItem(KEY(value.fileFingerprint), JSON.stringify(value))
       } catch (error) {
-        console.warn('ResumableUploadStorage.write failed', error)
+        log('warn', 'ResumableUploadStorage.write failed', { error })
       }
     }),
   clear: (fingerprint: string) =>


### PR DESCRIPTION
## Summary

- Adds `apps/www/src/services/logger/` with a `Logger` Effect service plus sync helpers (`logDebug` / `logInfo` / `logWarn` / `logError`) that fan every call out to both `console.*` and `Sentry.logger.*`.
- Replaces 25 ad-hoc `console.*` call sites across components, routes, hooks, and storage services with the new logger.
- Enables Sentry's experimental Logs product (`enableLogs: true`) so `Sentry.logger.*` reaches the Sentry Logs UI. Errors are still serialized so they are useful, not opaque objects.
- Wires the new `LoggerLive` into the app runtime alongside the existing services, ready for the next step (routing `Effect.log*` through `Logger.layer`).

## Notes / follow-ups

- `tracesSampleRate: 1.0` is still set to 1.0 with the original "temporarily raised" comment. The trace investigation was outside the scope of this change.
- `consoleLoggingIntegration` was considered and skipped on purpose: our `Logger` already calls `console.*`, so installing the Sentry integration would double-log our own messages. We can add it back later with a smarter filter (or only enable it for third-party noise).
- Future Effect logger integration: the service methods return `Effect.Effect<void>` and the layer is already in the runtime. Wiring `Effect.log*` through `Logger.layer([Logger.consolePretty, sentryEffectLogger])` is a small follow-up that won't require touching call sites again.

## Verification

- `bun x oxfmt apps/www/src packages infra '*.{js,ts,tsx,jsx,json,css}' --check` — clean
- `bun x oxlint apps/*/src packages infra '*.{js,ts,tsx,jsx}'` — 0 warnings, 0 errors
- `tsgo --noEmit` and `bun --filter='*' typecheck` — green across all workspaces
- `bun run test:unit` — 107/107 passing (including the updated `http-client` test for the new `logError(error, context)` signature)