### PR TITLE
fix(dev): serve SPA auth pages on deep-link and trust localhost origin

### DIFF
--- a/apps/vps/src/lib/auth.ts
+++ b/apps/vps/src/lib/auth.ts
@@ -153,7 +153,9 @@ export const auth = betterAuth({
   trustedOrigins: [
     config.urls.frontend,
     'http://127.0.0.1:5173',
+    'http://localhost:5173',
     'http://127.0.0.1:3003',
+    'http://localhost:3003',
     'https://www.goosebumps.fm',
     'https://goosebumps.fm'
   ],

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from 'node:http'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'node:path'
@@ -13,6 +14,14 @@ const VPS_PROXY_TARGET = process.env.VITE_VPS_BASE_URL || 'http://127.0.0.1:3003
 const vpsProxy = {
   target: VPS_PROXY_TARGET,
   changeOrigin: true
+}
+
+const isDocumentRequest = (req: IncomingMessage) =>
+  typeof req.headers.accept === 'string' && req.headers.accept.includes('text/html')
+
+const authProxy = {
+  ...vpsProxy,
+  bypass: (req: IncomingMessage) => (isDocumentRequest(req) ? '/index.html' : undefined)
 }
 
 // https://vitejs.dev/config/
@@ -40,7 +49,7 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       '/api': vpsProxy,
-      '/auth': vpsProxy,
+      '/auth': authProxy,
       '/health': vpsProxy,
       '/rss.xml': vpsProxy,
       '/sitemap.xml': vpsProxy,


### PR DESCRIPTION
## Problem

Two dev-environment auth issues:

1. **Hard-loading an SPA auth page 404s.** The vite dev proxy blanket-forwards `/auth` to the API (better-auth). Opening `/auth/sign-in?redirect=...` directly (a browser document request) got proxied to the API, which has no such GET route, so it 404'd. In-app clicks worked because TanStack Router handles them client-side and never touch the proxy.

2. **Signing in from `localhost` fails with "Invalid origin".** `trustedOrigins` listed `127.0.0.1:5173` but not `localhost:5173`, so the `sign-in/email` POST from `http://localhost:5173` was rejected with 403.

## Fix

- **`apps/www/vite.config.ts`**: add a `bypass` to the `/auth` proxy. HTML document requests (browser navigation, `Accept: text/html`) serve `index.html` so the SPA renders the auth page; XHR/fetch (the better-auth client, `Accept: application/json`) still proxy to the API. The discriminator is the `Accept` header, which cleanly separates page loads from API calls.
- **`apps/vps/src/lib/auth.ts`**: add `http://localhost:5173` and `http://localhost:3003` to `trustedOrigins`.

## Prod is unaffected

- Prod serves the SPA via the SST `StaticSite` CDN, which does its own SPA fallback, and the auth client calls the VPS gateway **cross-origin** (`VITE_VPS_BASE_URL` is the gateway URL in prod, empty only in dev). So there is no `/auth` proxy in prod and no deep-link 404.
- The trusted-origins additions are `localhost` dev origins only; prod origins were already present.

## Verify

- `curl -H 'Accept: text/html' http://localhost:5173/auth/sign-in?redirect=/` -> 200 text/html (SPA).
- `curl -H 'Accept: application/json' http://localhost:5173/auth/get-session` -> 200 (still proxied to API).
- Sign-in from `http://localhost:5173` succeeds (no "Invalid origin").
