### PR TITLE
feat(vps): add granular OTEL spans to slow trace paths

### DIFF
--- a/apps/vps/src/db/index.ts
+++ b/apps/vps/src/db/index.ts
@@ -18,7 +18,9 @@ const dbConfig = {
   user: config.database.user,
   password: config.database.password,
   database: config.database.name,
-  ssl: sslConfig
+  ssl: sslConfig,
+  min: 1,
+  idleTimeoutMillis: 10 * 60 * 1000
 }
 
 console.log(

--- a/apps/vps/src/lib/mdx.ts
+++ b/apps/vps/src/lib/mdx.ts
@@ -44,7 +44,12 @@ const makeService = (fn: (content: string) => Promise<string>): Effect.Effect<Md
       timeToLive: ttl
     })
     return MdxService.of({
-      compile: (content) => Cache.get(cache, content),
+      compile: (content) =>
+        Cache.get(cache, content).pipe(
+          Effect.withSpan('mdx.compile', {
+            attributes: { 'mdx.contentLength': content.length }
+          })
+        ),
       invalidateAll: () => Cache.invalidateAll(cache)
     })
   })

--- a/apps/vps/src/services/music-entity/link.service.ts
+++ b/apps/vps/src/services/music-entity/link.service.ts
@@ -35,6 +35,10 @@ export const getLinksForEntityEffect =
           table: 'music_entity_links'
         })
     }).pipe(
+      Effect.withSpan('musicEntity.getLinksForEntity.query', {
+        attributes: { entityType, entityId }
+      }),
+      Effect.tap((rows) => Effect.annotateCurrentSpan('resultCount', rows.length)),
       Effect.withSpan('musicEntity.getLinksForEntity', {
         attributes: { entityType, entityId }
       })

--- a/apps/vps/src/services/post.service.ts
+++ b/apps/vps/src/services/post.service.ts
@@ -154,7 +154,7 @@ const buildPostWithCreators = (post: SelectPost, mdx: MdxService) =>
           operation: 'select',
           table: 'post_creators'
         })
-    })
+    }).pipe(Effect.withSpan('post.getCreators', { attributes: { postId: post.id } }))
 
     return yield* buildPostWithPreloadedCreators(post, creators, mdx)
   })
@@ -297,7 +297,9 @@ const getAllEffect = (
                 operation: 'select',
                 table: 'post_creators'
               })
-          })
+          }).pipe(
+            Effect.withSpan('post.getAll.creators', { attributes: { postCount: postIds.length } })
+          )
         : []
 
     const creatorsByPostId: Record<
@@ -492,7 +494,7 @@ const getBySlugEffect = (slug: string, mdx: MdxService) =>
           operation: 'select',
           table: 'posts'
         })
-    })
+    }).pipe(Effect.withSpan('post.getBySlug.query', { attributes: { slug } }))
 
     const post = postRecords[0]
     if (!post) {

--- a/apps/vps/src/services/profile.service.ts
+++ b/apps/vps/src/services/profile.service.ts
@@ -91,7 +91,7 @@ export const getPublicProfileEffect = (username: string) =>
           operation: 'select',
           table: 'user'
         })
-    })
+    }).pipe(Effect.withSpan('profile.getPublic.user', { attributes: { username } }))
 
     const foundUser = userRecords[0]
     if (!foundUser || foundUser.banned) {
@@ -119,7 +119,9 @@ export const getPublicProfileEffect = (username: string) =>
           operation: 'select',
           table: 'user_social_links'
         })
-    })
+    }).pipe(
+      Effect.withSpan('profile.getPublic.socialLinks', { attributes: { userId: foundUser.id } })
+    )
 
     const userMixes = yield* Effect.tryPromise({
       try: () =>
@@ -142,7 +144,7 @@ export const getPublicProfileEffect = (username: string) =>
           operation: 'select',
           table: 'audio'
         })
