### PR TITLE
fix(vps): auto-default OTel endpoint to localhost in dev stages

### DIFF
--- a/apps/vps/src/services/config.service.ts
+++ b/apps/vps/src/services/config.service.ts
@@ -143,7 +143,9 @@ export function createConfig(): ConfigService {
   const dbStage = isProd ? 'prod' : undefined
   const logLevel = undefined
 
-  const otelEndpoint = secretString('OTEL_EXPORTER_OTLP_ENDPOINT', '')
+  const otelEndpoint =
+    secretString('OTEL_EXPORTER_OTLP_ENDPOINT', '') ||
+    (['dev', 'local'].includes(appStage) ? 'http://localhost:4318' : '')
   const otelHeaders = secretString('OTEL_EXPORTER_OTLP_HEADERS', '')
 
   const adminEmail = secretString('AdminEmail', 'guidefari@icloud.com')


### PR DESCRIPTION
Automatically sets OTLP endpoint to `http://localhost:4318` when running in `dev` or `local` stages, so local traces go to Motel without extra config.