### PR TITLE
test(api): blackbox behavior spec for health endpoints (Step 1b)

### DIFF
--- a/apps/vps/package.json
+++ b/apps/vps/package.json
@@ -34,6 +34,7 @@
     "@effect/opentelemetry": "4.0.0-beta.93",
     "@effect/platform": "0.96.2",
     "@effect/platform-bun": "4.0.0-beta.93",
+    "@gbfm/api": "workspace:*",
     "@gbfm/core": "workspace:*",
     "@gbfm/email": "workspace:*",
     "@hono/zod-openapi": "1.3.0",

--- a/apps/vps/src/health.blackbox.test.ts
+++ b/apps/vps/src/health.blackbox.test.ts
@@ -1,0 +1,53 @@
+import { HealthLiveResponse, HealthReadyResponse } from '@gbfm/api/health'
+import { decodeResponseBody } from '@gbfm/api/testing'
+import { beforeAll, describe, expect, it } from 'vitest'
+import type { AppType } from '@/app'
+
+// Asserts only the wire contract (status, JSON body against @gbfm/api schemas) so these same assertions can run unchanged once health is ported to HttpApiBuilder (step 3a).
+let app: AppType
+
+beforeAll(async () => {
+  const mod = await import('@/app')
+  app = mod.default
+})
+
+describe('Health endpoints', () => {
+  it('GET /health/live returns 200 with liveness JSON', async () => {
+    const res = await app.request('/health/live')
+
+    expect(res.status).toBe(200)
+    await expect(decodeResponseBody(HealthLiveResponse, res)).resolves.toEqual({ ok: true })
+  })
+
+  it('GET /health/ready returns 200 with readiness JSON when the database is reachable', async () => {
+    const res = await app.request('/health/ready')
+
+    expect(res.status).toBe(200)
+    await expect(decodeResponseBody(HealthReadyResponse, res)).resolves.toEqual({
+      dbConnected: true
+    })
+  })
+
+  it('GET /health returns the same readiness result as /health/ready', async () => {
+    const res = await app.request('/health')
+
+    expect(res.status).toBe(200)
+    await expect(decodeResponseBody(HealthReadyResponse, res)).resolves.toEqual({
+      dbConnected: true
+    })
+  })
+
+  it('repeated readiness calls within the cache window keep returning 200', async () => {
+    const first = await app.request('/health/ready')
+    const second = await app.request('/health/ready')
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+  })
+
+  it('responds 404 to unsupported methods on health paths', async () => {
+    const res = await app.request('/health/live', { method: 'POST' })
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,7 @@
         "@effect/opentelemetry": "4.0.0-beta.93",
         "@effect/platform": "0.96.2",
         "@effect/platform-bun": "4.0.0-beta.93",
+        "@gbfm/api": "workspace:*",
         "@gbfm/core": "workspace:*",
         "@gbfm/email": "workspace:*",
         "@hono/zod-openapi": "1.3.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "exports": {
     "./health": "./src/health.ts",
-    "./errors": "./src/errors.ts"
+    "./errors": "./src/errors.ts",
+    "./testing": "./src/testing.ts"
   },
   "scripts": {
     "typecheck": "tsgo --noEmit",

--- a/packages/api/src/testing.ts
+++ b/packages/api/src/testing.ts
@@ -1,0 +1,11 @@
+import type { Schema } from 'effect'
+import { Effect, SchemaParser } from 'effect'
+
+// Lets a blackbox test decode a live Response against the same schema an HttpApiEndpoint declares, independent of which server produced it.
+export const decodeResponseBody = async <S extends Schema.Codec<unknown, unknown, never>>(
+  schema: S,
+  response: Response
+): Promise<S['Type']> => {
+  const body: unknown = await response.json()
+  return Effect.runPromise(SchemaParser.decodeUnknownEffect(schema)(body))
+}


### PR DESCRIPTION
Step 1b, stacked on #142 (merge that first). This is the behavior-preservation approach discussed on the migration doc: a blackbox suite that asserts only the wire contract, so the exact same assertions can run unchanged once health moves to `HttpApiBuilder` in step 3a.

## What
- `decodeResponseBody` (`packages/api/src/testing.ts`): decodes a `Response` body against a response schema with no decoding-service requirements (`Schema.Codec<unknown, unknown, never>`). Generic over any schema an endpoint declares for success or error -- reusable regardless of which server implementation produced the response.
- `health.blackbox.test.ts` (`apps/vps`): request/response assertions against the **live Hono app** (`app.request(path)`, same pattern as the existing `music.integration.test.ts`). Asserts status codes and body shape via the shared `@gbfm/api` schemas -- zero knowledge of Hono or Effect internals.

## Why blackbox, not implementation tests
The migration's actual risk is behavior drift while internals get swapped (Hono→Effect router, Zod→Schema, handlers rewritten). A suite that only asserts the new implementation's internals proves nothing about whether it still behaves like the old one. This suite is the spec: written once against current behavior, later pointed at the ported handler unchanged. If it still passes, behavior was preserved; if not, that's a real regression.

## Deliberately not covered here
- The readiness-failure/500 path and exact cache call-count -- both need a seam in `app.ts` (e.g. injectable DB check) that this contract-only step doesn't touch. Revisit once step 3a's handler port gives us that seam.

## Verification
- `bun --filter='@gbfm/api' typecheck` / `bun --filter='@gbfm/vps' typecheck` -- clean
- `bun run lint` / `bun run format:check` -- clean
- `apps/vps` test: 5/5 passing against a real Hono app + real Postgres (testcontainers)

## Next
Step 2a: add `HttpRouter.toWebHandler` as a second, unused export next to the existing `Bun.serve` entry point, with `HonoFallback` routing 100% of traffic through unchanged. No route behavior change.