### PR TITLE
feat(vps): port music entity-links/resolve/scrape/pending-queue (Step 6d)

### DIFF
--- a/apps/vps/src/http/music.handlers.ts
+++ b/apps/vps/src/http/music.handlers.ts
@@ -7,6 +7,7 @@ import type {
   CreateArtistInput,
   CreatePlaylistInput,
   CreateTrackInput,
+  EntityLinkResponse,
   PlaylistResponse,
   TrackResponse,
   UpdateAlbumInput,
@@ -19,18 +20,27 @@ import { HttpApiBuilder, HttpApiError } from 'effect/unstable/httpapi'
 import type {
   SelectMusicAlbum,
   SelectMusicArtist,
+  SelectMusicEntityLink,
   SelectMusicPlaylist,
   SelectMusicTrack
 } from '@/db/music-entity.schema'
-import { getErrorMessage } from '@/errors'
+import { FetchError, getErrorMessage } from '@/errors'
 import { dieOnDatabaseError as makeDieOnDatabaseError } from '@/http/handler-utils'
 import { runAppFork } from '@/runtime'
+import { ConfigService } from '@/services/config.service'
 import {
   type CreateAlbumInput as AlbumServiceCreateInput,
   type CreatePlaylistInput as PlaylistServiceCreateInput,
   type CreateTrackInput as TrackServiceCreateInput,
   MusicEntityService
 } from '@/services/music-entity'
+import { S3Service } from '@/services/s3.service'
+import {
+  isAppleMusicUrl,
+  isBandcampUrl,
+  isSpotifyUrl,
+  isYouTubeUrl
+} from '@/services/spotify.service'
 import { getIdFromSpotifyUrl } from '@/services/url-utils'
 
 const toArtistResponse = (row: SelectMusicArtist): ArtistResponse => ({
@@ -60,6 +70,14 @@ const toPlaylistResponse = (
 ): PlaylistResponse => ({
   ...row,
   publishedAt: row.publishedAt?.toISOString() ?? null,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString()
+})
+
+const toEntityLinkResponse = (row: SelectMusicEntityLink): EntityLinkResponse => ({
+  ...row,
+  scrapedAt: row.scrapedAt?.toISOString() ?? null,
+  verifiedAt: row.verifiedAt?.toISOString() ?? null,
   createdAt: row.createdAt.toISOString(),
   updatedAt: row.updatedAt.toISOString()
 })
@@ -151,6 +169,62 @@ const requireAdmin = Effect.gen(function* () {
     return yield* new HttpApiError.Forbidden()
   }
 })
+
+// scrapeAndCreateEntity returns a raw Drizzle row (Date fields, entity-type
+// dependent shape) but the API contract treats the resolved/scraped entity
+// as an opaque JSON record (ResolvedMusicEntityResponse/
+// ScrapeEntityLinksResponse both use Schema.Record) -- same looseness the
+// old Hono handler had via z.record(z.string(), z.unknown()). Dates need
+// converting or they'd serialize inconsistently.
+const toJsonEntity = (entity: Record<string, unknown>): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(entity).map(([key, value]) => [
+      key,
+      value instanceof Date ? value.toISOString() : value
+    ])
+  )
+
+const inferEntityTypeFromUrl = (url: string): 'album' | 'track' | 'playlist' => {
+  if (isSpotifyUrl(url)) {
+    if (url.includes('/album/')) return 'album'
+    if (url.includes('/playlist/')) return 'playlist'
+    return 'track'
+  }
+  if (isBandcampUrl(url)) return 'album'
+  if (isAppleMusicUrl(url)) return 'track'
+  if (isYouTubeUrl(url)) return 'track'
+  return 'track'
+}
+
+// Best-effort: a failed cover-image copy shouldn't fail the whole resolve --
+// the handler falls back to the original (often third-party, possibly
+// short-lived) coverImageUrl in that case. Mirrors the old Hono handler.
+const copyCoverImageEffect = (
+  entityType: 'album' | 'track' | 'playlist',
+  entityId: string,
+  coverImageUrl: string
+) =>
+  Effect.gen(function* () {
+    const config = yield* ConfigService
+    const s3 = yield* S3Service
+
+    const response = yield* Effect.tryPromise({
+      try: () => fetch(coverImageUrl),
+      catch: (cause) => new FetchError({ message: `Failed to fetch ${coverImageUrl}`, cause })
+    })
+
+    if (!response.ok) return null
+
+    const contentType = response.headers.get('content-type') || 'image/jpeg'
+    const arrayBuffer = yield* Effect.tryPromise({
+      try: () => response.arrayBuffer(),
+      catch: (cause) => new FetchError({ message: `Failed to read ${coverImageUrl}`, cause })
+    })
+    const buffer = Buffer.from(arrayBuffer)
+    const key = `music/${entityType}/${entityId}/cover`
+    const uploadedKey = yield* s3.uploadFile(key, buffer, contentType, config.buckets.userContent)
+    return `${config.urls.bucketRouter}/user-content/${uploadedKey}`
+  }).pipe(Effect.catch(() => Effect.succeed(null)))
 
 export const MusicHandlersLive = HttpApiBuilder.group(Api, 'music', (handlers) =>
   handlers
@@ -503,6 +577,146 @@ export const MusicHandlersLive = HttpApiBuilder.group(Api, 'music', (handlers) =
         yield* requireAdmin
         const svc = yield* MusicEntityService
         return yield* dieOnDatabaseError(dieOnSpotifyError(svc.syncPlaylistLinks(params.id)))
+      })
+    )
+    // -----------------------------------------------------------------
+    // Resolve a pasted URL into a music entity
+    // -----------------------------------------------------------------
+    .handle('resolveMusicEntity', ({ payload }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        const entityType = inferEntityTypeFromUrl(payload.url)
+
+        const result = yield* dieOnDatabaseError(
+          svc.scrapeAndCreateEntity(entityType, { url: payload.url })
+        )
+        const entity = result.entity
+        const coverImageUrl = 'coverImageUrl' in entity ? entity.coverImageUrl : null
+
+        if (coverImageUrl) {
+          const publicCoverImageUrl = yield* copyCoverImageEffect(
+            entityType,
+            entity.id,
+            coverImageUrl
+          )
+
+          if (publicCoverImageUrl && publicCoverImageUrl !== coverImageUrl) {
+            if (entityType === 'album') {
+              yield* dieOnDatabaseError(
+                svc.updateAlbum(entity.id, { coverImageUrl: publicCoverImageUrl })
+              ).pipe(Effect.catchTag('NotFoundError', () => Effect.void))
+            } else if (entityType === 'track') {
+              yield* dieOnDatabaseError(
+                svc.updateTrack(entity.id, { coverImageUrl: publicCoverImageUrl })
+              ).pipe(Effect.catchTag('NotFoundError', () => Effect.void))
+            } else {
+              yield* dieOnDatabaseError(
+                svc.updatePlaylist(entity.id, { coverImageUrl: publicCoverImageUrl })
+              ).pipe(Effect.catchTag('NotFoundError', () => Effect.void))
+            }
+            return {
+              entity: toJsonEntity({ ...entity, coverImageUrl: publicCoverImageUrl }),
+              entityType,
+              links: result.links.map(toEntityLinkResponse),
+              coverImageUrl: publicCoverImageUrl
+            }
+          }
+        }
+
+        return {
+          entity: toJsonEntity(entity),
+          entityType,
+          links: result.links.map(toEntityLinkResponse),
+          coverImageUrl
+        }
+      })
+    )
+    // -----------------------------------------------------------------
+    // Links
+    // -----------------------------------------------------------------
+    .handle('listEntityLinks', ({ params, query }) =>
+      Effect.gen(function* () {
+        const svc = yield* MusicEntityService
+        const rows = yield* dieOnDatabaseError(
+          svc.getLinksForEntity(params.entityType, params.entityId, query.status)
+        )
+        return rows.map(toEntityLinkResponse)
+      })
+    )
+    .handle('addEntityLink', ({ params, payload }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        const row = yield* dieOnDatabaseError(
+          svc.addLink({
+            entityType: params.entityType,
+            entityId: params.entityId,
+            platform: payload.platform,
+            url: payload.url,
+            status: payload.status
+          })
+        )
+        return toEntityLinkResponse(row)
+      })
+    )
+    .handle('updateEntityLinkStatus', ({ params, payload }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const { user } = yield* AuthSession
+        const userId = payload.status === 'verified' ? user.id : undefined
+        const svc = yield* MusicEntityService
+        const row = yield* dieOnDatabaseError(
+          svc
+            .updateLinkStatus(
+              params.entityType,
+              params.entityId,
+              params.linkId,
+              payload.status,
+              userId,
+              payload.metadata
+            )
+            .pipe(Effect.catchTag('NotFoundError', () => new HttpApiError.NotFound()))
+        )
+        return toEntityLinkResponse(row)
+      })
+    )
+    .handle('deleteEntityLink', ({ params }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        yield* dieOnDatabaseError(
+          svc
+            .deleteLink(params.entityType, params.entityId, params.linkId)
+            .pipe(Effect.catchTag('NotFoundError', () => new HttpApiError.NotFound()))
+        )
+      })
+    )
+    // -----------------------------------------------------------------
+    // Scrape
+    // -----------------------------------------------------------------
+    .handle('scrapeEntityLinks', ({ params, payload }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        const result = yield* dieOnDatabaseError(
+          svc.scrapeAndCreateEntity(params.entityType, payload)
+        )
+        return {
+          entity: result.entity,
+          links: result.links.map(toEntityLinkResponse)
+        }
+      })
+    )
+    // -----------------------------------------------------------------
+    // Review queue
+    // -----------------------------------------------------------------
+    .handle('listPendingLinks', ({ query }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        const rows = yield* dieOnDatabaseError(svc.getPendingLinks(query))
+        return rows.map(toEntityLinkResponse)
       })
     )
 )

