### PR TITLE
feat(www): swap spotify hooks to typed HttpApiClient (step 6b)

### DIFF
--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -366,40 +366,120 @@ type SpotifyProxyInput<T extends SpotifyContentType> = {
   spotifyContentType: T
 }
 
-type SpotifyProxyResponseType<T> = T extends 'album'
-  ? AlbumApiResponse
-  : T extends 'track'
-    ? TrackAPIResponse
-    : T extends 'playlist'
-      ? PlaylistApiResponse
-      : never
-
-export function useSpotifyProxy<T extends SpotifyContentType>({
-  id,
-  spotifyContentType
-}: SpotifyProxyInput<T>) {
-  const { data, error, isLoading } = useQuery<SpotifyProxyResponseType<typeof spotifyContentType>>({
-    queryKey: ['spotify/proxy', spotifyContentType, id],
-
-    queryFn: async () =>
-      fetcher(apiUrl(`/spotify/${spotifyContentType}`), {
-        method: 'POST',
-        body: JSON.stringify({ id })
-      }),
+const useSpotifyAlbumProxy = (id: string, enabled: boolean) => {
+  const { data, error, isLoading } = useQuery<AlbumApiResponse>({
+    queryKey: ['spotify/proxy', 'album', id],
+    queryFn: async () => {
+      const client = await getApiClient()
+      const album = await Effect.runPromise(
+        client.spotify
+          .getSpotifyAlbum({ payload: { id } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'spotify.getSpotifyAlbum' })
+            )
+          )
+      )
+      return { ...album, tracks: album.tracks.map((track) => ({ ...track })) }
+    },
+    enabled,
     staleTime: 15 * 60 * 1000
   })
-  return {
-    data: data,
-    isLoading,
-    error
-  }
+  return { data, isLoading, error }
+}
+
+const useSpotifyTrackProxy = (id: string, enabled: boolean) => {
+  const { data, error, isLoading } = useQuery<TrackAPIResponse>({
+    queryKey: ['spotify/proxy', 'track', id],
+    queryFn: async () => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.spotify
+          .getSpotifyTrack({ payload: { id } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'spotify.getSpotifyTrack' })
+            )
+          )
+      )
+    },
+    enabled,
+    staleTime: 15 * 60 * 1000
+  })
+  return { data, isLoading, error }
+}
+
+const useSpotifyPlaylistProxy = (id: string, enabled: boolean) => {
+  const { data, error, isLoading } = useQuery<PlaylistApiResponse>({
+    queryKey: ['spotify/proxy', 'playlist', id],
+    queryFn: async () => {
+      const client = await getApiClient()
+      const playlist = await Effect.runPromise(
+        client.spotify
+          .getSpotifyPlaylist({ payload: { id } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'spotify.getSpotifyPlaylist' })
+            )
+          )
+      )
+      return {
+        ...playlist,
+        coverImageUrl: playlist.coverImageUrl ?? '',
+        description: playlist.description ?? '',
+        ownerName: playlist.ownerName ?? '',
+        tracks: playlist.tracks.map((track) => ({ ...track }))
+      }
+    },
+    enabled,
+    staleTime: 15 * 60 * 1000
+  })
+  return { data, isLoading, error }
+}
+
+// No single proxy endpoint server-side -- getSpotifyTrack/Album/Playlist are
+// three separate endpoints with different response shapes. Each content type
+// gets its own concretely-typed hook, and the three overload signatures below
+// let each call site's literal `spotifyContentType` resolve to its own real
+// return type -- no runtime-to-generic type correlation needed, since
+// overload resolution is exactly what handles "the literal argument picks
+// the static return type" natively. React's rules of hooks require calling
+// all three unconditionally; `enabled` keeps the two inactive ones from ever
+// actually querying.
+export function useSpotifyProxy(input: SpotifyProxyInput<'album'>): {
+  data: AlbumApiResponse | undefined
+  isLoading: boolean
+  error: Error | null
+}
+export function useSpotifyProxy(input: SpotifyProxyInput<'track'>): {
+  data: TrackAPIResponse | undefined
+  isLoading: boolean
+  error: Error | null
+}
+export function useSpotifyProxy(input: SpotifyProxyInput<'playlist'>): {
+  data: PlaylistApiResponse | undefined
+  isLoading: boolean
+  error: Error | null
+}
+export function useSpotifyProxy({ id, spotifyContentType }: SpotifyProxyInput<SpotifyContentType>) {
+  const isAlbum = spotifyContentType === 'album'
+  const isTrack = spotifyContentType === 'track'
+  const isPlaylist = spotifyContentType === 'playlist'
+
+  const album = useSpotifyAlbumProxy(id, isAlbum)
+  const track = useSpotifyTrackProxy(id, isTrack)
+  const playlist = useSpotifyPlaylistProxy(id, isPlaylist)
+
+  if (isAlbum) return album
+  if (isTrack) return track
+  return playlist
 }
 
 export type EnrichedTrack = {
   title: string
   artist: string
   url: string
-  platform: 'spotify' | 'youtube' | 'apple_music' | 'other'
+  platform: 'spotify' | 'youtube' | 'apple_music' | 'bandcamp' | 'other'
   thumbnailUrl?: string
   duration?: number
   album?: string
@@ -408,11 +488,18 @@ export type EnrichedTrack = {
 export function useEnrichTrackFromUrl(url: string) {
   const { data, error, isLoading } = useQuery<EnrichedTrack>({
     queryKey: ['spotify/enrich', url],
-    queryFn: async () =>
-      fetcher(apiUrl('/spotify/enrich'), {
-        method: 'POST',
-        body: JSON.stringify({ url })
-      }),
+    queryFn: async () => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.spotify
+          .enrichSpotifyTrackFromUrl({ payload: { url: new URL(url) } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'spotify.enrichSpotifyTrackFromUrl' })
+            )
+          )
+      )
+    },
     enabled: Boolean(url) && url.length > 10, // Only run if URL is reasonably long
     staleTime: 15 * 60 * 1000
   })

