### PR TITLE
feat(vps): add unused Effect toWebHandler + Hono fallback (Step 2a)

### DIFF
--- a/apps/vps/src/http/routes.blackbox.test.ts
+++ b/apps/vps/src/http/routes.blackbox.test.ts
@@ -1,0 +1,53 @@
+import { HealthLiveResponse, HealthReadyResponse } from '@gbfm/api/health'
+import { decodeResponseBody } from '@gbfm/api/testing'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import type { AppType } from '@/app'
+import { createWebHandler } from './routes'
+
+// Step 2a (docs/migration-effect-http-api.md): the Effect toWebHandler + Hono
+// fallback must behave identically to the plain Hono app it wraps. Reuses the
+// same @gbfm/api schemas as the 1b blackbox suite so both point at one contract.
+let app: AppType
+let webHandler: ReturnType<typeof createWebHandler>
+
+beforeAll(async () => {
+  const mod = await import('@/app')
+  app = mod.default
+  webHandler = createWebHandler(app)
+})
+
+afterAll(async () => {
+  await webHandler.dispose()
+})
+
+describe('Effect toWebHandler fallback', () => {
+  it('GET /health/live matches the Hono app', async () => {
+    const res = await webHandler.handler(new Request('http://localhost/health/live'))
+
+    expect(res.status).toBe(200)
+    await expect(decodeResponseBody(HealthLiveResponse, res)).resolves.toEqual({ ok: true })
+  })
+
+  it('GET /health/ready matches the Hono app', async () => {
+    const res = await webHandler.handler(new Request('http://localhost/health/ready'))
+
+    expect(res.status).toBe(200)
+    await expect(decodeResponseBody(HealthReadyResponse, res)).resolves.toEqual({
+      dbConnected: true
+    })
+  })
+
+  it('GET /api/music/artists falls through to the Hono app', async () => {
+    const res = await webHandler.handler(new Request('http://localhost/api/music/artists'))
+
+    expect(res.status).toBe(200)
+    const body: unknown = await res.json()
+    expect(Array.isArray(body)).toBe(true)
+  })
+
+  it('unknown routes fall through to the Hono app and 404', async () => {
+    const res = await webHandler.handler(new Request('http://localhost/does-not-exist'))
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/vps/src/http/routes.ts
+++ b/apps/vps/src/http/routes.ts
@@ -1,0 +1,16 @@
+import { Effect, Layer } from 'effect'
+import { HttpRouter, HttpServer, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
+import type { AppType } from '@/app'
+
+// Routes every request to the existing Hono app unchanged. Removed one HttpApi group at a time as routes are ported (docs/migration-effect-http-api.md).
+export const honoFallback = (honoApp: AppType) =>
+  HttpRouter.add('*', '/*', (request) =>
+    Effect.gen(function* () {
+      const webRequest = yield* HttpServerRequest.toWeb(request)
+      const webResponse = yield* Effect.promise(() => Promise.resolve(honoApp.fetch(webRequest)))
+      return HttpServerResponse.fromWeb(webResponse)
+    })
+  )
+
+export const createWebHandler = (honoApp: AppType) =>
+  HttpRouter.toWebHandler(Layer.mergeAll(honoFallback(honoApp), HttpServer.layerServices))

--- a/apps/vps/src/index.ts
+++ b/apps/vps/src/index.ts
@@ -2,6 +2,11 @@ export const localVPSPort = 3003
 
 const { default: app } = await import('./app')
 
+// Step 2a (docs/migration-effect-http-api.md): proves the toWebHandler + fallback
+// layer builds and serves identically to the Hono app. Not wired to Bun.serve yet.
+const { createWebHandler } = await import('./http/routes')
+export const effectWebHandler = createWebHandler(app)
+
 export default {
   port: localVPSPort,
   fetch: app.fetch,

--- a/docs/migration-effect-http-api.md
+++ b/docs/migration-effect-http-api.md
@@ -501,15 +501,19 @@ The entry point must carry over **everything** in the app.ts inventory, not just
 | Graceful shutdown | SIGTERM/SIGINT → `toWebHandler`'s `dispose()` then `disposeRuntime()` |
 | 1GB request bodies | unchanged `maxRequestBodySize` on the Bun.serve export |
 
-better-auth mounts as a wildcard route. Its handler is async and returns a web `Response`, so it needs `Effect.promise` and `HttpServerResponse.fromWeb` -- `Effect.succeed(auth.handler(...))` would produce an unawaited `Promise` typed as the response:
+better-auth mounts as a wildcard route. Its handler is async and returns a web `Response`, so it needs `Effect.promise` and `HttpServerResponse.fromWeb` -- `Effect.succeed(auth.handler(...))` would produce an unawaited `Promise` typed as the response.
+
+**Verified against the installed types (corrects an earlier version of this doc)**: `HttpServerRequest.toWeb` is not a plain sync conversion -- it returns `Effect.Effect<Request, RequestError>` and must be `yield*`ed inside an `Effect.gen`, not called bare inside `Effect.promise`:
 
 ```ts
-const BetterAuthRoutes = HttpRouter.use((router) =>
-  router.add("*", "/auth/*", (request) =>
-    Effect.promise(() =>
-      auth.handler(prepareAuthRequest(HttpServerRequest.toWeb(request))),
-    ).pipe(Effect.map(HttpServerResponse.fromWeb)),
-  ),
+const BetterAuthRoutes = HttpRouter.add("*", "/auth/*", (request) =>
+  Effect.gen(function* () {
+    const webRequest = yield* HttpServerRequest.toWeb(request)
+    const webResponse = yield* Effect.promise(() =>
+      Promise.resolve(auth.handler(prepareAuthRequest(webRequest))),
+    )
+    return HttpServerResponse.fromWeb(webResponse)
+  }),
 )
 ```
 
@@ -565,14 +569,16 @@ One server, one port, one deploy at a time. The whole existing Hono app mounts a
 ```ts
 import honoApp from "@/app"
 
-const HonoFallback = HttpRouter.use((router) =>
-  router.add("*", "/*", (request) =>
-    Effect.promise(() => honoApp.fetch(HttpServerRequest.toWeb(request))).pipe(
-      Effect.map(HttpServerResponse.fromWeb),
-    ),
-  ),
+const HonoFallback = HttpRouter.add("*", "/*", (request) =>
+  Effect.gen(function* () {
+    const webRequest = yield* HttpServerRequest.toWeb(request)
+    const webResponse = yield* Effect.promise(() => Promise.resolve(honoApp.fetch(webRequest)))
+    return HttpServerResponse.fromWeb(webResponse)
+  }),
 )
 ```
+
+(Implemented and verified in `apps/vps/src/http/routes.ts`, step 2a. `honoApp.fetch` can return `Response | Promise<Response>` depending on the route; wrap in `Promise.resolve` so `Effect.promise`'s `PromiseLike` constraint is satisfied either way.)
 
 The router (find-my-way) gives static and parametric routes precedence over the wildcard, so each `HttpApi` group added takes over its paths automatically. Per group: port endpoints + handlers, delete the corresponding Hono router from `app.ts`, deploy. When `app.ts` has no routers left, delete `HonoFallback` and the Hono dependency.
 


### PR DESCRIPTION
Why this exists: the migration's biggest risk is the serving-stack cutover (Hono's Bun.serve -> Effect's HttpRouter). This PR de-risks that swap before it touches prod -- it builds the new handler and proves it behaves identically to the current app, without flipping the switch. If something were wrong with the handler/fallback plumbing, we find out here, not in a deploy.

Stacked on #143 (merge #142 -> #143 first).

## Verification
- New `routes.blackbox.test.ts`: the new handler behaves identically to the plain Hono app for health, a real API route, and an unknown route -- 4/4 passing against a live Postgres testcontainer.
- Full existing suite still green (9/9 across the two blackbox files).
- Typecheck, lint, format all clean.

## Bonus: caught a bug in the migration doc itself
Verified `HttpServerRequest.toWeb` against the installed effect types -- the doc's sketch treated it as sync, it's actually effectful. Fixed the doc so later steps don't copy the mistake.

## Next
Step 2b flips the switch: swap the deploy entry point to this handler for real.