### PR TITLE
feat(www): swap music-artist hooks to typed HttpApiClient (step 6b)

### DIFF
--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -1678,7 +1678,17 @@ export function useAdminArtists() {
 export function useAdminArtist(id: string) {
   return useQuery<MusicArtist>({
     queryKey: ['admin', 'artists', id],
-    queryFn: () => fetcher(apiUrl(`/music/artists/${id}`)),
+    queryFn: async () => {
+      const client = await getApiClient()
+      const artist = await Effect.runPromise(
+        client.music
+          .getArtist({ params: { id } })
+          .pipe(
+            Effect.tapError((error) => captureException(error, { endpoint: 'music.getArtist' }))
+          )
+      )
+      return { ...artist, genres: artist.genres ? [...artist.genres] : null }
+    },
     enabled: Boolean(id)
   })
 }
@@ -1686,11 +1696,17 @@ export function useAdminArtist(id: string) {
 export function useUpdateAdminArtist() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) =>
-      fetcher<MusicArtist>(apiUrl(`/music/artists/${id}`), {
-        method: 'PATCH',
-        body: JSON.stringify(data)
-      }),
+    mutationFn: async ({ id, data }: { id: string; data: Record<string, unknown> }) => {
+      const client = await getApiClient()
+      const artist = await Effect.runPromise(
+        client.music
+          .updateArtist({ params: { id }, payload: data })
+          .pipe(
+            Effect.tapError((error) => captureException(error, { endpoint: 'music.updateArtist' }))
+          )
+      )
+      return { ...artist, genres: artist.genres ? [...artist.genres] : null }
+    },
     onSuccess: (_, { id }) => {
       qc.invalidateQueries({ queryKey: ['admin', 'artists', id] })
       qc.invalidateQueries({ queryKey: ['admin', 'artists'] })
@@ -1701,7 +1717,16 @@ export function useUpdateAdminArtist() {
 export function useDeleteAdminArtist() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (id: string) => fetcher(apiUrl(`/music/artists/${id}`), { method: 'DELETE' }),
+    mutationFn: async (id: string) => {
+      const client = await getApiClient()
+      await Effect.runPromise(
+        client.music
+          .deleteArtist({ params: { id } })
+          .pipe(
+            Effect.tapError((error) => captureException(error, { endpoint: 'music.deleteArtist' }))
+          )
+      )
+    },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['admin', 'artists'] })
   })
 }
@@ -1866,7 +1891,7 @@ export function useDeleteAdminEntityLink() {
 export function useAddArtistToAlbum() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: ({
+    mutationFn: async ({
       albumId,
       artistId,
       role
@@ -1874,11 +1899,18 @@ export function useAddArtistToAlbum() {
       albumId: string
       artistId: string
       role?: string
-    }) =>
-      fetcher(apiUrl(`/music/albums/${albumId}/artists/${artistId}`), {
-        method: 'PUT',
-        body: JSON.stringify({ role })
-      }),
+    }) => {
+      const client = await getApiClient()
+      await Effect.runPromise(
+        client.music
+          .addArtistToAlbum({ params: { albumId, artistId }, payload: { role } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'music.addArtistToAlbum' })
+            )
+          )
+      )
+    },
     onSuccess: (_, { albumId }) =>
       qc.invalidateQueries({ queryKey: ['admin', 'links', 'album', albumId] })
   })
@@ -1887,10 +1919,18 @@ export function useAddArtistToAlbum() {
 export function useRemoveArtistFromAlbum() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: ({ albumId, artistId }: { albumId: string; artistId: string }) =>
-      fetcher(apiUrl(`/music/albums/${albumId}/artists/${artistId}`), {
-        method: 'DELETE'
-      }),
+    mutationFn: async ({ albumId, artistId }: { albumId: string; artistId: string }) => {
+      const client = await getApiClient()
+      await Effect.runPromise(
+        client.music
+          .removeArtistFromAlbum({ params: { albumId, artistId } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'music.removeArtistFromAlbum' })
+            )
+          )
+      )
+    },
     onSuccess: (_, { albumId }) =>
       qc.invalidateQueries({ queryKey: ['admin', 'links', 'album', albumId] })
   })
