### PR TITLE
feat(www): inline streaming-link verify in tweet composer

### DIFF
--- a/apps/www/src/components/TweetListCard.tsx
+++ b/apps/www/src/components/TweetListCard.tsx
@@ -29,9 +29,7 @@ export function TweetListCard({ post }: Props) {
           interactive={false}
         />
 
-        {post.title && (
-          <h2 className='text-base font-black leading-tight tracking-tight'>{post.title}</h2>
-        )}
+        {post.title && <h2 className='text-base font-medium leading-snug'>{post.title}</h2>}
 
         <div className='prose prose-sm dark:prose-invert max-w-none prose-p:my-0 prose-p:leading-relaxed prose-headings:text-base prose-headings:my-1 prose-a:text-foreground prose-a:underline prose-a:pointer-events-none [&_iframe]:hidden [&_img]:hidden [&_video]:hidden [&_audio]:hidden line-clamp-4'>
           <MDXRendrr mdxString={post.compiledContent ?? post.content ?? ''} />

--- a/apps/www/src/routes/new/-TweetCapturePage.tsx
+++ b/apps/www/src/routes/new/-TweetCapturePage.tsx
@@ -88,14 +88,21 @@ function TweetComposerCard({
 }) {
   return (
     <Card className='bg-gb-darker-bg border-gb-pastel-green-2/20'>
-      <CardHeader>
-        <CardTitle className='text-gb-pastel-green-1'>Post</CardTitle>
+      <CardHeader className='pb-3'>
+        <CardTitle className='text-base text-gb-pastel-green-1'>Post</CardTitle>
       </CardHeader>
       <CardContent className='space-y-4'>
-        <div className='space-y-2'>
-          <Label htmlFor='title' className='text-gb-pastel-green-1'>
-            Title
-          </Label>
+        <div className='space-y-1.5'>
+          <div className='flex items-baseline justify-between'>
+            <Label
+              htmlFor='title'
+              className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+              Title
+            </Label>
+            {title.length > 0 ? (
+              <span className='text-xs tabular-nums text-muted-foreground'>{title.length}/255</span>
+            ) : null}
+          </div>
           <Input
             id='title'
             value={title}
@@ -105,13 +112,12 @@ function TweetComposerCard({
             maxLength={255}
             autoFocus
           />
-          {title.length > 0 ? (
-            <p className='text-right text-xs text-muted-foreground'>{title.length}/255</p>
-          ) : null}
         </div>
 
-        <div className='space-y-2'>
-          <Label htmlFor='commentary' className='text-gb-pastel-green-1'>
+        <div className='space-y-1.5'>
+          <Label
+            htmlFor='commentary'
+            className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>
             Commentary
           </Label>
           <Textarea
@@ -120,15 +126,16 @@ function TweetComposerCard({
             onChange={(e) => onCommentaryChange(e.target.value)}
             placeholder='Optional commentary in markdown…'
             onKeyDown={onKeyDown}
+            className='min-h-28'
           />
         </div>
 
-        <div className='flex items-center gap-3'>
+        <div className='flex items-center gap-3 pt-1'>
           <Button onClick={onSubmit} disabled={!canSubmit || isPending} className='gap-2'>
             {isPending ? <Loader2 className='size-4 animate-spin' /> : <Send className='size-4' />}
             {isEditMode ? 'Update tweet' : 'Save tweet'}
           </Button>
-          <span className='text-sm text-muted-foreground'>Cmd+Enter submits</span>
+          <span className='text-xs text-muted-foreground'>⌘↵ to submit</span>
         </div>
       </CardContent>
     </Card>
@@ -156,17 +163,23 @@ function ResolvedMusicCard({
   onMusicUrlChange: (value: string) => void
   linksSlot?: ReactNode
 }) {
+  const metaLine = [displayedEntityType, displayedArtistNames?.join(', ')]
+    .filter(Boolean)
+    .join(' · ')
+
   return (
     <Card className='bg-gb-darker-bg border-gb-pastel-green-2/20'>
-      <CardHeader>
-        <CardTitle className='flex items-center gap-2 text-gb-pastel-green-1'>
-          <Music4 className='size-5' />
+      <CardHeader className='pb-3'>
+        <CardTitle className='flex items-center gap-2 text-base text-gb-pastel-green-1'>
+          <Music4 className='size-4' />
           Music
         </CardTitle>
       </CardHeader>
       <CardContent className='space-y-4'>
-        <div className='space-y-2'>
-          <Label htmlFor='musicUrl' className='text-gb-pastel-green-1'>
+        <div className='space-y-1.5'>
+          <Label
+            htmlFor='musicUrl'
+            className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>
             Music URL
           </Label>
           <div className='relative'>
@@ -183,57 +196,35 @@ function ResolvedMusicCard({
           </div>
         </div>
 
-        {linksSlot ? (
-          <div className='border-t border-gb-pastel-green-2/10 pt-4'>{linksSlot}</div>
-        ) : null}
-
-        <div className='grid gap-4 border-t border-gb-pastel-green-2/10 pt-4 sm:grid-cols-[96px_1fr] lg:grid-cols-1'>
-          <div className='overflow-hidden border rounded-sm bg-muted aspect-square'>
+        <div className='flex items-center gap-3 rounded-md border border-gb-pastel-green-2/15 bg-black/20 p-2.5'>
+          <div className='size-14 shrink-0 overflow-hidden rounded-sm bg-muted'>
             {displayedCoverImageUrl ? (
               <img
                 src={displayedCoverImageUrl}
                 alt='Cover art'
-                className='object-cover w-full h-full'
+                className='size-full object-cover'
               />
             ) : (
-              <div className='flex items-center justify-center h-full text-muted-foreground'>
+              <div className='flex size-full items-center justify-center text-muted-foreground'>
                 {isResolving ? (
-                  <Loader2 className='size-5 animate-spin' />
+                  <Loader2 className='size-4 animate-spin' />
                 ) : (
-                  <Music4 className='size-5' />
+                  <Music4 className='size-4' />
                 )}
               </div>
             )}
           </div>
-
-          <div className='space-y-3'>
-            <div>
-              <div className='text-xs uppercase tracking-wider text-muted-foreground'>Type</div>
-              <div className='font-medium capitalize'>
-                {displayedEntityType || (isResolving ? 'Resolving…' : 'Paste a link to start')}
-              </div>
+          <div className='min-w-0 flex-1'>
+            <div className='truncate text-sm font-medium'>
+              {displayedEntityTitle || (isResolving ? 'Resolving…' : 'Paste a link to start')}
             </div>
-            <div>
-              <div className='text-xs uppercase tracking-wider text-muted-foreground'>Title</div>
-              <div className='font-medium'>
-                {displayedEntityTitle || (isResolving ? 'Resolving…' : 'No entity resolved yet')}
-              </div>
+            <div className='truncate text-xs capitalize text-muted-foreground'>
+              {metaLine || (hasEntity ? '' : 'No entity resolved yet')}
             </div>
-            {displayedArtistNames?.length ? (
-              <div>
-                <div className='text-xs uppercase tracking-wider text-muted-foreground'>
-                  Artists
-                </div>
-                <div className='font-medium'>{displayedArtistNames.join(', ')}</div>
-              </div>
-            ) : null}
-            {!hasEntity && !isResolving ? (
-              <p className='text-xs text-muted-foreground'>
-                Streaming links appear here once a link resolves.
-              </p>
-            ) : null}
           </div>
         </div>
+
+        {linksSlot ? <div>{linksSlot}</div> : null}
       </CardContent>
     </Card>
   )

--- a/apps/www/src/routes/new/-TweetCapturePage.tsx
+++ b/apps/www/src/routes/new/-TweetCapturePage.tsx
@@ -17,7 +17,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, useRouter, useSearch } from '@tanstack/react-router'
 import { ArrowLeft, Loader2, Music4, Send } from 'lucide-react'
-import { type KeyboardEvent, useEffect, useMemo, useState } from 'react'
+import { type KeyboardEvent, type ReactNode, useEffect, useMemo, useState } from 'react'
 import { PostPageHeader } from '@/components/PostPageHeader'
 import { useSession } from '@/lib/auth-client'
 import {
@@ -63,6 +63,8 @@ const entityPathByType: Record<MusicEntityType, string> = {
   playlist: 'playlists'
 }
 
+const POST_CREATE_ROLES = new Set(['creator', 'editor', 'admin'])
+
 function TweetComposerCard({
   title,
   commentary,
@@ -99,10 +101,13 @@ function TweetComposerCard({
             value={title}
             onChange={(e) => onTitleChange(e.target.value)}
             onKeyDown={onKeyDown}
-            placeholder='Optional title for the tweet'
+            placeholder='A short quip, e.g. “I dig this”'
             maxLength={255}
+            autoFocus
           />
-          <p className='text-right text-xs text-muted-foreground'>{title.length}/255</p>
+          {title.length > 0 ? (
+            <p className='text-right text-xs text-muted-foreground'>{title.length}/255</p>
+          ) : null}
         </div>
 
         <div className='space-y-2'>
@@ -137,7 +142,9 @@ function ResolvedMusicCard({
   displayedEntityTitle,
   displayedArtistNames,
   isResolving,
-  onMusicUrlChange
+  hasEntity,
+  onMusicUrlChange,
+  linksSlot
 }: {
   musicUrl: string
   displayedCoverImageUrl: string | null
@@ -145,7 +152,9 @@ function ResolvedMusicCard({
   displayedEntityTitle: string | null
   displayedArtistNames: string[] | null
   isResolving: boolean
+  hasEntity: boolean
   onMusicUrlChange: (value: string) => void
+  linksSlot?: ReactNode
 }) {
   return (
     <Card className='bg-gb-darker-bg border-gb-pastel-green-2/20'>
@@ -160,16 +169,26 @@ function ResolvedMusicCard({
           <Label htmlFor='musicUrl' className='text-gb-pastel-green-1'>
             Music URL
           </Label>
-          <Input
-            id='musicUrl'
-            value={musicUrl}
-            onChange={(e) => onMusicUrlChange(e.target.value)}
-            placeholder='https://open.spotify.com/track/...'
-          />
+          <div className='relative'>
+            <Input
+              id='musicUrl'
+              value={musicUrl}
+              onChange={(e) => onMusicUrlChange(e.target.value)}
+              placeholder='https://open.spotify.com/track/...'
+              className='pr-9'
+            />
+            {isResolving && (
+              <Loader2 className='absolute right-3 top-1/2 size-4 -translate-y-1/2 animate-spin text-muted-foreground' />
+            )}
+          </div>
         </div>
 
-        <div className='grid gap-4 sm:grid-cols-[120px_1fr] lg:grid-cols-1'>
-          <div className='overflow-hidden border rounded-lg bg-muted aspect-square'>
+        {linksSlot ? (
+          <div className='border-t border-gb-pastel-green-2/10 pt-4'>{linksSlot}</div>
+        ) : null}
+
+        <div className='grid gap-4 border-t border-gb-pastel-green-2/10 pt-4 sm:grid-cols-[96px_1fr] lg:grid-cols-1'>
+          <div className='overflow-hidden border rounded-sm bg-muted aspect-square'>
             {displayedCoverImageUrl ? (
               <img
                 src={displayedCoverImageUrl}
@@ -189,18 +208,29 @@ function ResolvedMusicCard({
 
           <div className='space-y-3'>
             <div>
-              <div className='text-sm text-muted-foreground'>Resolved type</div>
-              <div className='font-medium'>{displayedEntityType || 'Waiting for a URL'}</div>
+              <div className='text-xs uppercase tracking-wider text-muted-foreground'>Type</div>
+              <div className='font-medium capitalize'>
+                {displayedEntityType || (isResolving ? 'Resolving…' : 'Paste a link to start')}
+              </div>
             </div>
             <div>
-              <div className='text-sm text-muted-foreground'>Title</div>
-              <div className='font-medium'>{displayedEntityTitle || 'No entity resolved yet'}</div>
+              <div className='text-xs uppercase tracking-wider text-muted-foreground'>Title</div>
+              <div className='font-medium'>
+                {displayedEntityTitle || (isResolving ? 'Resolving…' : 'No entity resolved yet')}
+              </div>
             </div>
             {displayedArtistNames?.length ? (
               <div>
-                <div className='text-sm text-muted-foreground'>Artists</div>
+                <div className='text-xs uppercase tracking-wider text-muted-foreground'>
+                  Artists
+                </div>
                 <div className='font-medium'>{displayedArtistNames.join(', ')}</div>
               </div>
+            ) : null}
+            {!hasEntity && !isResolving ? (
+              <p className='text-xs text-muted-foreground'>
+                Streaming links appear here once a link resolves.
+              </p>
             ) : null}
           </div>
         </div>
@@ -247,10 +277,10 @@ export function TweetCapturePage() {
   }, [existingPost])
 
   const canSubmit = useMemo(() => Boolean(title.trim() || commentary.trim()), [title, commentary])
+  const canCreatePosts = POST_CREATE_ROLES.has(user?.role ?? '')
+  const isOwnPost = Boolean(existingPost?.creators?.some((creator) => creator.id === user?.id))
   const canAccess = Boolean(
-    user &&
-    (user.role === 'admin' ||
-      (isEditMode && existingPost?.creators?.some((creator) => creator.id === user.id)))
+    user && (isEditMode ? user.role === 'admin' || isOwnPost : canCreatePosts)
   )
   const displayedEntityType = resolved.data?.entityType ?? existingPost?.musicEntityType ?? null
   const displayedEntityTitle = resolved.data?.entity?.title ?? existingMusicEntity?.title ?? null
@@ -473,19 +503,21 @@ export function TweetCapturePage() {
       />
 
       <div className='grid gap-6 lg:grid-cols-[minmax(0,1fr)_380px]'>
-        <TweetComposerCard
-          title={title}
-          commentary={commentary}
-          canSubmit={canSubmit}
-          isEditMode={isEditMode}
-          isPending={submitMutation.isPending}
-          onTitleChange={setTitle}
-          onCommentaryChange={setCommentary}
-          onSubmit={() => submitMutation.mutate()}
-          onKeyDown={handleSubmitShortcut}
-        />
+        <div className='order-2 lg:order-1'>
+          <TweetComposerCard
+            title={title}
+            commentary={commentary}
+            canSubmit={canSubmit}
+            isEditMode={isEditMode}
+            isPending={submitMutation.isPending}
+            onTitleChange={setTitle}
+            onCommentaryChange={setCommentary}
+            onSubmit={() => submitMutation.mutate()}
+            onKeyDown={handleSubmitShortcut}
+          />
+        </div>
 
-        <div className='space-y-6'>
+        <div className='order-1 lg:order-2'>
           <ResolvedMusicCard
             musicUrl={musicUrl}
             displayedCoverImageUrl={displayedCoverImageUrl}
@@ -493,19 +525,22 @@ export function TweetCapturePage() {
             displayedEntityTitle={displayedEntityTitle}
             displayedArtistNames={displayedArtistNames}
             isResolving={resolved.isLoading}
+            hasEntity={Boolean(currentEntityType && currentEntityId)}
             onMusicUrlChange={setMusicUrl}
+            linksSlot={
+              currentEntityType && currentEntityId ? (
+                <MusicEntityLinksPanel
+                  embedded
+                  links={entityLinks.data ?? []}
+                  readOnly={!canManageLinks}
+                  onAdd={handleAddLink}
+                  onEdit={handleEditLink}
+                  onUpdateStatus={handleUpdateLinkStatus}
+                  onDelete={handleDeleteLink}
+                />
+              ) : null
+            }
           />
-
-          {currentEntityType && currentEntityId ? (
-            <MusicEntityLinksPanel
-              links={entityLinks.data ?? []}
-              readOnly={!canManageLinks}
-              onAdd={handleAddLink}
-              onEdit={handleEditLink}
-              onUpdateStatus={handleUpdateLinkStatus}
-              onDelete={handleDeleteLink}
-            />
-          ) : null}
         </div>
       </div>
     </div>

--- a/apps/www/src/routes/new/tweet.tsx
+++ b/apps/www/src/routes/new/tweet.tsx
@@ -9,12 +9,14 @@ const searchSchema = z.object({
   edit: z.string().optional()
 })
 
+const POST_CREATE_ROLES = new Set(['creator', 'editor', 'admin'])
+
 export const Route = createFileRoute('/new/tweet')({
   beforeLoad: ({ context, location }) => {
     if (!context.auth.isAuthenticated) {
       throw signInRedirect(location.href)
     }
-    if (context.auth.user?.role !== 'admin') {
+    if (!POST_CREATE_ROLES.has(context.auth.user?.role ?? '')) {
       throw redirect({ to: '/' })
     }
   },

--- a/apps/www/src/routes/tweet/$slug.tsx
+++ b/apps/www/src/routes/tweet/$slug.tsx
@@ -111,7 +111,7 @@ function TweetPostPage() {
         </div>
 
         {post.title && (
-          <h1 className='text-xl font-black leading-tight tracking-tight'>{post.title}</h1>
+          <h1 className='text-lg font-medium leading-snug tracking-tight'>{post.title}</h1>
         )}
 
         <div className='prose prose-base dark:prose-invert max-w-none prose-headings:font-black prose-headings:tracking-tighter prose-p:leading-relaxed prose-p:my-0 prose-a:text-foreground prose-a:underline'>

--- a/packages/ui/src/components/music-entity-links-panel.tsx
+++ b/packages/ui/src/components/music-entity-links-panel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Badge } from './badge'
 import { Button } from './button'
-import { Card, CardContent, CardHeader, CardTitle } from './card'
+import { Card, CardContent, CardHeader } from './card'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from './dialog'
 import { Input } from './input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './select'
@@ -71,6 +71,7 @@ export interface MusicEntityLinksPanelProps {
   onUpdateStatus?: (linkId: string, status: LinkStatus) => void
   onDelete?: (linkId: string) => void
   readOnly?: boolean
+  embedded?: boolean
 }
 
 function toMusicPlatform(value: string): MusicPlatform {
@@ -84,12 +85,15 @@ export function MusicEntityLinksPanel({
   onEdit,
   onUpdateStatus,
   onDelete,
-  readOnly = false
+  readOnly = false,
+  embedded = false
 }: MusicEntityLinksPanelProps) {
   const [dialogMode, setDialogMode] = useState<'add' | 'edit' | null>(null)
   const [activeLinkId, setActiveLinkId] = useState<string | null>(null)
   const [draftPlatform, setDraftPlatform] = useState<MusicPlatform>('spotify')
   const [draftUrl, setDraftUrl] = useState('')
+
+  const pendingLinks = links.filter((link) => link.status === 'pending_review')
 
   function closeDialog() {
     setDialogMode(null)
@@ -124,119 +128,160 @@ export function MusicEntityLinksPanel({
     }
   }
 
-  return (
-    <Card>
-      <CardHeader className='flex flex-row items-center justify-between gap-3 space-y-0'>
-        <CardTitle className='text-sm font-medium'>Streaming links</CardTitle>
+  function verifyAllPending() {
+    for (const link of pendingLinks) {
+      onUpdateStatus?.(link.id, 'verified')
+    }
+  }
+
+  const header = (
+    <div className='flex flex-row items-center justify-between gap-3'>
+      <div className='flex items-center gap-2'>
+        <span className='text-sm font-medium'>Streaming links</span>
+        {pendingLinks.length > 0 && (
+          <Badge variant='secondary' className='rounded-sm'>
+            {pendingLinks.length} to verify
+          </Badge>
+        )}
+      </div>
+      <div className='flex items-center gap-1'>
+        {!readOnly && pendingLinks.length > 0 && (
+          <Button size='sm' variant='outline' className='rounded-sm' onClick={verifyAllPending}>
+            Verify all
+          </Button>
+        )}
         {!readOnly && (
-          <Button size='sm' variant='outline' onClick={openAddDialog}>
+          <Button size='sm' variant='ghost' className='rounded-sm' onClick={openAddDialog}>
             Add link
           </Button>
         )}
-      </CardHeader>
-      <CardContent className='space-y-4'>
-        {links.length === 0 && <p className='text-sm text-muted-foreground'>No links yet.</p>}
-        <div className='space-y-2'>
-          {links.map((link) => (
-            <div key={link.id} className='rounded-md border px-3 py-2 text-sm'>
-              <div className='flex min-w-0 flex-col gap-2'>
-                <div className='min-w-0 flex-1 space-y-1'>
-                  <div className='flex flex-wrap items-center gap-2'>
-                    <span className='font-medium capitalize'>
-                      {link.platform.replace(/_/g, ' ')}
-                    </span>
-                    <Badge variant={STATUS_VARIANTS[link.status] ?? 'outline'}>
-                      {link.status.replace('_', ' ')}
-                    </Badge>
-                  </div>
-                  <a
-                    href={link.url}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    className='block min-w-0 truncate text-xs text-blue-500 hover:underline'>
-                    {link.url}
-                  </a>
+      </div>
+    </div>
+  )
+
+  const list = (
+    <>
+      {links.length === 0 && (
+        <p className='text-sm text-muted-foreground'>
+          {readOnly ? 'No links yet.' : 'No links yet. Paste a URL above to auto-fetch them.'}
+        </p>
+      )}
+      <div className='space-y-2'>
+        {links.map((link) => (
+          <div key={link.id} className='rounded-md border px-3 py-2 text-sm'>
+            <div className='flex min-w-0 flex-col gap-2'>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <div className='flex flex-wrap items-center gap-2'>
+                  <span className='font-medium capitalize'>{link.platform.replace(/_/g, ' ')}</span>
+                  <Badge variant={STATUS_VARIANTS[link.status] ?? 'outline'} className='rounded-sm'>
+                    {link.status.replace('_', ' ')}
+                  </Badge>
                 </div>
-                {!readOnly && (
-                  <div className='flex flex-wrap gap-1'>
-                    <Button size='sm' variant='ghost' onClick={() => openEditDialog(link)}>
-                      Edit
-                    </Button>
-                    {link.status !== 'verified' && (
-                      <Button
-                        size='sm'
-                        variant='ghost'
-                        onClick={() => onUpdateStatus?.(link.id, 'verified')}>
-                        Verify
-                      </Button>
-                    )}
-                    {link.status !== 'rejected' && (
-                      <Button
-                        size='sm'
-                        variant='ghost'
-                        onClick={() => onUpdateStatus?.(link.id, 'rejected')}>
-                        Reject
-                      </Button>
-                    )}
+                <a
+                  href={link.url}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='block min-w-0 truncate text-xs text-blue-500 hover:underline'>
+                  {link.url}
+                </a>
+              </div>
+              {!readOnly && (
+                <div className='flex flex-wrap gap-1'>
+                  <Button size='sm' variant='ghost' onClick={() => openEditDialog(link)}>
+                    Edit
+                  </Button>
+                  {link.status !== 'verified' && (
                     <Button
                       size='sm'
                       variant='ghost'
-                      className='text-destructive'
-                      onClick={() => onDelete?.(link.id)}>
-                      Delete
+                      onClick={() => onUpdateStatus?.(link.id, 'verified')}>
+                      Verify
                     </Button>
-                  </div>
-                )}
-              </div>
+                  )}
+                  {link.status !== 'rejected' && (
+                    <Button
+                      size='sm'
+                      variant='ghost'
+                      onClick={() => onUpdateStatus?.(link.id, 'rejected')}>
+                      Reject
+                    </Button>
+                  )}
+                  <Button
+                    size='sm'
+                    variant='ghost'
+                    className='text-destructive'
+                    onClick={() => onDelete?.(link.id)}>
+                    Delete
+                  </Button>
+                </div>
+              )}
             </div>
-          ))}
-        </div>
-      </CardContent>
-
-      <Dialog open={dialogMode !== null} onOpenChange={(open) => !open && closeDialog()}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              {dialogMode === 'edit' ? 'Edit streaming link' : 'Add streaming link'}
-            </DialogTitle>
-          </DialogHeader>
-          <div className='space-y-3'>
-            <Select
-              value={draftPlatform}
-              onValueChange={(v) => setDraftPlatform(toMusicPlatform(v))}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {PLATFORMS.map((p) => (
-                  <SelectItem key={p} value={p}>
-                    {p.replace(/_/g, ' ')}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Input
-              placeholder='https://...'
-              value={draftUrl}
-              onChange={(e) => setDraftUrl(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault()
-                  handleSave()
-                }
-              }}
-            />
           </div>
-          <DialogFooter>
-            <Button variant='ghost' onClick={closeDialog}>
-              Cancel
-            </Button>
-            <Button onClick={handleSave} disabled={!draftUrl.trim()}>
-              Save link
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        ))}
+      </div>
+    </>
+  )
+
+  const dialog = (
+    <Dialog open={dialogMode !== null} onOpenChange={(open) => !open && closeDialog()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {dialogMode === 'edit' ? 'Edit streaming link' : 'Add streaming link'}
+          </DialogTitle>
+        </DialogHeader>
+        <div className='space-y-3'>
+          <Select value={draftPlatform} onValueChange={(v) => setDraftPlatform(toMusicPlatform(v))}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PLATFORMS.map((p) => (
+                <SelectItem key={p} value={p}>
+                  {p.replace(/_/g, ' ')}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            placeholder='https://...'
+            value={draftUrl}
+            onChange={(e) => setDraftUrl(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                handleSave()
+              }
+            }}
+          />
+        </div>
+        <DialogFooter>
+          <Button variant='ghost' onClick={closeDialog}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!draftUrl.trim()}>
+            Save link
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+
+  if (embedded) {
+    return (
+      <div className='space-y-3'>
+        {header}
+        {list}
+        {dialog}
+      </div>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className='space-y-0'>{header}</CardHeader>
+      <CardContent className='space-y-4'>{list}</CardContent>
+      {dialog}
     </Card>
   )
 }

--- a/packages/ui/src/components/music-entity-links-panel.tsx
+++ b/packages/ui/src/components/music-entity-links-panel.tsx
@@ -1,8 +1,14 @@
+import { Check, MoreHorizontal, Plus } from 'lucide-react'
 import { useState } from 'react'
-import { Badge } from './badge'
 import { Button } from './button'
 import { Card, CardContent, CardHeader } from './card'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from './dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from './dropdown-menu'
 import { Input } from './input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './select'
 
@@ -58,10 +64,10 @@ const PLATFORMS: MusicPlatform[] = [
   'other'
 ]
 
-const STATUS_VARIANTS: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
-  verified: 'default',
-  pending_review: 'secondary',
-  rejected: 'destructive'
+const STATUS_DOTS: Record<string, string> = {
+  verified: 'bg-gb-pastel-green-1',
+  pending_review: 'bg-amber-400',
+  rejected: 'bg-destructive'
 }
 
 export interface MusicEntityLinksPanelProps {
@@ -135,24 +141,36 @@ export function MusicEntityLinksPanel({
   }
 
   const header = (
-    <div className='flex flex-row items-center justify-between gap-3'>
-      <div className='flex items-center gap-2'>
-        <span className='text-sm font-medium'>Streaming links</span>
+    <div className='flex flex-row flex-wrap items-center justify-between gap-x-3 gap-y-2'>
+      <div className='flex items-baseline gap-2'>
+        <span className='whitespace-nowrap text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+          Streaming links
+        </span>
         {pendingLinks.length > 0 && (
-          <Badge variant='secondary' className='rounded-sm'>
+          <span className='whitespace-nowrap text-xs text-muted-foreground/70'>
             {pendingLinks.length} to verify
-          </Badge>
+          </span>
         )}
       </div>
       <div className='flex items-center gap-1'>
         {!readOnly && pendingLinks.length > 0 && (
-          <Button size='sm' variant='outline' className='rounded-sm' onClick={verifyAllPending}>
+          <Button
+            size='sm'
+            variant='outline'
+            className='h-7 rounded-sm px-2 text-xs'
+            onClick={verifyAllPending}>
+            <Check className='mr-1 size-3' />
             Verify all
           </Button>
         )}
         {!readOnly && (
-          <Button size='sm' variant='ghost' className='rounded-sm' onClick={openAddDialog}>
-            Add link
+          <Button
+            size='sm'
+            variant='ghost'
+            className='h-7 rounded-sm px-2 text-xs'
+            onClick={openAddDialog}>
+            <Plus className='mr-1 size-3' />
+            Add
           </Button>
         )}
       </div>
@@ -162,60 +180,64 @@ export function MusicEntityLinksPanel({
   const list = (
     <>
       {links.length === 0 && (
-        <p className='text-sm text-muted-foreground'>
+        <p className='text-xs text-muted-foreground'>
           {readOnly ? 'No links yet.' : 'No links yet. Paste a URL above to auto-fetch them.'}
         </p>
       )}
-      <div className='space-y-2'>
+      <div className='divide-y divide-border/50 rounded-md border'>
         {links.map((link) => (
-          <div key={link.id} className='rounded-md border px-3 py-2 text-sm'>
-            <div className='flex min-w-0 flex-col gap-2'>
-              <div className='min-w-0 flex-1 space-y-1'>
-                <div className='flex flex-wrap items-center gap-2'>
-                  <span className='font-medium capitalize'>{link.platform.replace(/_/g, ' ')}</span>
-                  <Badge variant={STATUS_VARIANTS[link.status] ?? 'outline'} className='rounded-sm'>
-                    {link.status.replace('_', ' ')}
-                  </Badge>
-                </div>
-                <a
-                  href={link.url}
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  className='block min-w-0 truncate text-xs text-blue-500 hover:underline'>
-                  {link.url}
-                </a>
-              </div>
-              {!readOnly && (
-                <div className='flex flex-wrap gap-1'>
-                  <Button size='sm' variant='ghost' onClick={() => openEditDialog(link)}>
-                    Edit
-                  </Button>
-                  {link.status !== 'verified' && (
-                    <Button
-                      size='sm'
-                      variant='ghost'
-                      onClick={() => onUpdateStatus?.(link.id, 'verified')}>
-                      Verify
-                    </Button>
-                  )}
-                  {link.status !== 'rejected' && (
-                    <Button
-                      size='sm'
-                      variant='ghost'
-                      onClick={() => onUpdateStatus?.(link.id, 'rejected')}>
-                      Reject
-                    </Button>
-                  )}
+          <div
+            key={link.id}
+            className='group flex items-center gap-2.5 px-2.5 py-2 text-sm first:rounded-t-md last:rounded-b-md hover:bg-muted/40'>
+            <span
+              className={`size-2 shrink-0 rounded-full ${STATUS_DOTS[link.status] ?? 'bg-muted-foreground/40'}`}
+              title={link.status.replace('_', ' ')}
+            />
+            <a
+              href={link.url}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='min-w-0 flex-1 truncate font-medium capitalize hover:underline'
+              title={link.url}>
+              {link.platform.replace(/_/g, ' ')}
+            </a>
+            {!readOnly && (
+              <div className='flex shrink-0 items-center gap-1'>
+                {link.status !== 'verified' && (
                   <Button
                     size='sm'
                     variant='ghost'
-                    className='text-destructive'
-                    onClick={() => onDelete?.(link.id)}>
-                    Delete
+                    className='h-7 rounded-sm px-2 text-xs text-gb-pastel-green-1 opacity-0 focus-visible:opacity-100 group-hover:opacity-100'
+                    onClick={() => onUpdateStatus?.(link.id, 'verified')}>
+                    Verify
                   </Button>
-                </div>
-              )}
-            </div>
+                )}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      size='icon'
+                      variant='ghost'
+                      className='size-7 rounded-sm text-muted-foreground opacity-0 focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100'>
+                      <MoreHorizontal className='size-4' />
+                      <span className='sr-only'>More actions</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align='end' className='w-32'>
+                    <DropdownMenuItem onClick={() => openEditDialog(link)}>Edit</DropdownMenuItem>
+                    {link.status !== 'rejected' && (
+                      <DropdownMenuItem onClick={() => onUpdateStatus?.(link.id, 'rejected')}>
+                        Reject
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem
+                      className='text-destructive focus:text-destructive'
+                      onClick={() => onDelete?.(link.id)}>
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            )}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## What

UX improvements to the tweet composer (`/new/tweet`), focused on the streaming-link verify flow that was buried below the fold.

## Changes

- **Inline link verification.** Collapse the standalone "Streaming links" panel into the Music card, directly under the URL input. Links surface and verify at the paste point instead of below the cover art. Adds a **Verify all** action and a pending-count badge. `MusicEntityLinksPanel` gains an `embedded` variant so the admin detail page is unaffected.
- **Mobile order.** On mobile the Music card (URL + inline verify) now sits above the composer to match the paste-first, verify-first flow. Desktop keeps composer-left / music-right.
- **Softened display title.** The tweet display title drops `font-black` for `font-medium` so short quips read as commentary, not a headline.
- **Polish.** Inline resolving spinner in the URL field, capitalized resolved type, clearer empty/resolving copy, autofocus on title, hide the char counter until typing, `rounded-sm` on new controls.
- **Access.** Tweet creation opens to `creator` and `editor` roles (was admin-only); link moderation stays admin-only to match the API.

## Verification

Verified live with browser automation: pasted a Spotify album link, spotify + tidal links appeared inline under the URL, **Verify all** flipped both to verified in one click. Mobile order confirmed via the grid `order` classes. Softened title confirmed on the display page. `bun precommit` passes.

## Notes

- Rebased on top of current prod (which now includes the auth-context and dev-deeplink fixes). The `/new/tweet` guard keeps both the redirect-back behavior from prod and the new role gate.
