### PR TITLE
test(vps): strengthen music-artists fallback parity check

### DIFF
--- a/apps/vps/src/http/routes.blackbox.test.ts
+++ b/apps/vps/src/http/routes.blackbox.test.ts
@@ -37,12 +37,14 @@ describe('Effect toWebHandler fallback', () => {
     })
   })
 
-  it('GET /api/music/artists falls through to the Hono app', async () => {
-    const res = await webHandler.handler(new Request('http://localhost/api/music/artists'))
+  it('GET /api/music/artists returns the same response as the plain Hono app', async () => {
+    const [viaHandler, viaHono] = await Promise.all([
+      webHandler.handler(new Request('http://localhost/api/music/artists')),
+      app.request('/api/music/artists')
+    ])
 
-    expect(res.status).toBe(200)
-    const body: unknown = await res.json()
-    expect(Array.isArray(body)).toBe(true)
+    expect(viaHandler.status).toBe(viaHono.status)
+    await expect(viaHandler.json()).resolves.toEqual(await viaHono.json())
   })
 
   it('unknown routes fall through to the Hono app and 404', async () => {


### PR DESCRIPTION
Why this exists: you flagged that the step 2a test for \`/api/music/artists\` only checked \`Array.isArray(body)\` -- that would pass even if the fallback silently returned an empty array or a shape Hono never actually produces. It wasn't testing what the file claims to test (parity between the new handler and Hono).

Stacked on #146 (merge #142 -> ... -> #146 first).

## What changed
Replaced the shape sniff with a real parity check: request the same path through both \`webHandler.handler()\` and the known-good \`app.request()\`, assert identical status and body.

## Verification
- \`bun --filter='@gbfm/vps' typecheck\` -- clean
- \`routes.blackbox.test.ts\`: 6/6 passing
- lint/format clean

## Next
Step 3a: port health handlers to \`HttpApiBuilder.group\`, the first real \`HttpApi\` group taking over live traffic from the fallback.