@@ -1899,7 +1939,7 @@ export function useRemoveArtistFromAlbum() {
 export function useAddArtistToTrack() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: ({
+    mutationFn: async ({
       trackId,
       artistId,
       role
@@ -1907,11 +1947,18 @@ export function useAddArtistToTrack() {
       trackId: string
       artistId: string
       role?: string
-    }) =>
-      fetcher(apiUrl(`/music/tracks/${trackId}/artists/${artistId}`), {
-        method: 'PUT',
-        body: JSON.stringify({ role })
-      }),
+    }) => {
+      const client = await getApiClient()
+      await Effect.runPromise(
+        client.music
+          .addArtistToTrack({ params: { trackId, artistId }, payload: { role } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'music.addArtistToTrack' })
+            )
+          )
+      )
+    },
     onSuccess: (_, { trackId }) =>
       qc.invalidateQueries({ queryKey: ['admin', 'links', 'track', trackId] })
   })
@@ -1920,10 +1967,18 @@ export function useAddArtistToTrack() {
 export function useRemoveArtistFromTrack() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: ({ trackId, artistId }: { trackId: string; artistId: string }) =>
-      fetcher(apiUrl(`/music/tracks/${trackId}/artists/${artistId}`), {
-        method: 'DELETE'
-      }),
+    mutationFn: async ({ trackId, artistId }: { trackId: string; artistId: string }) => {
+      const client = await getApiClient()
+      await Effect.runPromise(
+        client.music
+          .removeArtistFromTrack({ params: { trackId, artistId } })
+          .pipe(
+            Effect.tapError((error) =>
+              captureException(error, { endpoint: 'music.removeArtistFromTrack' })
+            )
+          )
+      )
+    },
     onSuccess: (_, { trackId }) =>
       qc.invalidateQueries({ queryKey: ['admin', 'links', 'track', trackId] })
   })