--- a/apps/vps/src/http/routes.blackbox.test.ts
+++ b/apps/vps/src/http/routes.blackbox.test.ts
@@ -334,6 +334,107 @@ describe('music albums/tracks/playlists (HttpApiBuilder group, Step 6c)', () => 
   })
 })
 
+describe('music entity-links/resolve/scrape (HttpApiBuilder group, Step 6d)', () => {
+  it('GET /api/music/artist/:id/links returns 200 with a decodable (empty) list for an unknown entity', async () => {
+    const res = await webHandler.handler(
+      new Request('http://localhost/api/music/artist/00000000-0000-0000-0000-000000000000/links')
+    )
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual([])
+  })
+
+  it('GET /api/music/:entityType/:entityId/links 400s for an invalid entityType (schema-level rejection)', async () => {
+    const res = await webHandler.handler(
+      new Request(
+        'http://localhost/api/music/not-a-real-type/00000000-0000-0000-0000-000000000000/links'
+      )
+    )
+
+    expect(res.status).toBe(400)
+  })
+
+  it('POST /api/music/artist/:id/links returns 401 without a session cookie', async () => {
+    const res = await webHandler.handler(
+      new Request('http://localhost/api/music/artist/00000000-0000-0000-0000-000000000000/links', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ platform: 'spotify', url: 'https://open.spotify.com/artist/x' })
+      })
+    )
+
+    expect(res.status).toBe(401)
+  })
+
+  it('PATCH /api/music/artist/:id/links/:linkId returns 401 without a session cookie', async () => {
+    const res = await webHandler.handler(
+      new Request(
+        'http://localhost/api/music/artist/00000000-0000-0000-0000-000000000000/links/00000000-0000-0000-0000-000000000000',
+        {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ status: 'verified' })
+        }
+      )
+    )
+
+    expect(res.status).toBe(401)
+  })
+
+  it('DELETE /api/music/artist/:id/links/:linkId returns 401 without a session cookie', async () => {
+    const res = await webHandler.handler(
+      new Request(
+        'http://localhost/api/music/artist/00000000-0000-0000-0000-000000000000/links/00000000-0000-0000-0000-000000000000',
+        { method: 'DELETE' }
+      )
+    )
+
+    expect(res.status).toBe(401)
+  })
+
+  it('POST /api/music/resolve returns 401 without a session cookie', async () => {
+    const res = await webHandler.handler(
+      new Request('http://localhost/api/music/resolve', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'https://open.spotify.com/track/abc' })
+      })
+    )
+
+    expect(res.status).toBe(401)
+  })
+
+  it('POST /api/music/resolve returns 401 (not 400) for a non-URL body without a session -- AuthMiddleware runs before payload schema validation', async () => {
+    const res = await webHandler.handler(
+      new Request('http://localhost/api/music/resolve', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'not-a-url' })
+      })
+    )
+
+    expect(res.status).toBe(401)
+  })
+
+  it('POST /api/music/artist/scrape returns 401 without a session cookie', async () => {
+    const res = await webHandler.handler(
+      new Request('http://localhost/api/music/artist/scrape', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ artistName: 'Test Artist' })
+      })
+    )
+
+    expect(res.status).toBe(401)
+  })
+
+  it('GET /api/music/links/pending returns 401 without a session cookie', async () => {
+    const res = await webHandler.handler(new Request('http://localhost/api/music/links/pending'))
+
+    expect(res.status).toBe(401)
+  })
+})
+
 describe('search (HttpApiBuilder group, Step 6)', () => {
   it('GET /api/search?q=test returns 200 with a decodable grouped result', async () => {
     const res = await webHandler.handler(new Request('http://localhost/api/search?q=test'))

--- a/packages/api/src/music.ts
+++ b/packages/api/src/music.ts
@@ -240,6 +240,93 @@ const albumIdParam = { id: Schema.String }
 const trackIdParam = { id: Schema.String }
 const playlistIdParam = { id: Schema.String }
 
+// Mirrors apps/vps/src/db/music-entity.schema.ts's MUSIC_ENTITY_TYPES,
+// MUSIC_PLATFORMS, LINK_STATUSES.
+export const EntityType = Schema.Literals(['artist', 'album', 'track', 'playlist'])
+export const MusicPlatform = Schema.Literals([
+  'spotify',
+  'youtube',
+  'youtube_music',
+  'apple_music',
+  'bandcamp',
+  'soundcloud',
+  'tidal',
+  'deezer',
+  'amazon_music',
+  'discord',
+  'website',
+  'instagram',
+  'twitter',
+  'musicbrainz',
+  'other'
+])
+export const LinkStatus = Schema.Literals(['pending_review', 'verified', 'rejected'])
+
+// Mirrors selectMusicEntityLinkSchema -- entityType/platform/status use plain
+// String in the select shape (Drizzle types varchar FK columns as string;
+// enum validation is enforced on inputs only), same convention the old Hono
+// select schema used.
+export const EntityLinkResponse = Schema.Struct({
+  id: Schema.String,
+  entityType: Schema.String,
+  entityId: Schema.String,
+  platform: Schema.String,
+  url: Schema.String,
+  status: Schema.String,
+  scrapedAt: Schema.NullOr(Schema.String),
+  verifiedAt: Schema.NullOr(Schema.String),
+  verifiedBy: Schema.NullOr(Schema.String),
+  metadata: Schema.NullOr(Schema.Record(Schema.String, Schema.Unknown)),
+  createdAt: Schema.String,
+  updatedAt: Schema.String
+})
+export type EntityLinkResponse = typeof EntityLinkResponse.Type
+
+export const EntityLinkListResponse = Schema.Array(EntityLinkResponse)
+
+const entityLinkParams = { entityType: EntityType, entityId: Schema.String }
+
+export const AddEntityLinkInput = Schema.Struct({
+  platform: MusicPlatform,
+  url: UrlString,
+  status: Schema.optional(LinkStatus)
+})
+
+export const UpdateEntityLinkStatusInput = Schema.Struct({
+  status: LinkStatus,
+  metadata: Schema.optional(Schema.Record(Schema.String, Schema.Unknown))
+})
+
+export const ResolveMusicEntityInput = Schema.Struct({
+  url: UrlString
+})
+
+export const ResolvedMusicEntityResponse = Schema.Struct({
+  entityType: EntityType,
+  entity: Schema.Record(Schema.String, Schema.Unknown),
+  links: Schema.Array(EntityLinkResponse),
+  coverImageUrl: Schema.NullOr(Schema.String)
+})
+
+export const ScrapeEntityLinksInput = Schema.Struct({
+  url: Schema.optional(UrlString),
+  artistName: Schema.optional(Schema.String),
+  albumTitle: Schema.optional(Schema.String),
+  trackTitle: Schema.optional(Schema.String),
+  mbid: Schema.optional(Schema.String),
+  isrc: Schema.optional(Schema.String)
+})
+
+export const ScrapeEntityLinksResponse = Schema.Struct({
+  entity: Schema.Record(Schema.String, Schema.Unknown),
+  links: Schema.Array(EntityLinkResponse)
+})
+
+export const PendingLinksQuery = Schema.Struct({
+  limit: Schema.optional(Schema.NumberFromString),
+  offset: Schema.optional(Schema.NumberFromString)
+})
+
 export const MusicGroup = HttpApiGroup.make('music')
   .add(HttpApiEndpoint.get('listArtists', '/api/music/artists', { success: ArtistListResponse }))
   .add(
@@ -461,6 +548,74 @@ export const MusicGroup = HttpApiGroup.make('music')
     HttpApiEndpoint.post('syncPlaylistLinks', '/api/music/playlists/:id/sync-links', {
       params: playlistIdParam,
       success: SyncPlaylistLinksResponse,
+      error: HttpApiError.Forbidden
+    }).middleware(AuthMiddleware)
+  )
+  // ---------------------------------------------------------------------
+  // Resolve a pasted URL into a music entity
+  // ---------------------------------------------------------------------
+  .add(
+    HttpApiEndpoint.post('resolveMusicEntity', '/api/music/resolve', {
+      payload: ResolveMusicEntityInput,
+      success: ResolvedMusicEntityResponse,
+      error: HttpApiError.Forbidden
+    }).middleware(AuthMiddleware)
+  )
+  // ---------------------------------------------------------------------
+  // Links -- per entity
+  // ---------------------------------------------------------------------
+  .add(
+    HttpApiEndpoint.get('listEntityLinks', '/api/music/:entityType/:entityId/links', {
+      params: entityLinkParams,
+      query: Schema.Struct({ status: Schema.optional(LinkStatus) }),
+      success: EntityLinkListResponse
+    })
+  )
+  .add(
+    HttpApiEndpoint.post('addEntityLink', '/api/music/:entityType/:entityId/links', {
+      params: entityLinkParams,
+      payload: AddEntityLinkInput,
+      success: EntityLinkResponse,
+      error: HttpApiError.Forbidden
+    }).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.patch(
+      'updateEntityLinkStatus',
+      '/api/music/:entityType/:entityId/links/:linkId',
+      {
+        params: { ...entityLinkParams, linkId: Schema.String },
+        payload: UpdateEntityLinkStatusInput,
+        success: EntityLinkResponse,
+        error: [HttpApiError.NotFound, HttpApiError.Forbidden]
+      }
+    ).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.delete('deleteEntityLink', '/api/music/:entityType/:entityId/links/:linkId', {
+      params: { ...entityLinkParams, linkId: Schema.String },
+      success: HttpApiSchema.NoContent,
+      error: [HttpApiError.NotFound, HttpApiError.Forbidden]
+    }).middleware(AuthMiddleware)
+  )
+  // ---------------------------------------------------------------------
+  // Scrape -- trigger link discovery for an entity
+  // ---------------------------------------------------------------------
+  .add(
+    HttpApiEndpoint.post('scrapeEntityLinks', '/api/music/:entityType/scrape', {
+      params: { entityType: EntityType },
+      payload: ScrapeEntityLinksInput,
+      success: ScrapeEntityLinksResponse,
+      error: HttpApiError.Forbidden
+    }).middleware(AuthMiddleware)
+  )
+  // ---------------------------------------------------------------------
+  // Review queue -- all pending links (admin)
+  // ---------------------------------------------------------------------
+  .add(
+    HttpApiEndpoint.get('listPendingLinks', '/api/music/links/pending', {
+      query: PendingLinksQuery,
+      success: EntityLinkListResponse,
       error: HttpApiError.Forbidden
     }).middleware(AuthMiddleware)
   )


### PR DESCRIPTION
## Why

Completes the music album/track/playlist port from #191 with the remaining groups that PR deliberately scoped out: entity-link management and the paste-a-URL resolve flow. Together with #191, this fully resolves the `d052ce82` regression tracked in `docs/migration-effect-http-api.md` -- every endpoint the old (deleted) `routes/music/*` Hono handlers served is now back.

## What

Extends `packages/api/src/music.ts`'s `MusicGroup` and `apps/vps/src/http/music.handlers.ts`'s `MusicHandlersLive` with:
- Entity-link CRUD: `listEntityLinks` (public), `addEntityLink`, `updateEntityLinkStatus`, `deleteEntityLink` (all admin-gated)
- `resolveMusicEntity`: paste-a-URL flow (infers entity type from URL, scrapes, creates the entity, best-effort re-uploads the cover image to our own S3 bucket)
- `scrapeEntityLinks`: trigger link discovery for a manually-specified entity (admin tooling, not currently wired to any `apps/www` UI)
- `listPendingLinks`: admin review queue for links awaiting verification

Real `apps/www` consumers: `useAdminEntityLinks`/`useAddAdminEntityLink`/`useUpdateAdminEntityLinkStatus`/`useDeleteAdminEntityLink` (used in both `-MusicEntityDetailPage.tsx` and `-TweetCapturePage.tsx`) and `useResolveMusicEntity` (`-TweetCapturePage.tsx`'s paste-a-link flow). All were broken since `d052ce82`; this PR restores them.

`listEntityLinks` is intentionally public (no `AuthMiddleware`), matching the old Hono route -- everything else follows the same `requireAdmin` in-handler convention used throughout this file.

**Base note**: this branch stacks on `migration/6c-music-albums-tracks-playlists` (#191), which was updated after adversarial review to fix 3 real bugs (empty-slug validation, null-rejecting update schemas, a swallowed 400-as-500 on `addSpotifyTrackToPlaylist`). This PR's diff is purely the new entity-link/resolve/scrape/pending-queue work on top of that fixed base.

## Test evidence

**Blackbox tests** (9 new, 111/111 total in the file):

```
$ bun vitest run src/http/routes.blackbox.test.ts
 Test Files  1 passed (1)
      Tests  111 passed (111)
```

**Live curl verification** against dev server with real data:

```
$ curl -s "http://localhost:3003/api/music/artist/$ARTIST_ID/links"
[]
$ curl -s "http://localhost:3003/api/music/album/$ALBUM_ID/links" | head -c 300
[{"id":"692fb36a-...","entityType":"album","entityId":"7a0fea96-...","platform":"amazon_music",
  "url":"https://music.amazon.com/albums/B01MG4JUYK","status":"verified",
  "scrapedAt":"2026-07-11T09:29:04.533Z","verifiedAt":"2026-07-11T09:29:13.213Z", ...}]

$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3003/api/music/not-a-type/.../links
400   # invalid entityType rejected at the schema layer
$ curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:3003/api/music/resolve -d '...'
401   # admin-gated, correctly rejects without a session
$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3003/api/music/links/pending
401
```

Response shape matches `apps/www`'s `AdminMusicEntityLink` interface (`apps/www/src/lib/http.ts`) field-for-field against real production data (verified above, not just a synthetic payload).

Did not attempt a browser screenshot of the admin UI for this PR either, for the same reason as #191 -- no admin credential available and I won't grant admin role to a throwaway account without asking. API-contract-level evidence (curl against real data + blackbox tests) stands in for it; the UI code is unchanged, only the backend contract it already calls is being restored.

## Test plan
- [x] `bun run typecheck` clean (packages/api, apps/vps, apps/www)
- [x] `bun precommit` clean (format, lint, typecheck)
- [x] 9 new blackbox tests, 111/111 passing
- [x] Live curl verification against dev server with real production data (entity-links with actual link rows, not just empty-array cases)
- [x] Auth gating verified (401 for all admin-only routes without session, 400 for invalid entityType at the schema layer)
