### PR TITLE
feat(www): swap audio-group hooks to typed HttpApiClient (step 6b)

### DIFF
--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -100,10 +100,27 @@ export function useAudioByType(
     useInfiniteQuery<PaginatedResponse<SelectAudio>, Error>({
       queryKey: audioListQueryKey(type, tag, limit),
       queryFn: async ({ pageParam = 0 }) => {
-        const url = apiUrlObj(`/content/audio/${type}`)
-        setPaginationParams(url, Number(pageParam), { limit })
-        if (tag) url.searchParams.set('tag', tag)
-        return fetcher<PaginatedResponse<SelectAudio>>(url.toString())
+        const client = await getApiClient()
+        const result = await Effect.runPromise(
+          client.audio
+            .getAudioByType({ params: { type }, query: { limit, offset: Number(pageParam), tag } })
+            .pipe(
+              Effect.tapError((error) =>
+                captureException(error, { endpoint: 'audio.getAudioByType' })
+              )
+            )
+        )
+        return {
+          data: result.data.map((audio) => ({
+            ...audio,
+            bannerImageUrl: null,
+            createdAt: new Date(audio.createdAt),
+            updatedAt: new Date(audio.updatedAt),
+            tags: audio.tags ? [...audio.tags] : null,
+            creators: audio.creators ? [...audio.creators] : undefined
+          })),
+          pagination: result.pagination
+        }
       },
       initialPageParam: 0,
       getNextPageParam: getNextOffsetPageParam
@@ -123,7 +140,17 @@ export function useAudioByType(
 export function useAudioTags(type: AudioContentType) {
   const { data, error, isPending } = useQuery<string[], Error>({
     queryKey: audioTagsQueryKey(type),
-    queryFn: async () => fetcher<string[]>(apiUrl(`/content/audio/${type}/tags`)),
+    queryFn: async () => {
+      const client = await getApiClient()
+      const tags = await Effect.runPromise(
+        client.audio
+          .getAudioTags({ params: { type } })
+          .pipe(
+            Effect.tapError((error) => captureException(error, { endpoint: 'audio.getAudioTags' }))
+          )
+      )
+      return [...tags]
+    },
     staleTime: 1000 * 60 * 60
   })
   return { data: data ?? [], error, isPending }
@@ -153,7 +180,26 @@ export function useEditorialTags() {
 export function useAudioBySlug(type: AudioContentType, slug: string) {
   const { data, error, isPending } = useQuery<SelectMdxCompiledAudio, Error>({
     queryKey: audioSlugQueryKey(type, slug),
-    queryFn: async () => fetcher(apiUrl(`/content/audio/${type}/${slug}`)),
+    queryFn: async () => {
+      const client = await getApiClient()
+      const audio = await Effect.runPromise(
+        client.audio
+          .getAudioBySlug({ params: { type, slug } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'audio.getAudioBySlug' })
+            )
+          )
+      )
+      return {
+        ...audio,
+        bannerImageUrl: null,
+        createdAt: new Date(audio.createdAt),
+        updatedAt: new Date(audio.updatedAt),
+        tags: audio.tags ? [...audio.tags] : null,
+        creators: audio.creators ? [...audio.creators] : undefined
+      }
+    },
     enabled: Boolean(slug)
   })
 
@@ -1352,7 +1398,16 @@ type QRPdfResponse = {
 export function useMixQRPdf(slug: string, enabled = false) {
   return useQuery<QRPdfResponse>({
     queryKey: ['mix-qr-pdf', slug],
-    queryFn: () => fetcher<QRPdfResponse>(apiUrl(`/content/audio/mix/${slug}/qr-pdf`)),
+    queryFn: async () => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.audio
+          .getMixQRPdf({ params: { slug }, query: {} })
+          .pipe(
+            Effect.tapError((error) => captureException(error, { endpoint: 'audio.getMixQRPdf' }))
+          )
+      )
+    },
     enabled,
     staleTime: 1000 * 60 * 60 * 24
   })


### PR DESCRIPTION
## Summary
Step 6b: swaps the `audio` group hooks in `apps/www/src/lib/http.ts` from raw `fetcher()` calls to the typed `HttpApiClient`. Stacked on `migration/6b-post-hooks` (#177).

Ports: `useAudioByType`, `useAudioTags`, `useAudioBySlug`, `useMixQRPdf`.

## Notable decisions

- Same `bannerImageUrl`-filler pattern as label/release (#176) and post (#177): audio's real Drizzle schema (`apps/vps/src/db/audio.schema.ts`) has no `bannerImageUrl` column, but `SelectAudio`/`SelectMdxCompiledAudio` (from the still-Hono `@gbfm/vps/schemas`) require it -- filled with a literal `null`. `createdAt`/`updatedAt` converted back to `Date` objects. Readonly `tags`/`creators` arrays spread into mutable arrays.
- `useMixQRPdf` passes `query: {}` explicitly since `getMixQRPdf`'s query param (`force`) is optional but the client's TS overload still requires the key present -- same pattern as `getUserSubscriptions` in the user-hooks PR (#175).

## Test plan
- [x] `bun precommit` clean across all 8 packages (format, lint, typecheck)
- [ ] Could not verify end-to-end in a browser: same local disk-space/backend-dev-server limitation noted in #175/#176/#177.

https://claude.ai/code/session_01HHyEKmv9m7DRkS5jcexcqo
