### PR TITLE
feat(www): swap newsletter hooks to typed HttpApiClient (step 6b)

### DIFF
--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -1507,31 +1507,52 @@ type NewsletterSubscribeResponse = {
 
 export function useNewsletterSubscribe() {
   return useMutation<NewsletterSubscribeResponse, Error, { email: string; name?: string }>({
-    mutationFn: async ({ email, name }) =>
-      fetcher<NewsletterSubscribeResponse>(apiUrl('/newsletter/subscribe'), {
-        method: 'POST',
-        body: JSON.stringify({ email, name, source: 'subscribe_page' })
-      })
+    mutationFn: async ({ email, name }) => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.newsletter
+          .subscribe({ payload: { email, name, source: 'subscribe_page' } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'newsletter.subscribe' })
+            )
+          )
+      )
+    }
   })
 }
 
 export function useNewsletterUnsubscribe() {
   return useMutation<{ success: boolean }, Error, { token: string }>({
-    mutationFn: async ({ token }) =>
-      fetcher<{ success: boolean }>(apiUrl('/newsletter/unsubscribe'), {
-        method: 'POST',
-        body: JSON.stringify({ token })
-      })
+    mutationFn: async ({ token }) => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.newsletter
+          .unsubscribe({ payload: { token } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'newsletter.unsubscribe' })
+            )
+          )
+      )
+    }
   })
 }
 
 export function useRequestNewsletterUnsubscribe() {
   return useMutation<{ sent: boolean }, Error, { email: string }>({
-    mutationFn: async ({ email }) =>
-      fetcher<{ sent: boolean }>(apiUrl('/newsletter/request-unsubscribe'), {
-        method: 'POST',
-        body: JSON.stringify({ email })
-      })
+    mutationFn: async ({ email }) => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.newsletter
+          .requestUnsubscribe({ payload: { email } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'newsletter.requestUnsubscribe' })
+            )
+          )
+      )
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
Step 6b: swaps the `newsletter` group hooks in `apps/www/src/lib/http.ts` from raw `fetcher()` calls to the typed `HttpApiClient`. Stacked on `migration/6b-shows-hooks` (#181).

Ports: `useNewsletterSubscribe`, `useNewsletterUnsubscribe`, `useRequestNewsletterUnsubscribe`.

## Notable decisions

All three schemas (`SubscribeInput`/`Response`, `UnsubscribeInput`/`Response`, `RequestUnsubscribeInput`/`Response` in `packages/api/src/newsletter.ts`) are flat, no nested arrays or `Date` fields -- simplest 6b port so far. Preserved the old hook's hardcoded `source: 'subscribe_page'` on subscribe.

## Test plan
- [x] `bun precommit` clean across all 8 packages (format, lint, typecheck)
- [ ] Could not verify end-to-end in a browser: same local disk-space/backend-dev-server limitation noted in prior 6b PRs.

https://claude.ai/code/session_01HHyEKmv9m7DRkS5jcexcqo
