### PR TITLE
fix(www): resolve auth context before guarding routes and preserve redirect target

### DIFF
--- a/apps/www/src/lib/route-guards.ts
+++ b/apps/www/src/lib/route-guards.ts
@@ -1,0 +1,7 @@
+import { redirect } from '@tanstack/react-router'
+
+export const signInRedirect = (href: string) =>
+  redirect({
+    to: '/auth/sign-in',
+    search: { redirect: href }
+  })

--- a/apps/www/src/main.tsx
+++ b/apps/www/src/main.tsx
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRouter, RouterProvider } from '@tanstack/react-router'
+import { Loader2 } from 'lucide-react'
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { env } from '@/env'
@@ -80,7 +81,7 @@ if (env.sentryDsn && (!env.isDev || env.sentryEnableLocal)) {
 }
 
 function App() {
-  const { data: session } = useSession()
+  const { data: session, isPending } = useSession()
   const auth = {
     user: session?.user ?? null,
     isAuthenticated: Boolean(session?.user)
@@ -97,7 +98,13 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme='dark' storageKey='vite-ui-theme'>
-        <RouterProvider router={router} context={{ auth }} />
+        {isPending ? (
+          <div className='flex min-h-dvh items-center justify-center'>
+            <Loader2 className='h-6 w-6 animate-spin text-muted-foreground' />
+          </div>
+        ) : (
+          <RouterProvider router={router} context={{ auth }} />
+        )}
       </ThemeProvider>
     </QueryClientProvider>
   )

--- a/apps/www/src/routes/label-upload.tsx
+++ b/apps/www/src/routes/label-upload.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
+import { signInRedirect } from '@/lib/route-guards'
 
 export const Route = createFileRoute('/label-upload')({
-  beforeLoad: ({ context }) => {
+  beforeLoad: ({ context, location }) => {
     if (!context.auth.isAuthenticated) {
-      throw redirect({ to: '/auth/sign-in' })
+      throw signInRedirect(location.href)
     }
     if (context.auth.user?.role !== 'admin') {
       throw redirect({ to: '/' })

--- a/apps/www/src/routes/mix-upload.tsx
+++ b/apps/www/src/routes/mix-upload.tsx
@@ -1,9 +1,10 @@
-import { createFileRoute, redirect } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
+import { signInRedirect } from '@/lib/route-guards'
 
 export const Route = createFileRoute('/mix-upload')({
-  beforeLoad: ({ context }) => {
+  beforeLoad: ({ context, location }) => {
     if (!context.auth.isAuthenticated) {
-      throw redirect({ to: '/auth/sign-in' })
+      throw signInRedirect(location.href)
     }
   }
 })

--- a/apps/www/src/routes/new/editorial.tsx
+++ b/apps/www/src/routes/new/editorial.tsx
@@ -2,6 +2,7 @@
 
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { z } from 'zod'
+import { signInRedirect } from '@/lib/route-guards'
 import { EditorialPage } from './-EditorialPage'
 
 const searchSchema = z.object({
@@ -9,9 +10,9 @@ const searchSchema = z.object({
 })
 
 export const Route = createFileRoute('/new/editorial')({
-  beforeLoad: ({ context }) => {
+  beforeLoad: ({ context, location }) => {
     if (!context.auth.isAuthenticated) {
-      throw redirect({ to: '/auth/sign-in' })
+      throw signInRedirect(location.href)
     }
     if (context.auth.user?.role !== 'admin') {
       throw redirect({ to: '/' })

--- a/apps/www/src/routes/new/tweet.tsx
+++ b/apps/www/src/routes/new/tweet.tsx
@@ -2,6 +2,7 @@
 
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { z } from 'zod'
+import { signInRedirect } from '@/lib/route-guards'
 import { TweetCapturePage } from './-TweetCapturePage'
 
 const searchSchema = z.object({
@@ -9,9 +10,9 @@ const searchSchema = z.object({
 })
 
 export const Route = createFileRoute('/new/tweet')({
-  beforeLoad: ({ context }) => {
+  beforeLoad: ({ context, location }) => {
     if (!context.auth.isAuthenticated) {
-      throw redirect({ to: '/auth/sign-in' })
+      throw signInRedirect(location.href)
     }
     if (context.auth.user?.role !== 'admin') {
       throw redirect({ to: '/' })


### PR DESCRIPTION
## Problem

Two related auth-navigation bugs in `apps/www` (Vite SPA + TanStack Router + better-auth):

1. **Hard-loading a gated route while logged in wrongly bounces to sign-in.** `useSession()` is async, so on a fresh page load the router's `auth` context starts as `{ user: null, isAuthenticated: false }`. Route `beforeLoad` guards run immediately against that stale context and redirect to `/auth/sign-in`, even though the user has a valid session cookie.

2. **That redirect drops the originally-requested page.** `/auth/sign-in` already supports a `redirect` search param (via `safeRedirect`) and returns the user there after login, but the guards never populated it, so users always landed on `/`.

## Fix

- **Resolve auth before guarding.** `main.tsx` now reads `isPending` from `useSession()` and renders a minimal on-brand `Loader2` until the session settles, mounting `RouterProvider` only once the `auth` context is truthful. Guards never evaluate against an unhydrated context. Safe for this client-only SPA (no SSR).
- **Preserve the target page.** New helper `apps/www/src/lib/route-guards.ts` `signInRedirect(href)` throws `redirect({ to: '/auth/sign-in', search: { redirect: href } })`. The 4 guarded routes (`new/tweet`, `new/editorial`, `mix-upload`, `label-upload`) pass `location.href` in the not-authenticated branch only. Role-based `/` redirects are unchanged.

## Verify

- Logged-in hard load of `/new/tweet` no longer flashes/redirects to sign-in.
- Logged-out hard load of `/new/tweet` lands on sign-in with `?redirect=/new/tweet` and returns there after login.
- `bun precommit` passes (format + lint:fix + typecheck across all packages).

## Notes

- Branch is based on `prod`, so `new/tweet.tsx` here still uses the admin-only role check. A separate branch (`improve/tweet-edit-ux`) opens creation to creator/editor; the two touch different branches of the guard and merge cleanly.
