### PR TITLE
fix(www): render artwork in WebKit tweet exports

### DIFF
--- a/apps/www/src/components/tweet-export/TweetDownloadDialog.tsx
+++ b/apps/www/src/components/tweet-export/TweetDownloadDialog.tsx
@@ -18,6 +18,11 @@ import { PosterFrame, SleeveFrame, type TweetExportData } from './frames'
 
 const EXPORT_WIDTH = 540
 
+const isWebKit = () =>
+  typeof navigator !== 'undefined' &&
+  /AppleWebKit/.test(navigator.userAgent) &&
+  !/Chrome\//.test(navigator.userAgent)
+
 const formats = [
   { key: 'poster', name: 'poster', Frame: PosterFrame },
   { key: 'sleeve', name: 'sleeve', Frame: SleeveFrame }
@@ -71,10 +76,17 @@ export function TweetDownloadDialog({ post, slug, open, onOpenChange }: Props) {
     setDownloading(true)
     setError(null)
     try {
-      const dataUrl = await toPng(exportRef.current, {
+      const options = {
         pixelRatio: 1080 / EXPORT_WIDTH,
         cacheBust: true
-      })
+      }
+      // WebKit rasterizes the first toPng before embedded images finish
+      // decoding, dropping the artwork; warm-up renders work around it
+      if (isWebKit()) {
+        await toPng(exportRef.current, options)
+        await toPng(exportRef.current, options)
+      }
+      const dataUrl = await toPng(exportRef.current, options)
       const link = document.createElement('a')
       link.href = dataUrl
       link.download = `${slug}-${format}.png`


### PR DESCRIPTION
## Problem
On iOS Safari, "download for socials" produced a PNG without the music entity artwork.

## Root cause
WebKit rasterizes html-to-image's first `toPng` pass before images embedded in the SVG foreignObject finish decoding. First export drops the artwork; subsequent renders are correct. Not CORS: `cacheBust` gives each attempt a unique URL, and only attempt 1 failed.

Verified with a pixel-diff harness (real CDN cover, same lib version and options):

| Engine | attempt 1 | attempt 2 | attempt 3 |
|---|---|---|---|
| Chromium | pass | pass | pass |
| Desktop Safari | fail (blank) | pass | pass |
| iOS Simulator Safari | fail (blank) | pass | pass |

## Fix
Two warm-up `toPng` renders before the real export on WebKit browsers (all iOS browsers + desktop Safari), detected via user agent. Adds ~1s to export on WebKit, no change elsewhere.

## Validation
- typecheck + oxfmt clean
- e2e: dev app driven headlessly, dialog export downloads a PNG with artwork present
- no regression seam in CI: repo playwright has no WebKit browser installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N27hN1p1WPHzzHwbi7nrXX