--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -1507,31 +1507,52 @@ type NewsletterSubscribeResponse = {
 
 export function useNewsletterSubscribe() {
   return useMutation<NewsletterSubscribeResponse, Error, { email: string; name?: string }>({
-    mutationFn: async ({ email, name }) =>
-      fetcher<NewsletterSubscribeResponse>(apiUrl('/newsletter/subscribe'), {
-        method: 'POST',
-        body: JSON.stringify({ email, name, source: 'subscribe_page' })
-      })
+    mutationFn: async ({ email, name }) => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.newsletter
+          .subscribe({ payload: { email, name, source: 'subscribe_page' } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'newsletter.subscribe' })
+            )
+          )
+      )
+    }
   })
 }
 
 export function useNewsletterUnsubscribe() {
   return useMutation<{ success: boolean }, Error, { token: string }>({
-    mutationFn: async ({ token }) =>
-      fetcher<{ success: boolean }>(apiUrl('/newsletter/unsubscribe'), {
-        method: 'POST',
-        body: JSON.stringify({ token })
-      })
+    mutationFn: async ({ token }) => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.newsletter
+          .unsubscribe({ payload: { token } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'newsletter.unsubscribe' })
+            )
+          )
+      )
+    }
   })
 }
 
 export function useRequestNewsletterUnsubscribe() {
   return useMutation<{ sent: boolean }, Error, { email: string }>({
-    mutationFn: async ({ email }) =>
-      fetcher<{ sent: boolean }>(apiUrl('/newsletter/request-unsubscribe'), {
-        method: 'POST',
-        body: JSON.stringify({ email })
-      })
+    mutationFn: async ({ email }) => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.newsletter
+          .requestUnsubscribe({ payload: { email } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'newsletter.requestUnsubscribe' })
+            )
+          )
+      )
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
Step 6b: swaps the `spotify` group hooks in `apps/www/src/lib/http.ts` from raw `fetcher()` calls to the typed `HttpApiClient`. Stacked on `migration/6b-newsletter-hooks` (#182).

Ports: `useSpotifyProxy`, `useEnrichTrackFromUrl`.

## Notable decisions

- **No single `/spotify/:type` proxy endpoint server-side** -- `getSpotifyTrack`/`getSpotifyAlbum`/`getSpotifyPlaylist` are three separate endpoints with different response shapes. Split `useSpotifyProxy`'s internal implementation into three concretely-typed hooks (`useSpotifyAlbumProxy`/`TrackProxy`/`PlaylistProxy`), each unconditionally called per React's rules of hooks, with `enabled` gating so only the one matching the caller's `spotifyContentType` actually queries. The public `useSpotifyProxy` is now three overload signatures (one per content-type literal) plus one implementation signature -- this lets a call site's literal argument resolve to its real return type via normal overload resolution, **with zero type assertions anywhere**, replacing the old generic conditional-type approach that couldn't be proven correct against a runtime string check (the old `fetcher()`-based code only worked around this by being untyped, not by actually solving it).
- **Real schema drift fixed**: `EnrichTrackResponse.platform`'s real union includes `'bandcamp'` (`packages/api/src/spotify.ts`), which the local `EnrichedTrack` type never declared -- added it. No consumer does an exhaustive switch (`reminders.tsx` just renders the value as text), so this was a silent type gap, not a runtime bug, until now.
- `EnrichTrackInput.url` is `Schema.URLFromString` (real WHATWG URL parse) -- payload sends `new URL(url)`, matching the schema's `Type` side.
- Album/playlist responses' readonly `tracks` arrays spread into mutable arrays; playlist's optional `coverImageUrl`/`description`/`ownerName` defaulted to `''` to match the local `PlaylistApiResponse` type's existing contract (already treated as possibly-absent by every real consumer's `data?.field || ''` fallback, so this doesn't change actual behavior).

## Test plan
- [x] `bun precommit` clean across all 8 packages (format, lint, typecheck) -- **zero type assertions** used anywhere in this PR, verified against the project's `consistent-type-assertions` lint rule
- [ ] Could not verify end-to-end in a browser: same local disk-space/backend-dev-server limitation noted in prior 6b PRs.

https://claude.ai/code/session_01HHyEKmv9m7DRkS5jcexcqo
