### PR TITLE
feat(www): swap post-group hooks to typed HttpApiClient (step 6b)

### DIFF
--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -132,7 +132,19 @@ export function useAudioTags(type: AudioContentType) {
 export function useEditorialTags() {
   const { data, error, isPending } = useQuery<string[], Error>({
     queryKey: ['editorial-tags'],
-    queryFn: async () => fetcher<string[]>(apiUrl('/content/posts/editorials/tags')),
+    queryFn: async () => {
+      const client = await getApiClient()
+      const tags = await Effect.runPromise(
+        client.post
+          .getEditorialTags({})
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'post.getEditorialTags' })
+            )
+          )
+      )
+      return [...tags]
+    },
     staleTime: 1000 * 60 * 60
   })
   return { data: data ?? [], error, isPending }
@@ -157,11 +169,27 @@ export function useEditorialPosts(tag?: string, limit = DEFAULT_PAGE_SIZE) {
     useInfiniteQuery<PaginatedResponse<SelectMdxCompiledEditorialPost>, Error>({
       queryKey: ['posts', 'editorials', tag, limit],
       queryFn: async ({ pageParam = 0 }) => {
-        const url = apiUrlObj(`/content/posts/editorials`)
-        url.searchParams.set('limit', String(limit))
-        url.searchParams.set('offset', String(pageParam))
-        if (tag) url.searchParams.set('tag', tag)
-        return fetcher<PaginatedResponse<SelectMdxCompiledEditorialPost>>(url.toString())
+        const client = await getApiClient()
+        const result = await Effect.runPromise(
+          client.post
+            .getEditorialPosts({ query: { limit, offset: Number(pageParam), tag } })
+            .pipe(
+              Effect.tapError((error) =>
+                captureException(error, { endpoint: 'post.getEditorialPosts' })
+              )
+            )
+        )
+        return {
+          data: result.data.map((post) => ({
+            ...post,
+            bannerImageUrl: null,
+            createdAt: new Date(post.createdAt),
+            updatedAt: new Date(post.updatedAt),
+            tags: post.tags ? [...post.tags] : null,
+            creators: post.creators ? [...post.creators] : undefined
+          })),
+          pagination: result.pagination
+        }
       },
       initialPageParam: 0,
       getNextPageParam: getNextOffsetPageParam
@@ -183,10 +211,27 @@ export function useMicroPosts(limit = DEFAULT_PAGE_SIZE) {
     useInfiniteQuery<PaginatedResponse<SelectMdxCompiledMicroPost>, Error>({
       queryKey: ['posts', 'micro', limit],
       queryFn: async ({ pageParam = 0 }) => {
-        const url = apiUrlObj(`/content/posts/micro`)
-        url.searchParams.set('limit', String(limit))
-        url.searchParams.set('offset', String(pageParam))
-        return fetcher<PaginatedResponse<SelectMdxCompiledMicroPost>>(url.toString())
+        const client = await getApiClient()
+        const result = await Effect.runPromise(
+          client.post
+            .getMicroPosts({ query: { limit, offset: Number(pageParam) } })
+            .pipe(
+              Effect.tapError((error) =>
+                captureException(error, { endpoint: 'post.getMicroPosts' })
+              )
+            )
+        )
+        return {
+          data: result.data.map((post) => ({
+            ...post,
+            bannerImageUrl: null,
+            createdAt: new Date(post.createdAt),
+            updatedAt: new Date(post.updatedAt),
+            tags: post.tags ? [...post.tags] : null,
+            creators: post.creators ? [...post.creators] : undefined
+          })),
+          pagination: result.pagination
+        }
       },
       initialPageParam: 0,
       getNextPageParam: getNextOffsetPageParam
@@ -206,7 +251,26 @@ export function useMicroPosts(limit = DEFAULT_PAGE_SIZE) {
 export function useEditorialPostBySlug(slug: string) {
   const { data, error, isPending } = useQuery<SelectMdxCompiledEditorialPost, Error>({
     queryKey: ['post', 'editorial', slug],
-    queryFn: async () => fetcher(apiUrl(`/content/posts/editorials/${slug}`)),
+    queryFn: async () => {
+      const client = await getApiClient()
+      const post = await Effect.runPromise(
+        client.post
+          .getEditorialPostBySlug({ params: { slug } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'post.getEditorialPostBySlug' })
+            )
+          )
+      )
+      return {
+        ...post,
+        bannerImageUrl: null,
+        createdAt: new Date(post.createdAt),
+        updatedAt: new Date(post.updatedAt),
+        tags: post.tags ? [...post.tags] : null,
+        creators: post.creators ? [...post.creators] : undefined
+      }
+    },
     enabled: Boolean(slug)
   })
 
@@ -220,7 +284,26 @@ export function useEditorialPostBySlug(slug: string) {
 export function useMicroPostBySlug(slug: string) {
   const { data, error, isPending } = useQuery<SelectMdxCompiledMicroPost, Error>({
     queryKey: ['post', 'micro', slug],
-    queryFn: async () => fetcher(apiUrl(`/content/posts/micro/${slug}`)),
+    queryFn: async () => {
+      const client = await getApiClient()
+      const post = await Effect.runPromise(
+        client.post
+          .getMicroPostBySlug({ params: { slug } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'post.getMicroPostBySlug' })
+            )
+          )
+      )
+      return {
+        ...post,
+        bannerImageUrl: null,
+        createdAt: new Date(post.createdAt),
+        updatedAt: new Date(post.updatedAt),
+        tags: post.tags ? [...post.tags] : null,
+        creators: post.creators ? [...post.creators] : undefined
+      }
+    },
     enabled: Boolean(slug)
   })
 


### PR DESCRIPTION
## Summary
Step 6b: swaps the `post` group hooks in `apps/www/src/lib/http.ts` from raw `fetcher()` calls to the typed `HttpApiClient`. Stacked on `migration/6b-label-release-hooks` (#176).

Ports: `useEditorialTags`, `useEditorialPosts`, `useMicroPosts`, `useEditorialPostBySlug`, `useMicroPostBySlug`.

## Notable decisions

Same `bannerImageUrl`-filler and `Date`-conversion pattern as the label/release PR (#176), with a correction from adversarial review: **the `posts` table genuinely has a `bannerImageUrl` column in production** (added by migration `0023_parallel_switch.sql`, via `defaultContentFields`) -- my original PR description incorrectly claimed the column didn't exist. The real situation is that `PostResponse`'s wire schema (`packages/api/src/post.ts`, written during the earlier post-group backend port, #173) never declared this field, so it's silently stripped from the JSON response before it ever reaches the client, regardless of what's in the DB row. This frontend hook can't recover a value the backend never sends, so the `null` filler here is still correct behavior -- confirmed via grep that no editorial/tweet consumer reads `bannerImageUrl` today -- but if the backend schema is ever fixed to include the real value, this filler will silently overwrite it with `null` again. Flagging as a known follow-up rather than fixing the backend schema in this frontend-only PR.

`createdAt`/`updatedAt` converted back to `Date` objects to match the existing type contracts. Readonly `tags`/`creators` arrays spread into mutable arrays.

## Test plan
- [x] `bun precommit` clean across all 8 packages (format, lint, typecheck)
- [ ] Could not verify end-to-end in a browser: same local disk-space/backend-dev-server limitation noted in #175/#176.

https://claude.ai/code/session_01HHyEKmv9m7DRkS5jcexcqo
