### PR TITLE
feat(vps): swap entry point to Effect toWebHandler (Step 2b)

### DIFF
--- a/apps/vps/src/app.ts
+++ b/apps/vps/src/app.ts
@@ -135,11 +135,21 @@ const sitemapRegenerationEffect = regenerateSitemap.pipe(
 
 const mainEffect = setupRoutesEffect
 
+// Registered by the entry point (src/index.ts) to dispose the Effect
+// HttpRouter handler before the runtime shuts down. No-op until Step 2b wires
+// the entry point to serve through it (docs/migration-effect-http-api.md).
+let disposeWebHandler: (() => Promise<void>) | undefined
+
+export const onShutdown = (dispose: () => Promise<void>) => {
+  disposeWebHandler = dispose
+}
+
 const setupGracefulShutdown = () => {
   const shutdown = async (signal: string) => {
     console.log(`Graceful shutdown initiated via ${signal}`)
 
     try {
+      await disposeWebHandler?.()
       const { disposeRuntime } = await import('./runtime')
       await disposeRuntime()
       console.log('Runtime disposed successfully')

--- a/apps/vps/src/index.ts
+++ b/apps/vps/src/index.ts
@@ -1,14 +1,18 @@
 export const localVPSPort = 3003
 
-const { default: app } = await import('./app')
+const { default: app, onShutdown } = await import('./app')
 
-// Step 2a (docs/migration-effect-http-api.md): proves the toWebHandler + fallback
-// layer builds and serves identically to the Hono app. Not wired to Bun.serve yet.
+// Step 2 (docs/migration-effect-http-api.md): the process now serves through
+// this handler. It wildcards every request to the same Hono app unchanged --
+// app.ts still owns route setup, background forks, and its SIGTERM/SIGINT
+// wiring. This is where the serving topology changes.
 const { createWebHandler } = await import('./http/routes')
 export const effectWebHandler = createWebHandler(app)
 
+onShutdown(effectWebHandler.dispose)
+
 export default {
   port: localVPSPort,
-  fetch: app.fetch,
+  fetch: effectWebHandler.handler,
   maxRequestBodySize: 1024 * 1024 * 1000 // 1GB
 }


### PR DESCRIPTION
Why this exists: this is the actual cutover -- prod now serves through the Effect handler instead of Hono's Bun.serve directly. Route behavior is unchanged (still 100% Hono fallback under the hood), so this PR isolates one risk only: did the swap itself break anything (startup, shutdown, background jobs).

Stacked on #144 (merge #142 -> #143 -> #144 first).

## Verification
- Full `apps/vps` suite: 140/140 passing, unchanged from before this PR.
- Background forks (reminders, sitemap) untouched -- still start the same way.
- Shutdown: had to fix a real ordering bug here (see below), not just wire it up.

## Not verified
No real SIGTERM against a booted server -- this environment can't boot vps standalone (needs SST resources). Worth a manual check on staging before prod.

## The bug this caught
Naively adding a second `process.on('SIGTERM', ...)` for the new handler would race the existing one, which calls `process.exit()` unconditionally. Fixed by threading the new dispose call through the existing shutdown sequence instead.

## Next
Step 2c: port the better-auth route onto the new router, isolated so an auth regression is diagnosable to one small diff.