--- a/apps/www/src/routes/admin/_components/-MusicEntityDetailPage.tsx
+++ b/apps/www/src/routes/admin/_components/-MusicEntityDetailPage.tsx
@@ -62,9 +62,17 @@ function ArtistDetailPage({ id }: { id: string }) {
 
   async function handleDelete() {
     if (!confirm(`Delete artist "${data?.name}"? This cannot be undone.`)) return
-    await del.mutateAsync(id)
-    toast({ title: 'Artist deleted' })
-    navigate({ to: '/admin/music' })
+    try {
+      await del.mutateAsync(id)
+      toast({ title: 'Artist deleted' })
+      navigate({ to: '/admin/music' })
+    } catch (e) {
+      toast({
+        title: 'Failed to delete artist',
+        description: e instanceof Error ? e.message : undefined,
+        variant: 'destructive'
+      })
+    }
   }
 
   return (
@@ -86,12 +94,25 @@ function ArtistDetailPage({ id }: { id: string }) {
           initialData={toArtistMetadata(data)}
           isSaving={update.isPending}
           onSubmit={async (d) => {
-            const metadata = Object.fromEntries(Object.entries(d))
-            await update.mutateAsync({
-              id,
-              data: metadata
-            })
-            toast({ title: 'Artist saved' })
+            const metadata = Object.fromEntries(
+              Object.entries(d).map(([key, value]) => [
+                key,
+                value instanceof Date ? value.toISOString() : value
+              ])
+            )
+            try {
+              await update.mutateAsync({
+                id,
+                data: metadata
+              })
+              toast({ title: 'Artist saved' })
+            } catch (e) {
+              toast({
+                title: 'Failed to save artist',
+                description: e instanceof Error ? e.message : undefined,
+                variant: 'destructive'
+              })
+            }
           }}
         />
       }


### PR DESCRIPTION
## Summary
Step 6b: swaps the `music` group's **artist** hooks in `apps/www/src/lib/http.ts` from raw `fetcher()` calls to the typed `HttpApiClient`. Branched directly off `migration/effect-http-api` (independent of the spotify PR #183, now merged).

Ports: `useAdminArtist`, `useUpdateAdminArtist`, `useDeleteAdminArtist`, `useAddArtistToAlbum`, `useRemoveArtistFromAlbum`, `useAddArtistToTrack`, `useRemoveArtistFromTrack`. `useAdminArtists` (list) was already ported in step 5 -- the precedent this whole 6b effort follows.

## Scope note (important)

This PR is scoped strictly to what the `music` HttpApi group (`packages/api/src/music.ts`) actually exposes: artist CRUD + artist-to-album/track junction endpoints. **The remaining ~10 admin music hooks in `http.ts` have no corresponding backend endpoint yet**, confirmed by reading `music.ts`'s full endpoint list:

- `useAdminAlbums`/`useAdminAlbum`/`useUpdateAdminAlbum`/`useDeleteAdminAlbum`
- `useAdminTracks`/`useAdminTrack`/`useUpdateAdminTrack`/`useDeleteAdminTrack`
- `useAdminEntityLinks`/`useAddAdminEntityLink`/`useUpdateAdminEntityLinkStatus`/`useDeleteAdminEntityLink`
- `useResolveMusicEntity`

None of these have a `client.music.*` method to call -- porting them now would mean calling methods that don't exist. Left on `fetcher()` until album/track/links/resolve are ported server-side first.

## Fix applied after adversarial review

Review caught a real regression: the old `fetcher()`/`JSON.stringify` path silently serialized `Date` objects (e.g. `publishedAt`, set as a real `Date` by `MusicEntityMetadataForm`) to ISO strings. The typed client's Effect Schema encoder does not do this coercion -- `UpdateArtistInput.publishedAt` is `Schema.optional(Schema.String)`, and encoding a raw `Date` against it throws a `SchemaError`, which would have silently failed every artist metadata save with no visible error (`ArtistDetailPage.onSubmit` had no `try/catch`).

Fixed in `apps/www/src/routes/admin/_components/-MusicEntityDetailPage.tsx`:
- Convert any `Date` value in the form's output to an ISO string before calling `mutateAsync`.
- Added `onError` handling to both `onSubmit` and `handleDelete`, matching the existing `LinksPanel` toast-on-error pattern already in the same file, so a real failure surfaces to the user instead of an unhandled rejection.

## Known pre-existing bug found during review, NOT fixed in this PR (out of scope)

Follow-up verification of the Date fix found a second, structurally identical issue: `UpdateArtistInput.bio`/`imageUrl`/`genres`/`publishedAt` (`packages/api/src/music.ts`) are `Schema.optional(Schema.String)` -- accepts a string or an absent key, but **rejects `null` outright**. `toArtistMetadata` (unchanged by this PR) legitimately produces `null` for any unset field, and `MusicEntityMetadataForm`'s `handleSubmit` always submits the full form state (not a diff), so any artist with an unset bio/image/genres/publishedAt will hit this on save.

Traced this back through git history: `packages/api/src/music.ts`'s `UpdateArtistInput` schema mirrors the **original pre-migration** Hono/zod `updateMusicArtistSchema` (`apps/vps/src/db/music-entity.schema.ts`, still using `.optional()` only, no `.nullable()`) exactly -- confirmed via `git show` on the deleted Hono route file before this session's earlier `music` group port. This means **the bug predates this entire migration** and was never introduced or worsened by this PR, the earlier backend `music` port, or the Date fix above. It's a real, live production bug, not a regression from this work.

Not fixing it here because: (a) it requires a schema change in `packages/api/src/music.ts` (`UpdateArtistInput` should be `Schema.optional(Schema.NullOr(Schema.String))` per field, matching `ArtistResponse`'s existing `Schema.NullOr` pattern), which is backend-port scope, not a frontend client-swap; (b) the correct fix depends on confirming the service layer (`MusicEntityService.updateArtist`) and the underlying Drizzle update actually treat `null` as "clear this field" as intended, not just relaxing the schema without checking the write path handles it. Recommend a small dedicated follow-up PR for `packages/api/src/music.ts`'s `UpdateArtistInput` schema.

## Test plan
- [x] `bun precommit` clean across all 8 packages (format, lint, typecheck)
- [ ] Could not verify end-to-end in a browser: same local disk-space/backend-dev-server limitation noted in prior 6b PRs.

https://claude.ai/code/session_01HHyEKmv9m7DRkS5jcexcqo
