### PR TITLE
feat(www): swap label+release hooks to typed HttpApiClient (step 6b)

### DIFF
--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -586,9 +586,27 @@ export function useAllLabels({ limit = DEFAULT_PAGE_SIZE }: PaginationOptions = 
     useInfiniteQuery<PaginatedResponse<SelectLabel>, Error>({
       queryKey: ['labels', limit],
       queryFn: async ({ pageParam = 0 }) => {
-        const url = apiUrlObj(`/content/labels`)
-        setPaginationParams(url, Number(pageParam), { limit })
-        return fetcher<PaginatedResponse<SelectLabel>>(url.toString())
+        const client = await getApiClient()
+        const result = await Effect.runPromise(
+          client.label
+            .getAllLabels({ query: { limit, offset: Number(pageParam) } })
+            .pipe(
+              Effect.tapError((error) =>
+                captureException(error, { endpoint: 'label.getAllLabels' })
+              )
+            )
+        )
+        return {
+          data: result.data.map((label) => ({
+            ...label,
+            bannerImageUrl: null,
+            createdAt: new Date(label.createdAt),
+            updatedAt: new Date(label.updatedAt),
+            tags: label.tags ? [...label.tags] : null,
+            genres: label.genres ? [...label.genres] : null
+          })),
+          pagination: result.pagination
+        }
       },
       initialPageParam: 0,
       getNextPageParam: getNextOffsetPageParam
@@ -607,7 +625,27 @@ export function useAllLabels({ limit = DEFAULT_PAGE_SIZE }: PaginationOptions = 
 export function useLabelBySlug(slug: string) {
   const { data, error, isPending } = useQuery<SelectMdxCompiledLabel, Error>({
     queryKey: ['label', slug],
-    queryFn: async () => fetcher(apiUrl(`/content/labels/${slug}`)),
+    queryFn: async () => {
+      const client = await getApiClient()
+      const label = await Effect.runPromise(
+        client.label
+          .getLabelBySlug({ params: { slug } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'label.getLabelBySlug' })
+            )
+          )
+      )
+      return {
+        ...label,
+        bannerImageUrl: null,
+        createdAt: new Date(label.createdAt),
+        updatedAt: new Date(label.updatedAt),
+        tags: label.tags ? [...label.tags] : null,
+        genres: label.genres ? [...label.genres] : null,
+        creators: label.creators ? [...label.creators] : undefined
+      }
+    },
     enabled: Boolean(slug)
   })
 
@@ -626,9 +664,31 @@ export function useReleasesByLabel(
     useInfiniteQuery<PaginatedResponse<SelectRelease>, Error>({
       queryKey: ['releases', 'label', labelSlug, limit],
       queryFn: async ({ pageParam = 0 }) => {
-        const url = apiUrlObj(`/content/labels/${labelSlug}/releases`)
-        setPaginationParams(url, Number(pageParam), { limit })
-        return fetcher<PaginatedResponse<SelectRelease>>(url.toString())
+        const client = await getApiClient()
+        const result = await Effect.runPromise(
+          client.release
+            .getReleasesByLabel({
+              params: { labelSlug },
+              query: { limit, offset: Number(pageParam) }
+            })
+            .pipe(
+              Effect.tapError((error) =>
+                captureException(error, { endpoint: 'release.getReleasesByLabel' })
+              )
+            )
+        )
+        return {
+          data: result.data.map((release) => ({
+            ...release,
+            bannerImageUrl: null,
+            createdAt: new Date(release.createdAt),
+            updatedAt: new Date(release.updatedAt),
+            releaseDate: release.releaseDate ? new Date(release.releaseDate) : null,
+            tags: release.tags ? [...release.tags] : null,
+            streamingLinks: release.streamingLinks ? [...release.streamingLinks] : null
+          })),
+          pagination: result.pagination
+        }
       },
       initialPageParam: 0,
       getNextPageParam: getNextOffsetPageParam,
@@ -648,7 +708,27 @@ export function useReleasesByLabel(
 export function useReleaseBySlug(slug: string) {
   const { data, error, isPending } = useQuery<SelectMdxCompiledRelease, Error>({
     queryKey: ['release', slug],
-    queryFn: async () => fetcher(apiUrl(`/content/releases/${slug}`)),
+    queryFn: async () => {
+      const client = await getApiClient()
+      const release = await Effect.runPromise(
+        client.release
+          .getReleaseBySlug({ params: { slug } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'release.getReleaseBySlug' })
+            )
+          )
+      )
+      return {
+        ...release,
+        bannerImageUrl: null,
+        createdAt: new Date(release.createdAt),
+        updatedAt: new Date(release.updatedAt),
+        releaseDate: release.releaseDate ? new Date(release.releaseDate) : null,
+        tags: release.tags ? [...release.tags] : null,
+        streamingLinks: release.streamingLinks ? [...release.streamingLinks] : null
+      }
+    },
     enabled: Boolean(slug)
   })
 


### PR DESCRIPTION
## Summary
Step 6b: swaps the `label`+`release` group hooks in `apps/www/src/lib/http.ts` from raw `fetcher()` calls to the typed `HttpApiClient`. Stacked on `migration/6b-user-hooks` (#175).

Ports: `useAllLabels`, `useLabelBySlug`, `useReleasesByLabel`, `useReleaseBySlug`. Batched label+release together since they were already stacked back-to-back server-side (PRs #171/#172) and share the exact same shape (paginated list + get-by-slug).

## Notable decisions

- `LabelResponse`/`ReleaseResponse` never included `bannerImageUrl` (confirmed correct during the label/release group ports -- the old zod schema never declared it either), but the local `SelectLabel`/`SelectRelease` types (from the still-Hono `@gbfm/vps/schemas`) require it. Filled with a literal `null` in the response mapping rather than changing the shared exported type, since nothing in `apps/www` reads `bannerImageUrl` off a label or release anywhere (confirmed by grep -- every real usage is `shows`-only).
- `createdAt`/`updatedAt`/`releaseDate` converted back to `Date` objects in each hook (the wire format is now ISO strings, matching every other ported group), preserving the existing `Date`-based type contracts rather than changing shared exported types.
- Readonly-array fields (`tags`, `genres`, `streamingLinks`, `creators`) spread into mutable arrays to match the local types' plain array expectations.

## Test plan
- [x] `bun precommit` clean across all 8 packages (format, lint, typecheck)
- [ ] Could not verify end-to-end in a browser: same local disk-space/backend-dev-server limitation noted in #175.

https://claude.ai/code/session_01HHyEKmv9m7DRkS5jcexcqo
