### PR TITLE
feat(www): typed HttpApiClient for music-artists (Step 5)

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -19,6 +19,7 @@
     "@dnd-kit/modifiers": "9.0.0",
     "@dnd-kit/sortable": "10.0.0",
     "@dnd-kit/utilities": "3.2.2",
+    "@gbfm/api": "workspace:*",
     "@gbfm/core": "workspace:*",
     "@gbfm/theme": "workspace:*",
     "@gbfm/ui": "workspace:*",

--- a/apps/www/src/lib/api-client.ts
+++ b/apps/www/src/lib/api-client.ts
@@ -1,0 +1,24 @@
+import { Api } from '@gbfm/api/api'
+import { Effect, Layer } from 'effect'
+import { FetchHttpClient } from 'effect/unstable/http'
+import { HttpApiClient } from 'effect/unstable/httpapi'
+
+const VPS_BASE_URL = import.meta.env.VITE_VPS_BASE_URL || window.location.origin
+
+const FetchLive = FetchHttpClient.layer.pipe(
+  Layer.provide(Layer.succeed(FetchHttpClient.RequestInit, { credentials: 'include' }))
+)
+
+const buildClient = () =>
+  HttpApiClient.make(Api, { baseUrl: VPS_BASE_URL }).pipe(Effect.provide(FetchLive))
+
+export type ApiClient = Effect.Success<ReturnType<typeof buildClient>>
+
+let _client: ApiClient | null = null
+
+export const getApiClient = async (): Promise<ApiClient> => {
+  if (!_client) {
+    _client = await Effect.runPromise(buildClient())
+  }
+  return _client
+}

--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -12,9 +12,11 @@ import type {
   SelectShow,
   SelectShowSubscription
 } from '@gbfm/vps/schemas'
+import { Effect } from 'effect'
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { RuntimeClient } from '@/runtime'
 import { captureException } from '@/services/analytics'
+import { getApiClient } from './api-client'
 import { useSession } from './auth-client'
 import { createFetcher, getRequestMethod, getRequestUrl, type ApiFailureInput } from './http-client'
 import {
@@ -1155,7 +1157,17 @@ export interface AdminMusicEntityLink {
 export function useAdminArtists() {
   return useQuery<MusicArtist[]>({
     queryKey: ['admin', 'artists'],
-    queryFn: () => fetcher(apiUrl('/music/artists'))
+    queryFn: async () => {
+      const client = await getApiClient()
+      const artists = await Effect.runPromise(
+        client.music
+          .listArtists({})
+          .pipe(
+            Effect.tapError((error) => captureException(error, { endpoint: 'music.listArtists' }))
+          )
+      )
+      return artists.map((a) => ({ ...a, genres: a.genres ? [...a.genres] : null }))
+    }
   })
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -131,6 +131,7 @@
         "@dnd-kit/modifiers": "9.0.0",
         "@dnd-kit/sortable": "10.0.0",
         "@dnd-kit/utilities": "3.2.2",
+        "@gbfm/api": "workspace:*",
         "@gbfm/core": "workspace:*",
         "@gbfm/theme": "workspace:*",
         "@gbfm/ui": "workspace:*",

--- a/docs/migration-effect-http-api.md
+++ b/docs/migration-effect-http-api.md
@@ -643,7 +643,7 @@ const buildClient = () =>
     baseUrl: import.meta.env.VITE_VPS_BASE_URL || window.location.origin,
   }).pipe(Effect.provide(FetchLive))
 
-export type ApiClient = Effect.Effect.Success<ReturnType<typeof buildClient>>
+export type ApiClient = Effect.Success<ReturnType<typeof buildClient>>
 
 let _client: ApiClient | null = null
 


### PR DESCRIPTION
## Why

Everything so far proved the server side: contract, handler, auth, one full CRUD group behind the Effect router. Nothing has proven the *client* side of the migration -- that a generated `HttpApiClient` actually works end to end from a browser, including the one failure mode that only shows up outside a type checker: cookies crossing origins. This step swaps one hook (`useAdminArtists`) to close that gap before any more hooks move.

## What to look for

- `apps/www/src/lib/api-client.ts` -- the client. `FetchHttpClient.RequestInit` (`credentials: 'include'`) is provided to the `FetchHttpClient` layer itself, not around `HttpApiClient.make`'s build effect -- doc has the full reasoning (`layerMergedContext` captures context at layer-build time, not call time).
- `apps/www/src/lib/http.ts` -- `useAdminArtists` now calls `client.music.listArtists({})` instead of `fetcher(apiUrl(...))`. Kept the same Sentry error-reporting behavior the old `fetcher` had on failure (`Effect.tapError` -> `captureException`), so this endpoint doesn't go dark in monitoring just because it changed transport.

Adversarially reviewed (headless agent, worktree isolation) against 7 specific failure classes (cookie/credentials threading, base URL correctness, readonly-array cast safety, client-singleton race, error-reporting parity, workspace dependency leakage, dead code). One real finding -- the dropped Sentry reporting -- fixed before this PR was opened, not left as a follow-up.

Stacked on #153 (branch-ancestry fix for Step 4 -- see that PR for why it exists).

## Test evidence

Signed in as a real admin session against the local VPS (not just typecheck), loaded `/admin/music`, confirmed the artists list renders through the new `HttpApiClient` path -- server had already stopped serving this route from Hono in Step 4, so a broken client would show an empty list or an error, not stale data:

![Admin music catalog rendering artists via the typed client](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/154/admin-music-artists-list.png)

Also confirmed directly that the endpoint returns 200 with cookies included (not just that the UI happened to render):

```
> fetch('/api/music/artists', {credentials:'include'}).then(r => ({status: r.status, ct: r.headers.get('content-type')}))
{ "status": 200, "ct": "application/json" }
```