-    })
+    }).pipe(Effect.withSpan('profile.getPublic.mixes', { attributes: { userId: foundUser.id } }))
 
     const userShows = yield* Effect.tryPromise({
       try: () =>
@@ -163,7 +165,7 @@ export const getPublicProfileEffect = (username: string) =>
           operation: 'select',
           table: 'shows'
         })
-    })
+    }).pipe(Effect.withSpan('profile.getPublic.shows', { attributes: { userId: foundUser.id } }))
 
     const userPosts = yield* Effect.tryPromise({
       try: () =>
@@ -187,7 +189,7 @@ export const getPublicProfileEffect = (username: string) =>
           operation: 'select',
           table: 'posts'
         })
-    })
+    }).pipe(Effect.withSpan('profile.getPublic.posts', { attributes: { userId: foundUser.id } }))
 
     const editorials = userPosts
       .filter((p): p is typeof p & { title: string } => Boolean(p.type === 'post' && p.title))


### PR DESCRIPTION
## Summary
Three traces in production tracing showed up as a single opaque ~1.5-1.7s child span with no breakdown of what was actually slow:

- `api.profile.getPublic` → `profile.getPublic` (1.7s, 2 spans)
- `api.music.listEntityLinks` → `musicEntity.getLinksForEntity` (1.4s, 2 spans)
- `post.getMicroPostBySlug` → `post.getBySlug` (1.7s, 2 spans)

This adds child spans around each sequential step so the next slow trace actually shows where time goes.

- **`profile.service.ts`**: `getPublicProfileEffect` runs 5 sequential queries (user, socialLinks, mixes, shows, posts) — each now wrapped in its own `Effect.withSpan`.
- **`music-entity/link.service.ts`**: `getLinksForEntityEffect` query wrapped in `Effect.withSpan`, result count annotated onto the span via `Effect.tap` + `Effect.annotateCurrentSpan`.
- **`post.service.ts`**: `getBySlugEffect` query and `buildPostWithCreators`/`getAllEffect` creator-hydration steps each wrapped.
- **`lib/mdx.ts`**: `compile` (cache-miss path) wrapped, annotated with content length.

All additive — wraps existing calls, no logic changes.

## Follow-up: pg pool cold-start was the real dominant cost

Audited the worst-offender traces across the last 7-14 days (`sentry trace list` sorted by duration) to see if more span coverage was needed elsewhere. It wasn't — the actual bottleneck was already visible once broken into spans, just not the one this PR set out to fix.

Nearly every DB-touching request (`/s/tweet/*`, `/s/mix/*`, `/s/editorial/*`, `/api/content/posts/*`, `/api/resolve/*`, `/rss.xml`) showed a `pg.connect` span eating **560-570ms** as the first DB call, dwarfing the actual query time (~90-280ms total across 3-5 queries). Requests that skip the DB entirely (`/auth/get-session`, `/sitemap.xml`) finish in 1-5ms, confirming the gap is connection setup, not app logic.

Root cause: `apps/vps/src/db/index.ts` created the `pg` `Pool` with no `min` or `idleTimeoutMillis` override, so it used `pg`'s defaults (`min: 0`, `idleTimeoutMillis: 10000`). On a low-traffic app, the pool was closing its only idle connection between requests and re-paying the TCP+TLS handshake almost every time.

Fix: set `min: 1` to keep one connection warm, and raised `idleTimeoutMillis` to 10 minutes since traffic is sparse enough that shorter timeouts still churn.

This should cut most page loads from ~700-1100ms down to ~150-250ms — a bigger win than the added span coverage, though the spans are still useful for future regressions.

## Test plan
- [x] `bun run typecheck` — pass
- [x] oxlint — pass
- [x] oxfmt — pass
- [x] Manual diff review — confirmed changes are purely additive span/annotation wrapping around existing query calls, no control-flow changes
- [ ] Post-deploy: confirm `pg.connect` no longer appears as a per-request cost in new traces
