### PR TITLE
feat(www): swap resolve consumer to typed Effect client (step 6b)

### DIFF
--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -943,10 +943,10 @@ export type ResolvedShow = {
     description: string | null
     thumbnailUrl: string | null
     bannerImageUrl: string | null
-    tags: string[] | null
+    tags: ReadonlyArray<string> | null
     createdAt: string
     compiledContent: string | null
-    hosts: Array<{ id: string; name: string; username: string | null }>
+    hosts: ReadonlyArray<{ id: string; name: string; username: string | null }>
   }
 }
 
@@ -956,7 +956,14 @@ export function useResolveSlug(slug: string) {
   const { data, error, isPending } = useQuery<ResolveResult, Error>({
     queryKey: ['resolve', slug],
     queryFn: async () => {
-      return fetcher<ResolveResult>(apiUrl(`/resolve/${slug}`))
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.resolve
+          .resolveSlug({ params: { slug } })
+          .pipe(
+            Effect.tapError((error) => captureException(error, { endpoint: 'resolve.resolveSlug' }))
+          )
+      )
     },
     enabled: Boolean(slug),
     retry: false

--- a/apps/www/src/lib/seo.ts
+++ b/apps/www/src/lib/seo.ts
@@ -224,7 +224,7 @@ export type ResolvedShowData = {
   description: string | null
   thumbnailUrl: string | null
   compiledContent: string | null
-  hosts: Array<{ id: string; name: string }>
+  hosts: ReadonlyArray<{ id: string; name: string }>
 }
 
 export function generateResolvedShowSEO(show: ResolvedShowData, slug: string): SEOHeadData {

--- a/apps/www/src/routes/$slug.tsx
+++ b/apps/www/src/routes/$slug.tsx
@@ -1,13 +1,17 @@
 import { createFileRoute, Link, Navigate } from '@tanstack/react-router'
+import { Effect } from 'effect'
 import { PublicProfilePage } from '@/components/profile/PublicProfilePage'
-import { apiUrl, fetcher, type ResolveResult } from '@/lib/http'
+import { getApiClient } from '@/lib/api-client'
 import { generateProfileSEO, generateResolvedShowSEO, generateSEOMeta } from '@/lib/seo'
 
 export const Route = createFileRoute('/$slug')({
   component: SlugPage,
   loader: async ({ params }) => {
     try {
-      const resolved = await fetcher<ResolveResult>(apiUrl(`/resolve/${params.slug}`))
+      const client = await getApiClient()
+      const resolved = await Effect.runPromise(
+        client.resolve.resolveSlug({ params: { slug: params.slug } })
+      )
       return { resolved }
     } catch {
       return { resolved: null }


### PR DESCRIPTION
## Why

Step 6b continues: swap the `resolve` group's frontend consumer from raw `fetcher()` to the typed `HttpApiClient`. The server-side port (#158) is already merged. This closes the loop for the resolve group -- the last step-6 group needing a client swap.

`useResolveMusicEntity` (calls `/music/resolve`, POST) is NOT swapped here -- that endpoint hasn't been ported to Effect HttpApi yet (it's still on Hono). Only `useResolveSlug` and the `$slug.tsx` loader are in scope.

## What to look for

- **ReadonlyArray compatibility**: Effect `Schema` decodes to `ReadonlySide<...>` with readonly arrays. `ResolvedShow.tags` changed from `string[] | null` to `ReadonlyArray<string> | null`, and `hosts` from `Array<...>` to `ReadonlyArray<...>`. The `seo.ts` `ResolvedShowData.hosts` was also updated for structural compatibility. All downstream consumers use `.map()` -- no mutations found.

- **Error handling equivalence**: The old `$slug.tsx` loader had a `try/catch` around `fetcher`. The new code has the same `try/catch` around `Effect.runPromise`. Both catch all errors and return `{ resolved: null }`.

- **`useResolveSlug` is dead code**: Exported from `http.ts` but never imported anywhere. Swapped anyway for consistency; candidates for removal in a future cleanup.

- **Auth is not involved**: The resolve endpoint is public. No auth regression risk.

## Test evidence

Catch-all slug page resolving `@guidefari` to their profile via typed Effect client:

![Resolve slug to profile](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/161/resolve-slug-profile.png)

```
$ curl -s 'http://localhost:3003/api/resolve/guidefari' | jq '.type'
"profile"
```
