### PR TITLE
feat(www): swap search + profile consumers to typed Effect client (step 6b)

### DIFF
--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -895,10 +895,10 @@ export type PublicProfile = {
   username: string | null
   image: string | null
   bio: string | null
-  socialLinks: SocialLink[]
+  socialLinks: ReadonlyArray<SocialLink>
   createdAt: string
   content: {
-    mixes: Array<{
+    mixes: ReadonlyArray<{
       id: string
       title: string
       slug: string
@@ -906,13 +906,13 @@ export type PublicProfile = {
       type: 'mix' | 'track' | 'misc'
       showId: string | null
     }>
-    shows: Array<{
+    shows: ReadonlyArray<{
       id: string
       title: string
       slug: string
       thumbnailUrl: string | null
     }>
-    editorials: Array<{
+    editorials: ReadonlyArray<{
       id: string
       title: string
       slug: string
@@ -920,7 +920,7 @@ export type PublicProfile = {
       description: string | null
       createdAt: string
     }>
-    tweets: Array<{
+    tweets: ReadonlyArray<{
       id: string
       title: string | null
       slug: string
@@ -990,9 +990,16 @@ export function usePublicProfile(username: string) {
   const { data, error, isPending } = useQuery<PublicProfile, Error>({
     queryKey: ['profile', username],
     queryFn: async () => {
-      const profile = await fetcher<PublicProfile>(apiUrl(`/profile/${username}`))
-      if (!profile?.id) throw new Error('Profile not found')
-      return profile
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.profile
+          .getPublicProfile({ params: { username } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'profile.getPublicProfile' })
+            )
+          )
+      )
     },
     enabled: Boolean(username),
     retry: false

--- a/apps/www/src/routes/admin/_components/-SearchTab.tsx
+++ b/apps/www/src/routes/admin/_components/-SearchTab.tsx
@@ -1,7 +1,8 @@
 import { Badge, Input } from '@gbfm/ui'
 import { useQuery } from '@tanstack/react-query'
+import { Effect } from 'effect'
 import { useId, useState } from 'react'
-import { apiUrl, fetcher } from '@/lib/http'
+import { getApiClient } from '@/lib/api-client'
 
 interface SearchResultItem {
   id: string
@@ -13,9 +14,9 @@ interface SearchResultItem {
 }
 
 interface SearchResults {
-  shows: SearchResultItem[]
-  audio: SearchResultItem[]
-  posts: SearchResultItem[]
+  shows: ReadonlyArray<SearchResultItem>
+  audio: ReadonlyArray<SearchResultItem>
+  posts: ReadonlyArray<SearchResultItem>
 }
 
 const GROUPS: Array<{ key: keyof SearchResults; label: string }> = [
@@ -24,7 +25,7 @@ const GROUPS: Array<{ key: keyof SearchResults; label: string }> = [
   { key: 'posts', label: 'Posts' }
 ]
 
-function ResultGroup({ label, items }: { label: string; items: SearchResultItem[] }) {
+function ResultGroup({ label, items }: { label: string; items: ReadonlyArray<SearchResultItem> }) {
   return (
     <div className='space-y-2'>
       <div className='flex items-center gap-2'>
@@ -62,7 +63,10 @@ export function SearchTab() {
 
   const { data, isPending, isError } = useQuery({
     queryKey: ['admin', 'search', query],
-    queryFn: () => fetcher<SearchResults>(apiUrl(`/search?q=${encodeURIComponent(query)}`)),
+    queryFn: async () => {
+      const client = await getApiClient()
+      return Effect.runPromise(client.search.searchContent({ query: { q: query, limit: 50 } }))
+    },
     enabled: query.length >= 2
   })
 

--- a/apps/www/src/routes/profile/$username.tsx
+++ b/apps/www/src/routes/profile/$username.tsx
@@ -1,13 +1,17 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
+import { Effect } from 'effect'
 import { PublicProfilePage } from '@/components/profile/PublicProfilePage'
-import { apiUrl, fetcher, type PublicProfile } from '@/lib/http'
+import { getApiClient } from '@/lib/api-client'
 import { generateProfileSEO, generateSEOMeta } from '@/lib/seo'
 
 export const Route = createFileRoute('/profile/$username')({
   component: ProfilePage,
   loader: async ({ params }) => {
     try {
-      const profile = await fetcher<PublicProfile>(apiUrl(`/profile/${params.username}`))
+      const client = await getApiClient()
+      const profile = await Effect.runPromise(
+        client.profile.getPublicProfile({ params: { username: params.username } })
+      )
       if (!profile?.id) return { profile: null }
       return { profile }
     } catch {


### PR DESCRIPTION
## Why

Step 6b of the Effect HttpApi migration: swap frontend consumers of the `search` and `profile` endpoints from raw `fetcher(apiUrl(...))` calls to the typed `HttpApiClient`. The server-side ports (search in #156, profile in #157) are already merged into `migration/effect-http-api`. This closes the loop by making the frontend use the typed client for those groups.

The `resolve` group is not included -- it hasn't been ported to Effect HttpApi on the server yet (no `packages/api/src/resolve.ts`). That needs its own server-side port PR first.

## What to look for

- **ReadonlyArray compatibility**: Effect `Schema` decodes to `ReadonlySide<...>` with readonly arrays. The `PublicProfile` type in `http.ts:892-930` was updated from mutable `Array<T>` to `ReadonlyArray<T>` to match. Check that downstream consumers (`PublicProfilePage`, `TweetAuthorRow`, `TweetDownloadDialog`) don't mutate these arrays.

- **SearchTab `limit` param**: The `searchContent` endpoint's `SearchQuery` schema requires `limit` (has a runtime default of 10 via `Schema.withDecodingDefaultType`). The old `fetcher` call didn't pass `limit` at all. The new call passes `limit: 50` explicitly. Verify this doesn't change behavior -- the old Hono route also had a default limit.

- **Error propagation change in `usePublicProfile`**: The old code had an explicit `if (!profile?.id) throw new Error('Profile not found')` guard. The new code lets the Effect `NotFound` error propagate directly. Both result in React Query `error` state. The `$username.tsx` route loader still has its own `!profile?.id` guard plus a `catch` block, so SSR is safe.

- **Auth is not involved**: Neither `ProfileGroup` nor `SearchGroup` has `.middleware(AuthMiddleware)`. Both are public endpoints. No auth regression risk.

- **`apiUrl`/`fetcher` removal scoped correctly**: `apiUrl` is still imported in `http.ts` (used by 70+ other hooks). Only removed from `SearchTab.tsx` and `$username.tsx` where it's no longer needed.

## Test evidence

Admin search tab using typed Effect client (query "FAR END" -- 1 show, 2 audio, 1 post returned):

![Admin search tab](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/160/admin-search-tab-v2.png)

```
$ curl -s 'http://localhost:3003/api/search?q=FAR%20END' | jq '{shows: [.shows[].title], audio: [.audio[].title], posts: [.posts[].title]}'
{
  "shows": ["FAR END RADIO"],
  "audio": ["TRANSMISSION 001: SIGNAL ARRIVES", "gb#66"],
  "posts": ["FAR END RADIO: Transmission As Method, & Listening As Archive"]
}
```

Profile page for @guidefari using typed Effect client (mixes, editorials, tweets all rendered):

![Profile page](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/160/profile-page.png)

```
$ curl -s -o /dev/null -w '%{http_code}' 'http://localhost:3003/api/profile/guidefari'
200
```
