### PR TITLE
feat(www): swap admin-group hooks to typed HttpApiClient (step 6b)

### DIFF
--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -706,7 +706,19 @@ type NewsletterSubscriber = {
 export function useAdminNewsletterSubscribers() {
   return useQuery<{ subscribers: NewsletterSubscriber[] }, Error>({
     queryKey: ['admin', 'newsletter-subscribers'],
-    queryFn: async () => fetcher(apiUrl('/admin/newsletter-subscribers'))
+    queryFn: async () => {
+      const client = await getApiClient()
+      const result = await Effect.runPromise(
+        client.admin
+          .getNewsletterSubscribers({})
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'admin.getNewsletterSubscribers' })
+            )
+          )
+      )
+      return { subscribers: result.subscribers.map((s) => ({ ...s })) }
+    }
   })
 }
 

--- a/apps/www/src/routes/admin/-overview.data.ts
+++ b/apps/www/src/routes/admin/-overview.data.ts
@@ -1,12 +1,48 @@
 import type { AdminOverview } from '@gbfm/vps/schemas'
+import { Effect } from 'effect'
 import { useQuery } from '@tanstack/react-query'
-import { apiUrl, fetcher } from '@/lib/http'
+import { getApiClient } from '@/lib/api-client'
+import { captureException } from '@/services/analytics'
 
 export type { AdminOverviewContentBreakdown } from '@gbfm/vps/schemas'
 
 export function useAdminOverview() {
   return useQuery<AdminOverview, Error>({
     queryKey: ['admin', 'overview'],
-    queryFn: () => fetcher<AdminOverview>(apiUrl('/admin/overview'))
+    queryFn: async () => {
+      const client = await getApiClient()
+      const overview = await Effect.runPromise(
+        client.admin
+          .getAdminOverview({})
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'admin.getAdminOverview' })
+            )
+          )
+      )
+      return {
+        ...overview,
+        publishing: {
+          ...overview.publishing,
+          recentContent: [...overview.publishing.recentContent],
+          topMixes: overview.publishing.topMixes.map((mix) => ({
+            ...mix,
+            creators: [...mix.creators]
+          }))
+        },
+        community: {
+          ...overview.community,
+          recentUsers: [...overview.community.recentUsers],
+          recentSubscribers: [...overview.community.recentSubscribers]
+        },
+        operations: {
+          ...overview.operations,
+          emails: {
+            ...overview.operations.emails,
+            recentFailures: [...overview.operations.emails.recentFailures]
+          }
+        }
+      }
+    }
   })
 }


### PR DESCRIPTION
## Summary
Step 6b: swaps the `admin` group hooks from raw `fetcher()` calls to the typed `HttpApiClient`. Stacked on the merged `migration/effect-http-api` tip (includes #175-#179).

Ports: `useAdminNewsletterSubscribers` (`apps/www/src/lib/http.ts`) and `useAdminOverview` (`apps/www/src/routes/admin/-overview.data.ts`, a separate file outside the usual `http.ts` inventory but genuinely part of the `admin` group).

## Notable decisions

- `useAdminEmailLogs` (`/email/logs`) intentionally **not** ported: confirmed earlier this session that the `email` group hasn't been ported to Effect HttpApi yet, so no `client.email.*` method exists for it.
- `AdminOverviewResponse`'s nested arrays (`publishing.recentContent`, `publishing.topMixes[].creators`, `community.recentUsers`, `community.recentSubscribers`, `operations.emails.recentFailures`) are spread into mutable arrays at each nesting level to match the local `AdminOverview` type (zod-inferred from `apps/vps/src/db/admin-overview.schema.ts`, mutable by default).

## Test plan
- [x] `bun precommit` clean across all 8 packages (format, lint, typecheck)
- [ ] Could not verify end-to-end in a browser: same local disk-space/backend-dev-server limitation noted in prior 6b PRs.

https://claude.ai/code/session_01HHyEKmv9m7DRkS5jcexcqo
