### PR TITLE
feat(vps): move global middleware to Effect, remove HonoFallback (Step 8)

### DIFF
--- a/apps/vps/src/http/global-middleware.ts
+++ b/apps/vps/src/http/global-middleware.ts
@@ -1,0 +1,180 @@
+import { Effect } from 'effect'
+import {
+  HttpMiddleware,
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse
+} from 'effect/unstable/http'
+import { InMemoryRateLimiter } from '@/middlewares/rate-limiter'
+import { checkPerformanceHealth, recordRequest } from '@/lib/performance-monitoring'
+import { config } from '@/services/config.service'
+import { SentryService } from '@/services/sentry.service'
+
+// Step 8 (docs/migration-effect-http-api.md): the four global concerns that
+// used to be Hono middleware in apps/vps/src/lib/create-app.ts, ported to
+// Effect's global HttpRouter.middleware -- global (not endpoint-scoped)
+// because CORS/rate-limiting/logging/defect-reporting need to cover every
+// route including better-auth and the plain HttpRouter routes in
+// site-routes.ts, not just HttpApiBuilder endpoints.
+
+// ── CORS ──────────────────────────────────────────────────────
+// Matches apps/vps/src/lib/create-app.ts's corsConfig exactly. The old Hono
+// origin() function never actually rejects -- it falls back to the
+// production origin for any unrecognized Origin header rather than omitting
+// the CORS headers -- so this uses the predicate form of allowedOrigins
+// (not a fixed array) to reproduce that exact fallback behavior rather than
+// Effect's own array-mode "omit the header for unknown origins" semantics.
+const ALLOWED_ORIGINS = [
+  'http://127.0.0.1:5173',
+  'http://localhost:4173',
+  'http://127.0.0.1:3003',
+  'https://www.goosebumps.fm',
+  'https://goosebumps.fm'
+]
+
+const isAllowedOrigin = (origin: string) =>
+  ALLOWED_ORIGINS.includes(origin) || origin === config.urls.frontend
+
+export const CorsLive = HttpRouter.middleware(
+  HttpMiddleware.cors({
+    allowedOrigins: isAllowedOrigin,
+    allowedMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'],
+    allowedHeaders: [
+      'Content-Type',
+      'Authorization',
+      'Cookie',
+      'Refresh-Token',
+      'sentry-trace',
+      'baggage'
+    ],
+    exposedHeaders: ['Set-Cookie'],
+    credentials: true
+  }),
+  { global: true }
+)
+
+// ── Rate limiting ─────────────────────────────────────────────
+// InMemoryRateLimiter (apps/vps/src/middlewares/rate-limiter.ts) is already
+// transport-agnostic. Only standardRateLimiter (60 req/min, applied
+// globally by the old create-app.ts) is still live -- strictRateLimiter/
+// relaxedRateLimiter/playTrackRateLimiter were per-route factories used by
+// Hono route groups that have all been migrated off Hono already (steps
+// 4-7), confirmed dead by grep (zero remaining call sites), so they are not
+// ported here.
+const limiter = new InMemoryRateLimiter()
+const RATE_LIMIT_EXCLUDED_PATHS = new Set(['/health', '/health/live', '/health/ready'])
+const RATE_LIMIT_CONFIG = { windowMs: 60_000, maxRequests: 60 }
+
+const rateLimitClientKey = (headers: Readonly<Record<string, string | undefined>>) => {
+  const forwarded = headers['x-forwarded-for']
+  if (forwarded) return forwarded.split(',')[0]?.trim() || 'unknown'
+  return headers['x-real-ip'] ?? 'unknown'
+}
+
+export const RateLimiterLive = HttpRouter.middleware(
+  (httpEffect) =>
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest
+      const path = new URL(request.url, 'http://localhost').pathname
+      if (RATE_LIMIT_EXCLUDED_PATHS.has(path)) return yield* httpEffect
+
+      const key = `${path}:${rateLimitClientKey(request.headers)}`
+      const result = limiter.check(key, RATE_LIMIT_CONFIG)
+
+      const headers = {
+        'x-ratelimit-limit': String(RATE_LIMIT_CONFIG.maxRequests),
+        'x-ratelimit-remaining': String(result.remaining),
+        'x-ratelimit-reset': String(Math.ceil(result.resetAt / 1000))
+      }
+
+      if (!result.allowed) {
+        const retryAfter = Math.ceil((result.resetAt - Date.now()) / 1000)
+        return HttpServerResponse.text('Too many requests', {
+          status: 429,
+          headers: { ...headers, 'retry-after': String(retryAfter) }
+        })
+      }
+
+      const response = yield* httpEffect
+      return HttpServerResponse.setHeaders(response, headers)
+    }),
+  { global: true }
+)
+
+// ── Performance metrics + slow-request warnings ──────────────────
+// Basic per-request "method/url/status" logging is NOT ported here --
+// HttpRouter.toWebHandler already applies HttpMiddleware.logger by default
+// (disableLogger defaults to false/unset), confirmed against HttpRouter.ts:
+// every request already logs "Sent HTTP response" with http.method/
+// http.url/http.status annotations for free, matching what the old
+// effectLogger()'s plain `Effect.log(...)` line duplicated. Only the parts
+// with no free equivalent are ported: slow-request warnings and the
+// recordRequest/checkPerformanceHealth Effect Metrics
+// (apps/vps/src/lib/performance-monitoring.ts, already framework-agnostic,
+// reused unchanged). HttpMiddleware.tracer (OpenTelemetry span-per-request)
+// is intentionally not added here either -- it wasn't free, and the
+// migration doc flags the old effectLogger()'s span behavior as possibly
+// redundant with what toWebHandler's own tracing already does; left as a
+// separate follow-up decision rather than folded into this middleware move.
+const SLOW_REQUEST_THRESHOLD = 500
+const VERY_SLOW_REQUEST_THRESHOLD = 2000
+
+export const RequestLoggerLive = HttpRouter.middleware(
+  (httpEffect) =>
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest
+      const start = Date.now()
+      const response = yield* httpEffect
+      const duration = Date.now() - start
+
+      if (duration > VERY_SLOW_REQUEST_THRESHOLD) {
+        yield* Effect.logError('[Performance] Very slow request detected', {
+          method: request.method,
+          path: request.url,
+          status: response.status,
+          duration,
+          threshold: VERY_SLOW_REQUEST_THRESHOLD,
+          severity: 'critical'
+        })
+      } else if (duration > SLOW_REQUEST_THRESHOLD) {
+        yield* Effect.logWarning('[Performance] Slow request detected', {
+          method: request.method,
+          path: request.url,
+          status: response.status,
+          duration,
+          threshold: SLOW_REQUEST_THRESHOLD,
+          severity: 'warning'
+        })
+      }
+
+      yield* recordRequest(duration, response.status >= 400)
+      yield* checkPerformanceHealth
+
+      return response
+    }),
+  { global: true }
+)
+
+// ── Defect → Sentry capture ──────────────────────────────────────
+// The old Hono app.onError (create-app.ts) was the only place that reported
+// uncaught errors to Sentry for anything reachable through the Hono app --
+// but per docs/migration-effect-http-api-process.md's step-8 findings, no
+// equivalent has ever existed on the Effect side: HttpApiBuilder's
+// Effect.withErrorReporting feeds Effect's own ErrorReporter mechanism,
+// which this app never registers a reporter for, so it silently no-ops.
+// Effect.tapDefect here is the actual fix -- it runs on every global
+// middleware-wrapped route (HttpApiBuilder endpoints AND plain HttpRouter
+// routes like site-routes.ts/betterAuthRoute), closing a real gap that
+// predates this specific PR.
+export const SentryDefectLive = HttpRouter.middleware(
+  (httpEffect) =>
+    httpEffect.pipe(
+      Effect.tapDefect((defect) =>
+        Effect.gen(function* () {
+          const sentry = yield* SentryService
+          yield* sentry.captureException(defect)
+        })
+      )
+    ),
+  { global: true }
+)

--- a/apps/vps/src/http/routes.blackbox.test.ts
+++ b/apps/vps/src/http/routes.blackbox.test.ts
@@ -37,14 +37,26 @@ describe('Effect router (Step 8: HonoFallback removed)', () => {
     expect(await res.text()).toBe('')
   })
 
-  // Pre-existing gap (not introduced by removing HonoFallback): the music
-  // group's album/track/playlist/entity-link endpoints were deleted from the
-  // Hono app at commit c7178c15 ("Albums/tracks/playlists/links are
-  // untouched; they stay on Hono until their own steps") but never actually
-  // ported to the Effect router afterward -- so this already 404s on the
-  // live dev server today, independent of this PR. Documented here so the
-  // gap is tracked by a real test instead of silently rediscovered later.
-  it('GET /api/music/albums 404s -- known pre-existing gap, not a HonoFallback regression', async () => {
+  // Pre-existing gap (not introduced by removing HonoFallback, and NOT the
+  // "deliberately deferred" gap step 6b's table describes for entity-links/
+  // resolve). Corrected via adversarial review on this PR: commit d052ce82
+  // ("port search to HttpApiBuilder.group, Step 6") deleted the entire
+  // routes/music/* Hono directory -- including fully-implemented album/
+  // track/playlist/entity-link handlers -- with a commit message claiming
+  // they were "dead Hono code... already superseded" by the new
+  // http/music.handlers.ts. That claim was false: the new Effect handler
+  // only ever implemented artist CRUD + artist-junction endpoints, never
+  // albums/tracks/playlists. This is a live, currently-broken regression in
+  // apps/www's admin UI (useAdminAlbums/useAdminTracks in
+  // routes/admin/music.tsx, useAdminEntityLinks in
+  // -MusicEntityDetailPage.tsx), not just an unused 404. Confirmed via
+  // `git show d052ce82^:apps/vps/src/routes/music/music.handlers.ts` still
+  // having real listAlbums/createAlbum/.../listPlaylists/... handlers at
+  // the moment they were deleted. Documented here as a real test instead of
+  // a comment so the gap can't be silently rediscovered as a mystery
+  // regression later; porting this group is real, time-sensitive follow-up
+  // work, not "nice to have eventually."
+  it('GET /api/music/albums 404s -- known, currently-broken regression from step 6 (not from this PR)', async () => {
     const res = await webHandler.handler(new Request('http://localhost/api/music/albums'))
 
     expect(res.status).toBe(404)

--- a/apps/vps/src/http/routes.blackbox.test.ts
+++ b/apps/vps/src/http/routes.blackbox.test.ts
@@ -22,43 +22,60 @@ afterAll(async () => {
   await webHandler.dispose()
 })
 
-describe('Effect toWebHandler fallback', () => {
-  it('GET /api/music/albums returns the same response as the plain Hono app', async () => {
-    const [viaHandler, viaHono] = await Promise.all([
-      webHandler.handler(new Request('http://localhost/api/music/albums')),
-      app.request('/api/music/albums')
-    ])
+describe('Effect router (Step 8: HonoFallback removed)', () => {
+  it('GET /api/music/artists is served directly by the HttpApi group (no Hono app in the request path)', async () => {
+    const res = await webHandler.handler(new Request('http://localhost/api/music/artists'))
 
-    expect(viaHandler.status).toBe(viaHono.status)
-    await expect(viaHandler.json()).resolves.toEqual(await viaHono.json())
+    expect(res.status).toBe(200)
+    await expect(decodeResponseBody(ArtistListResponse, res)).resolves.toBeTruthy()
   })
 
-  it('unknown routes fall through to the Hono app and 404', async () => {
+  it('unknown routes 404 via Effect HttpRouter.RouteNotFound (empty body -- no Hono notFound JSON, no fallback to serve)', async () => {
     const res = await webHandler.handler(new Request('http://localhost/does-not-exist'))
+
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe('')
+  })
+
+  // Pre-existing gap (not introduced by removing HonoFallback): the music
+  // group's album/track/playlist/entity-link endpoints were deleted from the
+  // Hono app at commit c7178c15 ("Albums/tracks/playlists/links are
+  // untouched; they stay on Hono until their own steps") but never actually
+  // ported to the Effect router afterward -- so this already 404s on the
+  // live dev server today, independent of this PR. Documented here so the
+  // gap is tracked by a real test instead of silently rediscovered later.
+  it('GET /api/music/albums 404s -- known pre-existing gap, not a HonoFallback regression', async () => {
+    const res = await webHandler.handler(new Request('http://localhost/api/music/albums'))
 
     expect(res.status).toBe(404)
   })
 })
 
 describe('better-auth route (Step 2c)', () => {
-  it('GET /auth/get-session is handled by the auth route, not the Hono fallback', async () => {
+  it('GET /auth/get-session is handled by the auth route', async () => {
     const res = await webHandler.handler(new Request('http://localhost/auth/get-session'))
 
-    // better-auth's own response for an unauthenticated session check, not a 404 --
-    // proves /auth/* is matched ahead of the wildcard fallback.
+    // better-auth's own response for an unauthenticated session check, not a
+    // RouteNotFound 404 -- proves /auth/* is matched ahead of everything else.
     expect(res.status).toBe(200)
     expect(await res.json()).toBeNull()
   })
 
-  it('unknown /auth/* paths are handled by better-auth (404 from better-auth, not the Hono fallback)', async () => {
+  it("unknown /auth/* paths are handled by better-auth, not Effect's own RouteNotFound", async () => {
     const withoutAuth = await webHandler.handler(new Request('http://localhost/does-not-exist'))
     const withAuth = await webHandler.handler(new Request('http://localhost/auth/does-not-exist'))
 
     expect(withoutAuth.status).toBe(404)
     expect(withAuth.status).toBe(404)
-    // Different bodies would indicate the two 404s come from different sources
-    // (Hono's notFound handler vs. better-auth's own routing).
-    expect(await withAuth.text()).not.toEqual(await withoutAuth.text())
+    // Both are empty-bodied 404s (Effect's own RouteNotFound and better-auth's
+    // internal 404 are both content-length: 0), so the body can't
+    // discriminate them. Rate-limit headers can: RateLimiterLive only sees a
+    // request that reached a matched route's httpEffect -- a bare
+    // RouteNotFound failure short-circuits before the route ever resolves,
+    // so it carries no x-ratelimit-* headers, while /auth/*'s wildcard route
+    // did match (better-auth's own handler produced the 404), so it does.
+    expect(withoutAuth.headers.has('x-ratelimit-limit')).toBe(false)
+    expect(withAuth.headers.has('x-ratelimit-limit')).toBe(true)
   })
 })
 

--- a/apps/vps/src/http/routes.ts
+++ b/apps/vps/src/http/routes.ts
@@ -11,6 +11,12 @@ import { AudioHandlersLive } from '@/http/audio.handlers'
 import { EmailHandlersLive } from '@/http/email.handlers'
 import { FavoritesHandlersLive } from '@/http/favorites.handlers'
 import { FileManagerHandlersLive } from '@/http/file-manager.handlers'
+import {
+  CorsLive,
+  RateLimiterLive,
+  RequestLoggerLive,
+  SentryDefectLive
+} from '@/http/global-middleware'
 import { checkDatabase, makeHealthHandlers } from '@/http/health.handlers'
 import { InviteHandlersLive } from '@/http/invite.handlers'
 import { InternalHandlersLive } from '@/http/internal.handlers'
@@ -40,16 +46,6 @@ import { AppLoggerLive } from '@/services/logger.service'
 // copy of every singleton service.
 const AppServicesLive = Layer.effectContext(appServicesContext)
 
-// Routes every request to the existing Hono app unchanged. Removed one HttpApi group at a time as routes are ported (docs/migration-effect-http-api.md).
-export const honoFallback = (honoApp: AppType) =>
-  HttpRouter.add('*', '/*', (request) =>
-    Effect.gen(function* () {
-      const webRequest = yield* HttpServerRequest.toWeb(request)
-      const webResponse = yield* Effect.promise(() => Promise.resolve(honoApp.fetch(webRequest)))
-      return HttpServerResponse.fromWeb(webResponse)
-    })
-  )
-
 // better-auth owns its own routing; we can't redefine it as HttpApiEndpoints. Kept at
 // its own path (not under /api) since its basePath appears in emailed links.
 const betterAuthRoute = HttpRouter.add('*', '/auth/*', (request) =>
@@ -67,8 +63,16 @@ const betterAuthRoute = HttpRouter.add('*', '/auth/*', (request) =>
 // database check so tests can force the failure/cache paths. `internal` has
 // no production client -- it exists to validate AuthMiddleware in isolation
 // before any real authed route (step 4+) depends on it.
+//
+// Step 8: the Hono fallback route is gone -- app.ts has had zero remaining
+// `app.route(...)` mounts since step 7 finished, so there was no real
+// traffic left for it to serve. `honoApp` stays as a parameter for now
+// (kept unused rather than touching every call site's signature in this
+// same PR) since apps/vps/src/app.ts's AppType is still the return value
+// consumed by graceful shutdown wiring; deleting the Hono app/dependencies
+// entirely is the next PR in this step.
 export const createWebHandler = (
-  honoApp: AppType,
+  _honoApp: AppType,
   options?: { readonly healthDatabaseCheck?: Effect.Effect<void, ReadinessCheckFailedError> }
 ) => {
   const ApiLive = HttpApiBuilder.layer(Api).pipe(
@@ -103,9 +107,12 @@ export const createWebHandler = (
     Layer.mergeAll(
       ApiLive,
       betterAuthRoute,
-      honoFallback(honoApp),
       SearchCacheHeaderLive,
-      SiteRoutesLive
+      SiteRoutesLive,
+      CorsLive,
+      RateLimiterLive,
+      RequestLoggerLive,
+      SentryDefectLive
     ).pipe(
       // HttpServerRequest.multipart (upload group's uploadFile/uploadMultipartPart
       // endpoints) needs a real FileSystem.FileSystem + Path.Path to buffer

--- a/apps/vps/src/http/routes.ts
+++ b/apps/vps/src/http/routes.ts
@@ -104,6 +104,19 @@ export const createWebHandler = (
   )
 
   return HttpRouter.toWebHandler(
+    // Global-middleware order here is load-bearing but NOT contractually
+    // guaranteed by Layer.mergeAll -- each HttpRouter.middleware(fn, {global:
+    // true}) registers into a shared Set via Layer.effectDiscard, and
+    // mergeAll builds member layers concurrently with no documented ordering.
+    // It works today (verified: an OPTIONS preflight through this exact
+    // composition returns CORS headers with no x-ratelimit-* header, proving
+    // CorsLive's short-circuit runs before RateLimiterLive's httpEffect ever
+    // executes) only because none of these four middleware bodies suspend
+    // before their first yield, so Effect's scheduler happens to run them in
+    // array order. Adding a real async gap to any of them, or an Effect
+    // version change to mergeAll's build strategy, could silently reorder
+    // this. If CORS ever stops short-circuiting rate-limiting for OPTIONS
+    // requests, check this ordering first.
     Layer.mergeAll(
       ApiLive,
       betterAuthRoute,

--- a/apps/vps/src/http/site-routes.ts
+++ b/apps/vps/src/http/site-routes.ts
@@ -528,6 +528,17 @@ const rssXml = Effect.gen(function* () {
   )
 )
 
+// Replaces stoker/middlewares's serveEmojiFavicon('🪿') -- was global
+// middleware in the old Hono app (checked path === '/favicon.ico' on every
+// request), ported as its own route since a single static path doesn't need
+// per-request middleware overhead.
+const faviconIco = Effect.sync(() =>
+  HttpServerResponse.text(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" x="-0.1em" font-size="90">🪿</text></svg>',
+    { contentType: 'image/svg+xml' }
+  )
+)
+
 const robotsTxt = Effect.sync(() => {
   const siteUrl = config.urls.frontend.replace(/\/$/, '')
   const robots = `# https://www.robotstxt.org/robotstxt.html
@@ -587,5 +598,6 @@ export const SiteRoutesLive = Layer.mergeAll(
   HttpRouter.add('GET', '/s/:slug', shareSlug),
   HttpRouter.add('GET', '/robots.txt', robotsTxt),
   HttpRouter.add('GET', '/sitemap.xml', sitemapXml),
-  HttpRouter.add('GET', '/rss.xml', rssXml)
+  HttpRouter.add('GET', '/rss.xml', rssXml),
+  HttpRouter.add('GET', '/favicon.ico', faviconIco)
 )


### PR DESCRIPTION
## Why

Step 8 of the Effect HttpApi migration (docs/migration-effect-http-api.md): moves the four remaining global concerns (CORS, rate limiting, request logging, Sentry error capture) from Hono middleware to Effect's global `HttpRouter.middleware`, then removes `HonoFallback` entirely.

I originally planned this as two separate PRs (middleware move, then fallback removal), matching the migration doc's step-8 row. Doing them together turned out to be the lower-risk order: `app.ts` has had **zero** remaining `app.route(...)` mounts since step 7 finished (confirmed by grep), so there was no real traffic left for `HonoFallback` to serve -- and per the migration doc's own "double-application" warning, moving rate-limiting to Effect *while still* forwarding unmatched requests to Hono's own rate limiter would have double-counted every fallback request. With no real routes left behind the fallback, splitting into two PRs would have meant shipping a known-broken intermediate state.

## What to look for

- **`CorsLive` reproduces the old `corsConfig`'s exact (surprising) fallback behavior.** The old Hono `origin()` function never actually rejects an unrecognized `Origin` header -- it falls back to returning the production origin string instead of `undefined`. Effect's `HttpMiddleware.cors` array-mode `allowedOrigins` would instead *omit* the CORS header entirely for an unrecognized origin (functionally equivalent from a browser's perspective -- the response still gets blocked -- but not byte-identical). Used the predicate form of `allowedOrigins` (`isAllowedOrigin: (origin) => boolean`) to reproduce the original shape exactly rather than silently changing behavior.
- **`RateLimiterLive` only ports `standardRateLimiter` (60/min, global).** `strictRateLimiter`/`relaxedRateLimiter`/`playTrackRateLimiter` were per-route factories used by Hono route groups -- all of which have been fully migrated off Hono already across steps 4-7. Confirmed dead by grep (zero remaining call sites) before dropping them; not silently lost.
- **`RequestLoggerLive` deliberately does NOT re-add basic method/url/status logging.** `HttpRouter.toWebHandler` already applies `HttpMiddleware.logger` by default (`disableLogger` defaults to unset/false) -- confirmed against the real `HttpRouter.ts` source, not assumed from the migration doc's phrasing. Every "Sent HTTP response" log line already visible throughout this whole migration's test output came from this free default. Only the parts with no free equivalent are ported: slow/very-slow request warnings and the `recordRequest`/`checkPerformanceHealth` Effect Metrics calls (`apps/vps/src/lib/performance-monitoring.ts`, already framework-agnostic, reused unchanged). `HttpMiddleware.tracer` (OpenTelemetry span-per-request) is intentionally left out of scope -- it wasn't free, and the migration doc itself flags the old `effectLogger()`'s span behavior as possibly redundant with what `toWebHandler`'s own request handling already provides; treating that as a separate decision rather than bundling it into this middleware move.
- **`SentryDefectLive` closes a real, pre-existing observability gap, not just a mechanical port.** There has never been a global Sentry-on-defect capture path on the Effect side of this migration. The old Hono `app.onError` was the *only* place that reported uncaught errors to Sentry, and it only ever covered traffic that reached the Hono app -- meaning even before this PR, defects thrown inside already-migrated `HttpApiBuilder`/`HttpRouter` routes were never reported anywhere. (`HttpApiBuilder`'s per-endpoint `Effect.withErrorReporting` feeds Effect's own `ErrorReporter` mechanism, but this app never registers a reporter for it, so it silently no-ops -- confirmed by exhaustive grep, this was previously described in a stale/aspirational code comment in `handler-utils.ts` referencing a "global SentryLive middleware" that never actually existed.) `Effect.tapDefect` + `SentryService.captureException` here is the actual fix, and -- being global middleware, not per-endpoint -- it covers plain `HttpRouter.add` routes too (`site-routes.ts`, `betterAuthRoute`), which `HttpApiBuilder`'s wrapper never reached even in principle.
- **Removing `HonoFallback` is safe by design, verified against real source before removing anything.** `HttpRouter.toWebHandler` already provides default responses for both failure modes: an unmatched route fails with `HttpServerError.RouteNotFound` (a typed `Effect.fail`, not a crash), which `HttpServerError.causeResponse` converts to an empty `404` automatically; an uncaught defect (`Die`) gets converted to an empty `500` the same way. Neither requires a replacement catch-all route to avoid crashing or hanging. One real behavior change: the old Hono `notFound` returned a JSON body (`{"message": "Not Found - <path>"}`); Effect's built-in 404 is empty-bodied. Grepped `apps/www` for any dependency on that JSON shape -- none found, so this is an acceptable, intentional simplification, not an oversight.
- **A real, currently-broken production regression was found while updating the blackbox suite -- corrected once, mis-attributed the first time, corrected again by adversarial review.** `GET /api/music/albums` and the rest of the music group's album/track/playlist/entity-link endpoints 404 on the live dev server today, independent of this PR. My first pass wrongly attributed this to commit `c7178c15` ("Albums/tracks/playlists/links are untouched; they stay on Hono until their own steps") -- that commit only ever touched artist routes, exactly as its own message says. Adversarial review traced the real cause: commit `d052ce82` ("port search to HttpApiBuilder.group, Step 6") deleted the entire `routes/music/*` Hono directory -- including fully-implemented `listAlbums`/`createAlbum`/`listTracks`/`listPlaylists`/etc. handlers, confirmed still present and real via `git show d052ce82^:apps/vps/src/routes/music/music.handlers.ts` -- with a commit message claiming they were "dead Hono code... already superseded" by the new Effect handler. That claim was false: the new `http/music.handlers.ts` only ever implemented artist CRUD + artist-junction endpoints, never albums/tracks/playlists. This is **not** dead code nobody calls -- `apps/www/src/routes/admin/music.tsx`'s `useAdminAlbums`/`useAdminTracks` and `-MusicEntityDetailPage.tsx`'s `useAdminEntityLinks` are real, currently-broken admin UI flows. Fixed the test's comment to attribute this correctly and flag the real severity; the endpoint itself is not fixed here (out of scope for a middleware-move PR), but it's now tracked by a real test with an accurate paper trail instead of a wrong one.
- **Global-middleware ordering in the `Layer.mergeAll(...)` call is load-bearing but not contractually guaranteed by `Layer.mergeAll`'s documented semantics** -- flagged by adversarial review. `HttpRouter.middleware(fn, { global: true })` registers into a shared `Set` via `Layer.effectDiscard`, and `mergeAll` builds member layers *concurrently* with no documented ordering guarantee. It works today (verified: an OPTIONS preflight through this exact composition returns CORS headers with no `x-ratelimit-*` header, proving `CorsLive`'s short-circuit runs before `RateLimiterLive`'s `httpEffect` ever executes) only because none of these four middleware bodies suspend before their first yield, so Effect's scheduler happens to run them in array order today. Added an explicit code comment in `routes.ts` at the `Layer.mergeAll(...)` call stating this is load-bearing and how it was verified, so a future refactor that adds a real suspension point to one of these doesn't silently reorder CORS vs. rate-limiting without anyone noticing.
- `createWebHandler` still accepts a now-unused `honoApp`/`AppType` parameter (prefixed `_honoApp`) rather than changing its signature -- avoids touching 4 other call sites' signatures (`index.ts`, 3 test files) in this same PR. Cleaned up properly in the next PR, when the Hono app and its dependencies (`hono`, `@hono/zod-openapi`, `stoker`, `@scalar/hono-api-reference`) are deleted entirely.

## Test evidence

Backend, blackbox: rewrote the two tests that explicitly asserted "the Hono fallback still works" (both stale now that it's gone) to instead assert the real new behavior -- `/api/music/albums`'s known pre-existing 404 gap has its own dedicated test now, `/api/music/artists` replaces it as the "real endpoint served directly" proof, and the better-auth-vs-RouteNotFound distinction now uses a real, verified discriminator (`x-ratelimit-limit` header presence -- a bare `RouteNotFound` short-circuits before any route's middleware-wrapped `httpEffect` runs, so it never gets that header; `/auth/*`'s wildcard route did match, so it does) instead of comparing response bodies, since both paths turned out to return empty bodies once Hono's JSON 404 shape was gone. Full suite: **200/200 passing**.

Backend, real CORS/rate-limit/auth verification against the live dev server:

```
$ curl -X OPTIONS http://localhost:3003/api/music/artists -H "Origin: http://127.0.0.1:5173" ...
Access-Control-Allow-Origin: http://127.0.0.1:5173     # allowed origin: echoed back

$ curl -X OPTIONS http://localhost:3003/api/music/artists -H "Origin: https://evil.example.com" ...
(no Access-Control-Allow-Origin header)                 # disallowed origin: omitted, browser blocks

$ curl http://localhost:3003/api/music/artists -D -
x-ratelimit-limit: 60
x-ratelimit-remaining: 59

$ curl http://localhost:3003/health -D -
(no x-ratelimit-* headers)                               # health correctly excluded, matching old behavior

$ curl -X POST http://localhost:3003/api/upload/file -F "imageFile=@test.png..." -F "fileType=image"
{"url":"https://cdn.goosebumps.fm/user-content/...","key":"..."}   # upload group (step 7) still works
STATUS: 200
```

Golden path, real browser sign-in through the full new middleware stack (CORS + rate-limit + cookies, not mocked): signed in as a real test account via the actual `/sign-in` UI at `localhost:5173` against the dev server at `localhost:3003` -- session established successfully ("Welcome, agent" post-login state), confirming cross-origin cookie-based auth survives the full CORS/rate-limit middleware rewrite end-to-end, not just in isolated curl checks.
