### PR TITLE
refactor(player): make the engine an Effect service with per-mount layers

### DIFF
--- a/apps/mobile/src/audio/NowPlayingProvider.tsx
+++ b/apps/mobile/src/audio/NowPlayingProvider.tsx
@@ -1,10 +1,11 @@
 import type { AudioResponse } from '@gbfm/api/audio'
 import {
-  createPlayerCore,
+  makePlayerCore,
   type EngineStatus,
-  type PlayerCore,
+  type PlayerCoreShape,
   type QueueTrackType
 } from '@gbfm/player'
+import { Effect, Layer, ManagedRuntime } from 'effect'
 import { useAudioPlayer } from 'expo-audio'
 import { useAtomValue } from '@effect/atom-react'
 import {
@@ -18,9 +19,9 @@ import {
   useState
 } from 'react'
 import { audioModeAtom } from '@/store/atoms/audio-mode'
-import { createExpoAudioEngine } from '@/audio/expoAudioEngine'
-import { recordPlayIfFresh } from '@/audio/playTracker'
-import { playerStorage } from '@/runtime'
+import { ExpoAudioEngineLayer } from '@/audio/expoAudioEngine'
+import { PlayReporterLive } from '@/audio/playTracker'
+import { PlayerStorageLive } from '@/audio/queueStorage'
 import type { QueueView } from '@/audio/queueAtom'
 import { useQueue, useQueueDispatch } from '@/audio/queueAtom'
 
@@ -85,39 +86,63 @@ export function NowPlayingProvider({ children }: PropsWithChildren) {
   const [status, setStatus] = useState<EngineStatus>(initialStatus)
   const [queueNotice, setQueueNotice] = useState<QueueNotice | null>(null)
 
-  const coreRef = useRef<PlayerCore | null>(null)
+  const coreRef = useRef<PlayerCoreShape | null>(null)
+  const runtimeRef = useRef<ManagedRuntime.ManagedRuntime<never, never> | null>(null)
   const skipNextRef = useRef<() => void>(() => {})
 
+  /** Runs a core operation on the mount's runtime. No-ops before the core is
+   *  built or after unmount. */
+  const runCore = useCallback((operation: (core: PlayerCoreShape) => Effect.Effect<void>) => {
+    const core = coreRef.current
+    const runtime = runtimeRef.current
+    if (!core || !runtime) return
+    runtime.runFork(operation(core))
+  }, [])
+
   useEffect(() => {
-    const core = createPlayerCore(createExpoAudioEngine(player), playerStorage, {
-      onStatus: setStatus,
-      onTrackFinished: () => skipNextRef.current(),
-      recordPlay: recordPlayIfFresh
-    })
-    coreRef.current = core
+    // The expo player is owned by this mount, so its layer and the core's
+    // status fiber live in a runtime scoped to the same lifetime.
+    const runtime = ManagedRuntime.make(
+      Layer.mergeAll(ExpoAudioEngineLayer(player), PlayReporterLive).pipe(
+        Layer.provideMerge(PlayerStorageLive)
+      )
+    )
+    runtimeRef.current = runtime
+
+    runtime.runFork(
+      Effect.gen(function* () {
+        const core = yield* makePlayerCore({
+          onStatus: setStatus,
+          onTrackFinished: () => skipNextRef.current()
+        })
+        coreRef.current = core
+        yield* Effect.never
+      }).pipe(Effect.scoped)
+    )
+
     return () => {
-      core.dispose()
       coreRef.current = null
+      runtimeRef.current = null
+      void runtime.dispose()
     }
   }, [player])
 
   useEffect(() => {
-    coreRef.current?.setSource(currentTrack)
-  }, [currentTrack])
+    runCore((core) => core.setSource(currentTrack))
+  }, [currentTrack, runCore])
 
   const loadAndPlay = useCallback(
     (nextTrack: Track) => {
-      const core = coreRef.current
-      if (!core) return
       if (currentTrack?.id === nextTrack.id) {
-        core.play(nextTrack.id)
+        runCore((core) => core.play(nextTrack.id))
         return
       }
-      core.requestPlayOnReady(nextTrack.id)
-      core.detachCurrentSource()
+      runCore((core) =>
+        core.requestPlayOnReady(nextTrack.id).pipe(Effect.andThen(core.detachCurrentSource))
+      )
       dispatch({ _tag: 'playNow', track: toQueueTrack(nextTrack) })
     },
-    [currentTrack?.id, dispatch]
+    [currentTrack?.id, dispatch, runCore]
   )
 
   const enqueue = useCallback(
@@ -142,30 +167,34 @@ export function NowPlayingProvider({ children }: PropsWithChildren) {
 
   const playAll = useCallback(
     (tracks: ReadonlyArray<Track>) => {
-      const core = coreRef.current
-      if (!core || tracks.length === 0) return
+      if (tracks.length === 0) return
       const queued = tracks.map(toQueueTrack)
       const first = queued[0]
       if (!first) return
-      core.requestPlayOnReady(first.id)
-      core.detachCurrentSource()
+      runCore((core) =>
+        core.requestPlayOnReady(first.id).pipe(Effect.andThen(core.detachCurrentSource))
+      )
       dispatch({ _tag: 'playAll', tracks: queued })
     },
-    [dispatch]
+    [dispatch, runCore]
   )
 
   const removeFromQueue = useCallback(
     (index: number) => {
-      const core = coreRef.current
-      if (!core || index < 0 || index >= queue.tracks.length) return
+      if (index < 0 || index >= queue.tracks.length) return
       if (index === queue.currentIndex) {
         const next = queue.tracks[index + 1] ?? queue.tracks[index - 1]
-        if (core.isDesiredPlaying() && next) core.requestPlayOnReady(next.id)
-        core.detachCurrentSource()
+        runCore((core) =>
+          Effect.flatMap(core.isDesiredPlaying, (desired) =>
+            (desired && next ? core.requestPlayOnReady(next.id) : Effect.void).pipe(
+              Effect.andThen(core.detachCurrentSource)
+            )
+          )
+        )
       }
       dispatch({ _tag: 'remove', index })
     },
-    [dispatch, queue.currentIndex, queue.tracks]
+    [dispatch, queue.currentIndex, queue.tracks, runCore]
   )
 
   const reorderQueue = useCallback(
@@ -177,18 +206,18 @@ export function NowPlayingProvider({ children }: PropsWithChildren) {
 
   const skipTo = useCallback(
     (index: number) => {
-      const core = coreRef.current
       const target = queue.tracks[index]
-      if (!core || !target) return
+      if (!target) return
       if (currentTrack?.id === target.id) {
-        core.play(target.id)
+        runCore((core) => core.play(target.id))
         return
       }
-      core.requestPlayOnReady(target.id)
-      core.detachCurrentSource()
+      runCore((core) =>
+        core.requestPlayOnReady(target.id).pipe(Effect.andThen(core.detachCurrentSource))
+      )
       dispatch({ _tag: 'playIndex', index })
     },
-    [currentTrack?.id, dispatch, queue.tracks]
+    [currentTrack?.id, dispatch, queue.tracks, runCore]
   )
 
   const skipNext = useCallback(() => {
@@ -200,29 +229,34 @@ export function NowPlayingProvider({ children }: PropsWithChildren) {
   const skipPrevious = useCallback(() => {
     if (queue.currentIndex < 0) return
     if (queue.currentIndex === 0) {
-      coreRef.current?.seekTo(0)
+      runCore((core) => core.seekTo(0))
       return
     }
     skipTo(queue.currentIndex - 1)
-  }, [queue.currentIndex, skipTo])
+  }, [queue.currentIndex, runCore, skipTo])
 
   skipNextRef.current = skipNext
 
   const togglePlayback = useCallback(() => {
-    const core = coreRef.current
-    if (!core || !currentTrack) return
-    if (core.isDesiredPlaying()) core.pause()
-    else core.play(currentTrack.id)
-  }, [currentTrack])
+    if (!currentTrack) return
+    runCore((core) =>
+      Effect.flatMap(core.isDesiredPlaying, (desired) =>
+        desired ? core.pause : core.play(currentTrack.id)
+      )
+    )
+  }, [currentTrack, runCore])
 
-  const seekTo = useCallback((seconds: number) => {
-    coreRef.current?.seekTo(seconds)
-  }, [])
+  const seekTo = useCallback(
+    (seconds: number) => {
+      runCore((core) => core.seekTo(seconds))
+    },
+    [runCore]
+  )
 
   const clearQueue = useCallback(() => {
-    coreRef.current?.detachCurrentSource()
+    runCore((core) => core.detachCurrentSource)
     dispatch({ _tag: 'clear' })
-  }, [dispatch])
+  }, [dispatch, runCore])
 
   const value = useMemo<NowPlayingContextValue>(
     () => ({

--- a/apps/mobile/src/audio/expoAudioEngine.ts
+++ b/apps/mobile/src/audio/expoAudioEngine.ts
@@ -1,4 +1,5 @@
-import type { AudioEngine, EngineStatus } from '@gbfm/player'
+import { AudioEngine, type EngineStatus, type NowPlayingMetadata } from '@gbfm/player'
+import { Effect, Layer, Queue, Stream } from 'effect'
 import type { AudioPlayer, AudioStatus } from 'expo-audio'
 import { Platform } from 'react-native'
 import { subscribeToPlaybackStatus } from '@/audio/audioPlayerAdapter'
@@ -12,29 +13,44 @@ const toEngineStatus = (status: AudioStatus): EngineStatus => ({
   isBuffering: status.isBuffering
 })
 
-export const createExpoAudioEngine = (player: AudioPlayer): AudioEngine => ({
-  replace: (url) => player.replace(url),
-  play: () => player.play(),
-  pause: () => player.pause(),
-  seekTo: (seconds) => player.seekTo(seconds),
-  currentStatus: () => toEngineStatus(player.currentStatus),
-  subscribe: (listener) =>
-    subscribeToPlaybackStatus(player, Platform.OS === 'web' ? 'web' : 'native', (status) =>
-      listener(toEngineStatus(status))
+const makeExpoAudioEngine = (player: AudioPlayer) =>
+  Effect.sync(() => ({
+    replace: (url: string) => Effect.sync(() => player.replace(url)),
+    play: Effect.sync(() => player.play()),
+    pause: Effect.sync(() => player.pause()),
+    seekTo: (seconds: number) => Effect.promise(() => player.seekTo(seconds)),
+    currentStatus: Effect.sync(() => toEngineStatus(player.currentStatus)),
+
+    changes: Stream.callback<EngineStatus>((queue) =>
+      Effect.gen(function* () {
+        const subscription = subscribeToPlaybackStatus(
+          player,
+          Platform.OS === 'web' ? 'web' : 'native',
+          (status) => {
+            Queue.offerUnsafe(queue, toEngineStatus(status))
+          }
+        )
+        yield* Effect.addFinalizer(() => Effect.sync(() => subscription.remove()))
+      })
     ),
-  setNowPlaying: (metadata) => {
-    if (!metadata) {
-      player.clearLockScreenControls()
-      return
-    }
-    player.setActiveForLockScreen(
-      true,
-      {
-        title: metadata.title,
-        artist: metadata.artist,
-        artworkUrl: metadata.artworkUrl
-      },
-      { showSeekForward: true, showSeekBackward: true }
-    )
-  }
-})
+
+    setNowPlaying: (metadata: NowPlayingMetadata | null) =>
+      Effect.sync(() => {
+        if (!metadata) {
+          player.clearLockScreenControls()
+          return
+        }
+        player.setActiveForLockScreen(
+          true,
+          {
+            title: metadata.title,
+            artist: metadata.artist,
+            artworkUrl: metadata.artworkUrl
+          },
+          { showSeekForward: true, showSeekBackward: true }
+        )
+      })
+  }))
+
+export const ExpoAudioEngineLayer = (player: AudioPlayer) =>
+  Layer.effect(AudioEngine, makeExpoAudioEngine(player))

--- a/apps/mobile/src/audio/playTracker.ts
+++ b/apps/mobile/src/audio/playTracker.ts
@@ -1,7 +1,6 @@
-import { Effect } from 'effect'
+import { createPlayDelivery, PlayerStorage, PlayReporter } from '@gbfm/player'
+import { Effect, Layer, Semaphore } from 'effect'
 import { getApiClient } from '@/api/client'
-import { createPlayDelivery } from '@gbfm/player'
-import { playerStorage } from '@/runtime'
 
 export const trackAudioPlay = (trackId: string) =>
   Effect.gen(function* () {
@@ -9,23 +8,28 @@ export const trackAudioPlay = (trackId: string) =>
     yield* client.audio.trackAudioPlay({ params: { id: trackId } })
   })
 
-const deliverPlayIfFresh = createPlayDelivery({
-  isWithinDedupWindow: playerStorage.isWithinDedupWindow,
-  deliver: trackAudioPlay,
-  remember: playerStorage.recordPlay,
-  now: Date.now
-})
+export const PlayReporterLive = Layer.effect(
+  PlayReporter,
+  Effect.gen(function* () {
+    const storage = yield* PlayerStorage
 
-let playDeliveryTail: Promise<void> = Promise.resolve()
+    const deliverPlayIfFresh = createPlayDelivery({
+      isWithinDedupWindow: storage.isWithinDedupWindow,
+      deliver: trackAudioPlay,
+      remember: storage.recordPlay,
+      now: Date.now
+    })
 
-export const recordPlayIfFresh = (trackId: string) =>
-  Effect.tryPromise({
-    try: () => {
-      const delivery = playDeliveryTail
-        .catch(() => undefined)
-        .then(() => Effect.runPromise(deliverPlayIfFresh(trackId)))
-      playDeliveryTail = delivery.catch(() => undefined)
-      return delivery
-    },
-    catch: (error) => error
+    // Plays are serialised so a burst of skips cannot interleave dedup reads
+    // with the write that closes the window.
+    const lock = yield* Semaphore.make(1)
+
+    return {
+      recordPlay: (trackId: string) =>
+        deliverPlayIfFresh(trackId).pipe(
+          Semaphore.withPermits(lock, 1),
+          Effect.catchCause(() => Effect.void)
+        )
+    }
   })
+)

--- a/apps/mobile/src/audio/queueAtom.ts
+++ b/apps/mobile/src/audio/queueAtom.ts
@@ -7,13 +7,13 @@ import {
   type QueueView
 } from '@gbfm/player'
 import { useAtomSet, useAtomValue } from '@effect/atom-react'
-import { playerStorage } from '@/runtime'
+import { queuePersistence } from '@/runtime'
 
 export { initialQueueState, mergeHydratedQueue, reduceQueue, type QueueAction, type QueueView }
 
 const { queueAtom, selectQueueView } = makeQueueAtom({
-  loadQueue: playerStorage.loadQueue,
-  saveQueue: playerStorage.saveQueue
+  loadQueue: queuePersistence.loadQueue,
+  saveQueue: queuePersistence.saveQueue
 })
 
 export { queueAtom }

--- a/apps/mobile/src/runtime.ts
+++ b/apps/mobile/src/runtime.ts
@@ -1,4 +1,4 @@
-import { PlayerStorage, type PlayerStorageShape } from '@gbfm/player'
+import { PlayerStorage, type PersistedQueueType, type PlayerStorageShape } from '@gbfm/player'
 import { Effect, Layer, Scope } from 'effect'
 import { PlayerStorageLive } from '@/audio/queueStorage'
 
@@ -14,14 +14,9 @@ const use = <A, E>(operation: (storage: PlayerStorageShape) => Effect.Effect<A, 
     catch: (error) => error
   })
 
-/** Storage bound to the app context, for callers that run effects themselves
- *  (the player core) rather than composing them into the runtime. */
-export const playerStorage: PlayerStorageShape = {
+/** Queue persistence bound to the app context, for the queue atom, which runs
+ *  outside React and so cannot use the player's per-mount runtime. */
+export const queuePersistence = {
   loadQueue: () => use((storage) => storage.loadQueue()),
-  saveQueue: (queue) => use((storage) => storage.saveQueue(queue)),
-  loadPosition: (trackId) => use((storage) => storage.loadPosition(trackId)),
-  savePosition: (trackId, position) => use((storage) => storage.savePosition(trackId, position)),
-  clearPosition: (trackId) => use((storage) => storage.clearPosition(trackId)),
-  recordPlay: (trackId) => use((storage) => storage.recordPlay(trackId)),
-  isWithinDedupWindow: (trackId) => use((storage) => storage.isWithinDedupWindow(trackId))
+  saveQueue: (queue: PersistedQueueType) => use((storage) => storage.saveQueue(queue))
 }

--- a/apps/www/src/runtime/index.ts
+++ b/apps/www/src/runtime/index.ts
@@ -4,7 +4,7 @@ import { env } from '@/env'
 import { getSpotifyRedirectUri } from '@/lib/spotify-pkce'
 import { type Analytics, SentryAnalyticsLayer, NoopAnalyticsLayer } from '@/services/analytics'
 import { type MediaSessionService, MediaSessionServiceLive } from '@/services/media-session'
-import { PlayerStorage, type PlayerStorageShape } from '@gbfm/player'
+import { PlayerStorage, type PersistedQueueType, type PlayerStorageShape } from '@gbfm/player'
 import { PlayerStorageLive } from '@/services/player/storage'
 import { log, type Logger, LoggerLive, NoopLogger } from '@/services/logger'
 import { SentryTracerLive } from '@/services/sentry-tracer'
@@ -78,15 +78,9 @@ const useStorage = <A, E>(operation: (storage: PlayerStorageShape) => Effect.Eff
     catch: (error) => error
   })
 
-/** Storage bound to the app context, for callers that run effects themselves
- *  (the player core) rather than composing them into the runtime. */
-export const playerStorage: PlayerStorageShape = {
+/** Queue persistence bound to the app context, for the queue atom, which runs
+ *  outside React and so cannot use the player's per-mount runtime. */
+export const queuePersistence = {
   loadQueue: () => useStorage((storage) => storage.loadQueue()),
-  saveQueue: (queue) => useStorage((storage) => storage.saveQueue(queue)),
-  loadPosition: (trackId) => useStorage((storage) => storage.loadPosition(trackId)),
-  savePosition: (trackId, position) =>
-    useStorage((storage) => storage.savePosition(trackId, position)),
-  clearPosition: (trackId) => useStorage((storage) => storage.clearPosition(trackId)),
-  recordPlay: (trackId) => useStorage((storage) => storage.recordPlay(trackId)),
-  isWithinDedupWindow: (trackId) => useStorage((storage) => storage.isWithinDedupWindow(trackId))
+  saveQueue: (queue: PersistedQueueType) => useStorage((storage) => storage.saveQueue(queue))
 }

--- a/apps/www/src/services/player/PlayerProvider.tsx
+++ b/apps/www/src/services/player/PlayerProvider.tsx
@@ -1,9 +1,10 @@
 import {
-  createPlayerCore,
+  makePlayerCore,
   type EngineStatus,
-  type PlayerCore,
+  type PlayerCoreShape,
   type QueueTrackType
 } from '@gbfm/player'
+import { Effect, Layer, ManagedRuntime } from 'effect'
 import { useAtomSet } from '@effect/atom-react'
 import {
   createContext,
@@ -14,10 +15,12 @@ import {
   useRef,
   type PropsWithChildren
 } from 'react'
-import { playerStorage } from '@/runtime'
+import { MediaSessionServiceLive } from '@/services/media-session'
+import { PlayerStorageLive } from './storage'
 import {
   persistVolume,
   previewSrcAtom,
+  readStoredVolume,
   transportAtom,
   useQueue,
   useQueueDispatch,
@@ -31,8 +34,8 @@ import {
   resolveSeekTarget,
   resolveVolume
 } from './decisions'
-import { createHtmlAudioEngine } from './htmlAudioEngine'
-import { recordPlayIfFresh } from './playTracker'
+import { HtmlAudioEngineLayer } from './htmlAudioEngine'
+import { PlayReporterLive } from './playTracker'
 
 type PlayerActions = {
   readonly play: () => void
@@ -77,14 +80,26 @@ export const PlayerProvider = ({ children }: PropsWithChildren) => {
   const setVisibility = useAtomSet(visibilityAtom)
   const setPreviewSrc = useAtomSet(previewSrcAtom)
 
-  const coreRef = useRef<PlayerCore | null>(null)
+  const coreRef = useRef<PlayerCoreShape | null>(null)
   const audioRef = useRef<HTMLAudioElement | null>(null)
+  const runtimeRef = useRef<ManagedRuntime.ManagedRuntime<never, never> | null>(null)
   const queueRef = useRef(queue)
-  const volumeRef = useRef({ volume: 100, isMuted: false })
+  // Seeded from the same stored value as volumeAtom so a restored mute or
+  // reduced volume is applied to the element, not just shown in the UI.
+  const volumeRef = useRef(readStoredVolume())
   const durationRef = useRef(0)
   const playNextRef = useRef<() => void>(() => {})
 
   queueRef.current = queue
+
+  /** Runs a core operation on the mount's runtime. No-ops before the core is
+   *  built or after unmount, matching the previous null-ref guards. */
+  const runCore = useCallback((operation: (core: PlayerCoreShape) => Effect.Effect<void>) => {
+    const core = coreRef.current
+    const runtime = runtimeRef.current
+    if (!core || !runtime) return
+    runtime.runFork(operation(core))
+  }, [])
 
   const onStatus = useCallback(
     (status: EngineStatus) => {
@@ -106,50 +121,85 @@ export const PlayerProvider = ({ children }: PropsWithChildren) => {
     audio.volume = resolveVolume(volumeRef.current.volume, volumeRef.current.isMuted)
     audioRef.current = audio
 
-    const engine = createHtmlAudioEngine(audio)
-    const core = createPlayerCore(engine, playerStorage, {
-      onStatus,
-      onTrackFinished: () => playNextRef.current(),
-      recordPlay: recordPlayIfFresh
-    })
+    // The engine is owned by this mount, so its layer and the core's status
+    // fiber live in a runtime scoped to the same lifetime.
+    const runtime = ManagedRuntime.make(
+      Layer.mergeAll(HtmlAudioEngineLayer(audio), PlayReporterLive).pipe(
+        Layer.provideMerge(Layer.mergeAll(PlayerStorageLive, MediaSessionServiceLive))
+      )
+    )
+    runtimeRef.current = runtime
 
     // The core only observes the engine while a queue track is loaded, so keep
-    // an independent subscription to drive transport during previews too.
-    const subscription = engine.subscribe(onStatus)
+    // a direct listener to drive transport during previews too.
+    const onPreviewStatus = () => {
+      if (queueRef.current.current) return
+      onStatus({
+        isLoaded: audio.readyState >= 1,
+        playing: !audio.paused && !audio.ended,
+        didJustFinish: audio.ended,
+        currentTime: audio.currentTime,
+        duration: Number.isFinite(audio.duration) ? audio.duration : 0,
+        isBuffering: audio.readyState < 3 && !audio.paused
+      })
+    }
+    audio.addEventListener('timeupdate', onPreviewStatus)
+    audio.addEventListener('loadedmetadata', onPreviewStatus)
+    audio.addEventListener('play', onPreviewStatus)
+    audio.addEventListener('pause', onPreviewStatus)
+    audio.addEventListener('ended', onPreviewStatus)
 
-    coreRef.current = core
-    setTransport((state) => ({ ...state, isInitialized: true }))
+    runtime.runFork(
+      Effect.gen(function* () {
+        const core = yield* makePlayerCore({
+          onStatus,
+          onTrackFinished: () => playNextRef.current()
+        })
+        coreRef.current = core
+        setTransport((state) => ({ ...state, isInitialized: true }))
+        // Hold the scope open so the core's status fiber keeps running until
+        // the runtime is disposed on unmount.
+        yield* Effect.never
+      }).pipe(Effect.scoped)
+    )
 
     return () => {
-      subscription.remove()
-      core.dispose()
-      audio.pause()
+      audio.removeEventListener('timeupdate', onPreviewStatus)
+      audio.removeEventListener('loadedmetadata', onPreviewStatus)
+      audio.removeEventListener('play', onPreviewStatus)
+      audio.removeEventListener('pause', onPreviewStatus)
+      audio.removeEventListener('ended', onPreviewStatus)
       coreRef.current = null
       audioRef.current = null
+      runtimeRef.current = null
+      void runtime.dispose()
+      audio.pause()
       setTransport((state) => ({ ...state, isInitialized: false }))
     }
   }, [onStatus, setTransport])
 
   useEffect(() => {
-    if (!currentTrack) return
-    setPreviewSrc(null)
-    coreRef.current?.setSource(currentTrack)
-  }, [currentTrack, setPreviewSrc])
+    // Runs for null too, so clearing or removing the last track tears the
+    // source down instead of leaving a detached element playing.
+    if (currentTrack) setPreviewSrc(null)
+    runCore((core) => core.setSource(currentTrack))
+  }, [currentTrack, runCore, setPreviewSrc])
 
   const playIndex = useCallback(
     (index: number) => {
-      const core = coreRef.current
       const target = queueRef.current.tracks[index]
-      if (!core || !target) return
+      if (!target) return
       if (queueRef.current.current?.id === target.id) {
-        core.play(target.id)
+        runCore((core) => core.play(target.id))
         return
       }
-      core.requestPlayOnReady(target.id)
-      core.detachCurrentSource()
+
+      runCore((core) =>
+        core.requestPlayOnReady(target.id).pipe(Effect.andThen(core.detachCurrentSource))
+      )
       dispatchQueue({ _tag: 'playIndex', index })
     },
-    [dispatchQueue]
+    [dispatchQueue, runCore]
   )
 
   const playNext = useCallback(() => {
@@ -170,10 +220,9 @@ export const PlayerProvider = ({ children }: PropsWithChildren) => {
 
   const actions = useMemo<PlayerActions>(() => {
     const startQueueAction = (action: QueueAction, firstId: string) => {
-      const core = coreRef.current
-      if (!core) return
-      core.requestPlayOnReady(firstId)
-      core.detachCurrentSource()
+      runCore((core) =>
+        core.requestPlayOnReady(firstId).pipe(Effect.andThen(core.detachCurrentSource))
+      )
       dispatchQueue(action)
     }
 
@@ -186,31 +235,33 @@ export const PlayerProvider = ({ children }: PropsWithChildren) => {
     return {
       play: () => {
         const current = queueRef.current.current
-        if (current) coreRef.current?.play(current.id)
+        if (current) runCore((core) => core.play(current.id))
         // A preview has no queue session, so drive the element directly.
         else void audioRef.current?.play().catch(() => undefined)
       },
       pause: () => {
-        if (queueRef.current.current) coreRef.current?.pause()
+        if (queueRef.current.current) runCore((core) => core.pause)
         else audioRef.current?.pause()
       },
       togglePlayPause: () => {
-        const core = coreRef.current
         const current = queueRef.current.current
-        if (!core || !current) return
-        if (core.isDesiredPlaying()) core.pause()
-        else core.play(current.id)
+        if (!current) return
+        runCore((core) =>
+          Effect.flatMap(core.isDesiredPlaying, (desired) =>
+            desired ? core.pause : core.play(current.id)
+          )
+        )
       },
-      seekTo: (time) => coreRef.current?.seekTo(time),
+      seekTo: (time) => runCore((core) => core.seekTo(time)),
       seekByPercentage: (percentage) =>
-        coreRef.current?.seekTo(resolveSeekTarget(percentage, durationRef.current)),
+        runCore((core) => core.seekTo(resolveSeekTarget(percentage, durationRef.current))),
       jumpForward: (seconds = 30) => {
         const audio = audioRef.current
-        if (audio) coreRef.current?.seekTo(audio.currentTime + seconds)
+        if (audio) runCore((core) => core.seekTo(audio.currentTime + seconds))
       },
       jumpBackward: (seconds = 15) => {
         const audio = audioRef.current
-        if (audio) coreRef.current?.seekTo(Math.max(0, audio.currentTime - seconds))
+        if (audio) runCore((core) => core.seekTo(Math.max(0, audio.currentTime - seconds)))
       },
 
       setVolume: (volume) => {
@@ -235,7 +286,7 @@ export const PlayerProvider = ({ children }: PropsWithChildren) => {
 
       playTrack: (track) => {
         if (queueRef.current.current?.id === track.id) {
-          coreRef.current?.play(track.id)
+          runCore((core) => core.play(track.id))
           return
         }
         startQueueAction({ _tag: 'playNow', track }, track.id)
@@ -250,7 +301,7 @@ export const PlayerProvider = ({ children }: PropsWithChildren) => {
       playPreview: (src) => {
         const audio = audioRef.current
         if (!audio) return
-        coreRef.current?.setSource(null)
+        runCore((core) => core.setSource(null))
         setPreviewSrc(src)
         audio.src = src
         void audio.play().catch(() => undefined)
@@ -259,19 +310,23 @@ export const PlayerProvider = ({ children }: PropsWithChildren) => {
       enqueue: (track) => dispatchQueue({ _tag: 'enqueue', track }),
       enqueueAll: (tracks) => dispatchQueue({ _tag: 'enqueueAll', tracks }),
       removeFromQueue: (index) => {
-        const core = coreRef.current
         const { tracks, currentIndex } = queueRef.current
-        if (!core || index < 0 || index >= tracks.length) return
+        if (index < 0 || index >= tracks.length) return
         if (index === currentIndex) {
           const next = tracks[index + 1] ?? tracks[index - 1]
-          if (core.isDesiredPlaying() && next) core.requestPlayOnReady(next.id)
-          core.detachCurrentSource()
+          runCore((core) =>
+            Effect.flatMap(core.isDesiredPlaying, (desired) =>
+              (desired && next ? core.requestPlayOnReady(next.id) : Effect.void).pipe(
+                Effect.andThen(core.detachCurrentSource)
+              )
+            )
+          )
         }
         dispatchQueue({ _tag: 'remove', index })
       },
       reorderQueue: (from, to) => dispatchQueue({ _tag: 'reorder', from, to }),
       clearQueue: () => {
-        coreRef.current?.detachCurrentSource()
+        runCore((core) => core.detachCurrentSource)
         dispatchQueue({ _tag: 'clear' })
       },
       playFromQueue: playIndex,
@@ -289,6 +344,7 @@ export const PlayerProvider = ({ children }: PropsWithChildren) => {
     playIndex,
     playNext,
     playPrevious,
+    runCore,
     setPreviewSrc,
     setVisibility,
     setVolumeState

--- a/apps/www/src/services/player/atoms.ts
+++ b/apps/www/src/services/player/atoms.ts
@@ -3,14 +3,14 @@ import { makeQueueAtom, selectQueueView, type QueueAction, type QueueView } from
 import { useAtomSet, useAtomValue } from '@effect/atom-react'
 import { Effect, Schema } from 'effect'
 import * as Atom from 'effect/unstable/reactivity/Atom'
-import { playerStorage } from '@/runtime'
+import { queuePersistence } from '@/runtime'
 import { log } from '@/services/logger'
 
 export type { QueueAction, QueueTrackType, QueueView }
 
 const { queueAtom } = makeQueueAtom({
-  loadQueue: playerStorage.loadQueue,
-  saveQueue: playerStorage.saveQueue,
+  loadQueue: queuePersistence.loadQueue,
+  saveQueue: queuePersistence.saveQueue,
   onError: (message, error) => log('error', message, { error })
 })
 
@@ -50,7 +50,7 @@ const StoredVolume = Schema.Struct({
   isMuted: Schema.Boolean
 })
 
-const readStoredVolume = (): VolumeState => {
+export const readStoredVolume = (): VolumeState => {
   if (typeof window === 'undefined') return defaultVolume
   const raw = window.localStorage.getItem(VOLUME_KEY)
   if (!raw) return defaultVolume

--- a/apps/www/src/services/player/htmlAudioEngine.ts
+++ b/apps/www/src/services/player/htmlAudioEngine.ts
@@ -1,7 +1,12 @@
-import type { AudioEngine, EngineStatus, NowPlayingMetadata } from '@gbfm/player'
-import { RuntimeClient } from '@/runtime'
+import {
+  AudioEngine,
+  PlaybackRejected,
+  type EngineStatus,
+  type NowPlayingMetadata
+} from '@gbfm/player'
+import { Effect, Layer, Queue, Stream } from 'effect'
 import { log } from '@/services/logger'
-import { setMetadata, setPlaybackState } from '@/services/media-session'
+import { MediaSessionService } from '@/services/media-session'
 
 const readStatus = (audio: HTMLAudioElement, didJustFinish: boolean): EngineStatus => ({
   isLoaded: audio.readyState >= 1,
@@ -12,88 +17,112 @@ const readStatus = (audio: HTMLAudioElement, didJustFinish: boolean): EngineStat
   isBuffering: audio.readyState < 3 && !audio.paused
 })
 
-export const createHtmlAudioEngine = (audio: HTMLAudioElement): AudioEngine => {
-  let justFinished = false
+const makeHtmlAudioEngine = (audio: HTMLAudioElement) =>
+  Effect.gen(function* () {
+    const mediaSession = yield* MediaSessionService
+    let justFinished = false
 
-  return {
-    replace: (url) => {
-      justFinished = false
-      audio.src = url
-      audio.load()
-    },
-
-    play: () => {
-      void audio.play().catch((error: unknown) => {
-        log('error', 'Unable to start playback', { error })
-      })
-    },
-
-    pause: () => audio.pause(),
-
-    seekTo: (seconds) =>
-      new Promise<void>((resolve) => {
-        const apply = () => {
-          audio.currentTime = seconds
-          resolve()
-        }
-        // Seeking before metadata lands silently no-ops in browsers.
-        if (audio.readyState >= 1) apply()
-        else audio.addEventListener('loadedmetadata', apply, { once: true })
-      }),
-
-    currentStatus: () => readStatus(audio, justFinished),
-
-    subscribe: (listener) => {
-      const emit = () => listener(readStatus(audio, justFinished))
-
-      const onEnded = () => {
-        justFinished = true
-        listener(readStatus(audio, true))
-        justFinished = false
-      }
-
-      const onPlay = () => {
-        justFinished = false
-        void RuntimeClient.runPromise(setPlaybackState('playing')).catch(() => undefined)
-        emit()
-      }
-
-      const onPause = () => {
-        void RuntimeClient.runPromise(setPlaybackState('paused')).catch(() => undefined)
-        emit()
-      }
-
-      audio.addEventListener('timeupdate', emit)
-      audio.addEventListener('loadedmetadata', emit)
-      audio.addEventListener('durationchange', emit)
-      audio.addEventListener('canplay', emit)
-      audio.addEventListener('waiting', emit)
-      audio.addEventListener('play', onPlay)
-      audio.addEventListener('pause', onPause)
-      audio.addEventListener('ended', onEnded)
-
-      return {
-        remove: () => {
-          audio.removeEventListener('timeupdate', emit)
-          audio.removeEventListener('loadedmetadata', emit)
-          audio.removeEventListener('durationchange', emit)
-          audio.removeEventListener('canplay', emit)
-          audio.removeEventListener('waiting', emit)
-          audio.removeEventListener('play', onPlay)
-          audio.removeEventListener('pause', onPause)
-          audio.removeEventListener('ended', onEnded)
-        }
-      }
-    },
-
-    setNowPlaying: (metadata: NowPlayingMetadata | null) => {
-      if (!metadata) {
-        void RuntimeClient.runPromise(setPlaybackState('none')).catch(() => undefined)
-        return
-      }
-      void RuntimeClient.runPromise(
-        setMetadata(metadata.title, metadata.artist ? [metadata.artist] : [], metadata.artworkUrl)
-      ).catch(() => undefined)
+    // DOM listeners are plain callbacks, so mediaSession effects are run
+    // detached rather than yielded.
+    const runDetached = (effect: Effect.Effect<void>) => {
+      Effect.runFork(effect)
     }
-  }
-}
+
+    const changes = Stream.callback<EngineStatus>((queue) =>
+      Effect.gen(function* () {
+        const emit = () => {
+          Queue.offerUnsafe(queue, readStatus(audio, justFinished))
+        }
+
+        const onEnded = () => {
+          justFinished = true
+          Queue.offerUnsafe(queue, readStatus(audio, true))
+          justFinished = false
+        }
+
+        const onPlay = () => {
+          justFinished = false
+          runDetached(mediaSession.setPlaybackState('playing'))
+          emit()
+        }
+
+        const onPause = () => {
+          runDetached(mediaSession.setPlaybackState('paused'))
+          emit()
+        }
+
+        audio.addEventListener('timeupdate', emit)
+        audio.addEventListener('loadedmetadata', emit)
+        audio.addEventListener('durationchange', emit)
+        audio.addEventListener('canplay', emit)
+        audio.addEventListener('waiting', emit)
+        audio.addEventListener('play', onPlay)
+        audio.addEventListener('pause', onPause)
+        audio.addEventListener('ended', onEnded)
+
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            audio.removeEventListener('timeupdate', emit)
+            audio.removeEventListener('loadedmetadata', emit)
+            audio.removeEventListener('durationchange', emit)
+            audio.removeEventListener('canplay', emit)
+            audio.removeEventListener('waiting', emit)
+            audio.removeEventListener('play', onPlay)
+            audio.removeEventListener('pause', onPause)
+            audio.removeEventListener('ended', onEnded)
+          })
+        )
+      })
+    )
+
+    return {
+      replace: (url: string) =>
+        Effect.sync(() => {
+          justFinished = false
+          audio.src = url
+          audio.load()
+        }),
+
+      // Safari rejects play() when it lands outside a user-gesture stack.
+      // The rejection is surfaced so the core can reconcile intent instead of
+      // staying stuck at "desired playing" against a paused element.
+      play: Effect.suspend(() =>
+        Effect.tryPromise({
+          try: () => audio.play(),
+          catch: (error: unknown) => {
+            log('error', 'Unable to start playback', { error })
+            return new PlaybackRejected({ cause: error })
+          }
+        })
+      ),
+
+      pause: Effect.sync(() => audio.pause()),
+
+      seekTo: (seconds: number) =>
+        Effect.callback<void>((resume) => {
+          const apply = () => {
+            audio.currentTime = seconds
+            resume(Effect.void)
+          }
+          // Seeking before metadata lands silently no-ops in browsers.
+          if (audio.readyState >= 1) apply()
+          else audio.addEventListener('loadedmetadata', apply, { once: true })
+        }),
+
+      currentStatus: Effect.sync(() => readStatus(audio, justFinished)),
+
+      changes,
+
+      setNowPlaying: (metadata: NowPlayingMetadata | null) =>
+        metadata === null
+          ? mediaSession.setPlaybackState('none')
+          : mediaSession.setMetadata(
+              metadata.title,
+              metadata.artist ? [metadata.artist] : [],
+              metadata.artworkUrl
+            )
+    }
+  })
+
+export const HtmlAudioEngineLayer = (audio: HTMLAudioElement) =>
+  Layer.effect(AudioEngine, makeHtmlAudioEngine(audio))

--- a/apps/www/src/services/player/index.ts
+++ b/apps/www/src/services/player/index.ts
@@ -19,4 +19,3 @@ export {
 } from './atoms'
 
 export { PlayerProvider, usePlayerActions } from './PlayerProvider'
-export { recordPlayIfFresh } from './playTracker'

--- a/apps/www/src/services/player/playTracker.ts
+++ b/apps/www/src/services/player/playTracker.ts
@@ -1,7 +1,6 @@
-import { createPlayDelivery } from '@gbfm/player'
-import { Effect } from 'effect'
+import { createPlayDelivery, PlayerStorage, PlayReporter } from '@gbfm/player'
+import { Effect, Layer, Semaphore } from 'effect'
 import { getApiClient } from '@/lib/api-client'
-import { playerStorage } from '@/runtime'
 
 const trackAudioPlay = (trackId: string) =>
   Effect.gen(function* () {
@@ -9,23 +8,28 @@ const trackAudioPlay = (trackId: string) =>
     yield* client.audio.trackAudioPlay({ params: { id: trackId } })
   })
 
-const deliverPlayIfFresh = createPlayDelivery({
-  isWithinDedupWindow: playerStorage.isWithinDedupWindow,
-  deliver: trackAudioPlay,
-  remember: playerStorage.recordPlay,
-  now: Date.now
-})
+export const PlayReporterLive = Layer.effect(
+  PlayReporter,
+  Effect.gen(function* () {
+    const storage = yield* PlayerStorage
 
-let playDeliveryTail: Promise<void> = Promise.resolve()
+    const deliverPlayIfFresh = createPlayDelivery({
+      isWithinDedupWindow: storage.isWithinDedupWindow,
+      deliver: trackAudioPlay,
+      remember: storage.recordPlay,
+      now: Date.now
+    })
 
-export const recordPlayIfFresh = (trackId: string) =>
-  Effect.tryPromise({
-    try: () => {
-      const delivery = playDeliveryTail
-        .catch(() => undefined)
-        .then(() => Effect.runPromise(deliverPlayIfFresh(trackId)))
-      playDeliveryTail = delivery.catch(() => undefined)
-      return delivery
-    },
-    catch: (error) => error
+    // Plays are serialised so a burst of skips cannot interleave dedup reads
+    // with the write that closes the window.
+    const lock = yield* Semaphore.make(1)
+
+    return {
+      recordPlay: (trackId: string) =>
+        deliverPlayIfFresh(trackId).pipe(
+          Semaphore.withPermits(lock, 1),
+          Effect.catchCause(() => Effect.void)
+        )
+    }
   })
+)

--- a/packages/player/src/engine.ts
+++ b/packages/player/src/engine.ts
@@ -1,3 +1,8 @@
+import * as Context from 'effect/Context'
+import * as Data from 'effect/Data'
+import type * as Effect from 'effect/Effect'
+import type * as Stream from 'effect/Stream'
+
 export type EngineStatus = {
   readonly isLoaded: boolean
   readonly playing: boolean
@@ -13,14 +18,26 @@ export type NowPlayingMetadata = {
   readonly artworkUrl?: string
 }
 
-/** The operations the shared player core needs from a platform audio engine.
- *  Implemented over expo-audio on mobile and HTMLAudioElement on web. */
-export type AudioEngine = {
-  readonly replace: (url: string) => void
-  readonly play: () => void
-  readonly pause: () => void
-  readonly seekTo: (seconds: number) => Promise<void>
-  readonly currentStatus: () => EngineStatus
-  readonly subscribe: (listener: (status: EngineStatus) => void) => { readonly remove: () => void }
-  readonly setNowPlaying?: (metadata: NowPlayingMetadata | null) => void
+/** Playback was refused by the platform, typically because the call did not
+ *  originate from a user gesture (Safari's autoplay policy). */
+export class PlaybackRejected extends Data.TaggedError('PlaybackRejected')<{
+  readonly cause?: unknown
+}> {}
+
+export interface AudioEngineShape {
+  readonly replace: (url: string) => Effect.Effect<void>
+  readonly play: Effect.Effect<void, PlaybackRejected>
+  readonly pause: Effect.Effect<void>
+  readonly seekTo: (seconds: number) => Effect.Effect<void>
+  readonly currentStatus: Effect.Effect<EngineStatus>
+  readonly changes: Stream.Stream<EngineStatus>
+  readonly setNowPlaying: (metadata: NowPlayingMetadata | null) => Effect.Effect<void>
 }
+
+/** The operations the shared player core needs from a platform audio engine.
+ *  Implemented over expo-audio on mobile and HTMLAudioElement on web. The
+ *  layer is built per mount, since both platforms tie the underlying object to
+ *  a React lifecycle. */
+export class AudioEngine extends Context.Service<AudioEngine, AudioEngineShape>()(
+  '@gbfm/player/AudioEngine'
+) {}

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -31,7 +31,15 @@ export {
 
 export { createPlayDelivery } from './playDelivery'
 
-export type { AudioEngine, EngineStatus, NowPlayingMetadata } from './engine'
+export { PlayReporter, PlayReporterNoop, type PlayReporterShape } from './playReporter'
+
+export {
+  AudioEngine,
+  PlaybackRejected,
+  type AudioEngineShape,
+  type EngineStatus,
+  type NowPlayingMetadata
+} from './engine'
 
 export {
   clearPosition,
@@ -42,7 +50,6 @@ export {
   PlayerStorage,
   PlayerStorageInMemory,
   PlayerStorageTest,
-  providePlayerStorage,
   recordPlay,
   savePosition,
   saveQueue,
@@ -50,12 +57,7 @@ export {
   type PositionRecord
 } from './playerStorage'
 
-export {
-  createPlayerCore,
-  type PlayerCore,
-  type PlayerCoreCallbacks,
-  type PlayerCoreStorage
-} from './playerCore'
+export { makePlayerCore, type PlayerCoreCallbacks, type PlayerCoreShape } from './playerCore'
 
 export {
   makeQueueAtom,

--- a/packages/player/src/playReporter.ts
+++ b/packages/player/src/playReporter.ts
@@ -1,0 +1,17 @@
+import * as Context from 'effect/Context'
+import * as Effect from 'effect/Effect'
+import * as Layer from 'effect/Layer'
+
+export interface PlayReporterShape {
+  /** Report that a track started playing. Implementations dedup and deliver to
+   *  the API; failures must not interrupt playback. */
+  readonly recordPlay: (trackId: string) => Effect.Effect<void>
+}
+
+export class PlayReporter extends Context.Service<PlayReporter, PlayReporterShape>()(
+  '@gbfm/player/PlayReporter'
+) {}
+
+export const PlayReporterNoop = Layer.succeed(PlayReporter, {
+  recordPlay: () => Effect.void
+})

--- a/packages/player/src/playerCore.test.ts
+++ b/packages/player/src/playerCore.test.ts
@@ -1,0 +1,299 @@
+import { Effect, Layer, PubSub, Stream } from 'effect'
+import { describe, expect, it } from 'vitest'
+import { AudioEngine, PlaybackRejected, type AudioEngineShape, type EngineStatus } from './engine'
+import type { QueueTrackType } from './persistedQueue'
+import { PlayReporter } from './playReporter'
+import { makePlayerCore } from './playerCore'
+import { PlayerStorage, type PositionRecord } from './playerStorage'
+
+const track: QueueTrackType = {
+  id: 'track-1',
+  title: 'Test Mix',
+  slug: 'test-mix',
+  url: 'https://cdn.example/test.mp3',
+  thumbnailUrl: null,
+  type: 'mix',
+  creators: [{ id: 'c1', name: 'Tester', username: 'tester' }]
+}
+
+const idleStatus: EngineStatus = {
+  isLoaded: false,
+  playing: false,
+  didJustFinish: false,
+  currentTime: 0,
+  duration: 0,
+  isBuffering: false
+}
+
+const makeRecordingEngine = (options: { readonly rejectPlay?: boolean } = {}) =>
+  Effect.gen(function* () {
+    const pubsub = yield* PubSub.unbounded<EngineStatus>()
+    const calls: Array<string> = []
+    let status = idleStatus
+
+    const engine: AudioEngineShape = {
+      replace: (url) =>
+        Effect.sync(() => {
+          calls.push(`replace:${url}`)
+        }),
+      play: options.rejectPlay
+        ? Effect.suspend(() => {
+            calls.push('play:rejected')
+            return Effect.fail(new PlaybackRejected({}))
+          })
+        : Effect.sync(() => {
+            calls.push('play')
+          }),
+      pause: Effect.sync(() => {
+        calls.push('pause')
+      }),
+      seekTo: (seconds) =>
+        Effect.sync(() => {
+          calls.push(`seek:${seconds}`)
+        }),
+      currentStatus: Effect.sync(() => status),
+      changes: Stream.fromPubSub(pubsub),
+      setNowPlaying: (metadata) =>
+        Effect.sync(() => {
+          calls.push(`nowPlaying:${metadata ? metadata.title : 'null'}`)
+        })
+    }
+
+    const emit = (next: Partial<EngineStatus>) =>
+      Effect.suspend(() => {
+        status = { ...status, ...next }
+        return PubSub.publish(pubsub, status)
+      })
+
+    /** Updates what the engine reports without publishing, modelling a source
+     *  that became ready before the core read its status. */
+    const setStatus = (next: Partial<EngineStatus>) =>
+      Effect.sync(() => {
+        status = { ...status, ...next }
+      })
+
+    return { engine, calls, emit, setStatus }
+  })
+
+const makeRecordingStorage = (stored: PositionRecord | null = null) => {
+  const saved: Array<{ readonly id: string; readonly position: number }> = []
+  const cleared: Array<string> = []
+
+  const layer = Layer.succeed(PlayerStorage, {
+    loadQueue: () => Effect.succeed(null),
+    saveQueue: () => Effect.void,
+    loadPosition: () => Effect.succeed(stored),
+    savePosition: (id: string, position: number) =>
+      Effect.sync(() => {
+        saved.push({ id, position })
+      }),
+    clearPosition: (id: string) =>
+      Effect.sync(() => {
+        cleared.push(id)
+      }),
+    recordPlay: () => Effect.void,
+    isWithinDedupWindow: () => Effect.succeed(false)
+  })
+
+  return { layer, saved, cleared }
+}
+
+const makeRecordingReporter = () => {
+  const reported: Array<string> = []
+  const layer = Layer.succeed(PlayReporter, {
+    recordPlay: (trackId: string) =>
+      Effect.sync(() => {
+        reported.push(trackId)
+      })
+  })
+  return { layer, reported }
+}
+
+describe('makePlayerCore', () => {
+  it('restores a stored position before starting playback', async () => {
+    const program = Effect.gen(function* () {
+      const { engine, calls, setStatus } = yield* makeRecordingEngine()
+      const storage = makeRecordingStorage({ position: 42, updatedAt: 0 })
+      const reporter = makeRecordingReporter()
+
+      const core = yield* makePlayerCore({
+        onStatus: () => {},
+        onTrackFinished: () => {}
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(Layer.succeed(AudioEngine, engine), storage.layer, reporter.layer)
+        )
+      )
+
+      yield* core.requestPlayOnReady(track.id)
+      yield* setStatus({ isLoaded: true, duration: 300 })
+      yield* core.setSource(track)
+      yield* Effect.yieldNow
+
+      return { calls, reported: reporter.reported }
+    }).pipe(Effect.scoped)
+
+    const { calls, reported } = await Effect.runPromise(program)
+
+    expect(calls).toContain('seek:42')
+    expect(calls.indexOf('seek:42')).toBeLessThan(calls.indexOf('play'))
+    expect(reported).toEqual([track.id])
+  })
+
+  it('does not seek when the stored position is near the end', async () => {
+    const program = Effect.gen(function* () {
+      const { engine, calls, setStatus } = yield* makeRecordingEngine()
+      const storage = makeRecordingStorage({ position: 298, updatedAt: 0 })
+      const reporter = makeRecordingReporter()
+
+      const core = yield* makePlayerCore({
+        onStatus: () => {},
+        onTrackFinished: () => {}
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(Layer.succeed(AudioEngine, engine), storage.layer, reporter.layer)
+        )
+      )
+
+      yield* core.requestPlayOnReady(track.id)
+      yield* setStatus({ isLoaded: true, duration: 300 })
+      yield* core.setSource(track)
+      yield* Effect.yieldNow
+
+      return calls
+    }).pipe(Effect.scoped)
+
+    const calls = await Effect.runPromise(program)
+    expect(calls.some((call) => call.startsWith('seek:'))).toBe(false)
+    expect(calls).toContain('play')
+  })
+
+  it('clears intent and skips play reporting when the platform refuses playback', async () => {
+    const program = Effect.gen(function* () {
+      const { engine, setStatus } = yield* makeRecordingEngine({ rejectPlay: true })
+      const storage = makeRecordingStorage()
+      const reporter = makeRecordingReporter()
+      const errors: Array<string> = []
+
+      const core = yield* makePlayerCore({
+        onStatus: () => {},
+        onTrackFinished: () => {},
+        onError: (message) => errors.push(message)
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(Layer.succeed(AudioEngine, engine), storage.layer, reporter.layer)
+        )
+      )
+
+      yield* core.requestPlayOnReady(track.id)
+      yield* setStatus({ isLoaded: true, duration: 300 })
+      yield* core.setSource(track)
+      yield* Effect.yieldNow
+
+      return { reported: reporter.reported, desired: yield* core.isDesiredPlaying, errors }
+    }).pipe(Effect.scoped)
+
+    const { reported, desired, errors } = await Effect.runPromise(program)
+
+    expect(reported).toEqual([])
+    expect(desired).toBe(false)
+    expect(errors).toContain('Playback was refused by the platform')
+  })
+
+  it('tears down the source and pauses when set to null', async () => {
+    const program = Effect.gen(function* () {
+      const { engine, calls, setStatus } = yield* makeRecordingEngine()
+      const storage = makeRecordingStorage()
+      const reporter = makeRecordingReporter()
+
+      const core = yield* makePlayerCore({
+        onStatus: () => {},
+        onTrackFinished: () => {}
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(Layer.succeed(AudioEngine, engine), storage.layer, reporter.layer)
+        )
+      )
+
+      yield* setStatus({ isLoaded: true, duration: 300 })
+      yield* core.setSource(track)
+      yield* Effect.yieldNow
+
+      yield* core.setSource(null)
+      yield* Effect.yieldNow
+
+      return { calls, trackId: yield* core.currentTrackId }
+    }).pipe(Effect.scoped)
+
+    const { calls, trackId } = await Effect.runPromise(program)
+
+    expect(trackId).toBeNull()
+    expect(calls).toContain('nowPlaying:null')
+    expect(calls.lastIndexOf('pause')).toBeGreaterThan(calls.indexOf('replace:' + track.url))
+  })
+
+  it('clears the stored position and notifies when a track finishes', async () => {
+    const program = Effect.gen(function* () {
+      const { engine, emit, setStatus } = yield* makeRecordingEngine()
+      const storage = makeRecordingStorage()
+      const reporter = makeRecordingReporter()
+      let finished = 0
+
+      const core = yield* makePlayerCore({
+        onStatus: () => {},
+        onTrackFinished: () => {
+          finished += 1
+        }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(Layer.succeed(AudioEngine, engine), storage.layer, reporter.layer)
+        )
+      )
+
+      yield* core.requestPlayOnReady(track.id)
+      yield* setStatus({ isLoaded: true, duration: 300 })
+      yield* core.setSource(track)
+      yield* Effect.yieldNow
+      yield* emit({ playing: true, currentTime: 300 })
+      yield* Effect.yieldNow
+      yield* emit({ playing: false, didJustFinish: true })
+      yield* Effect.yieldNow
+
+      return { finished, cleared: storage.cleared }
+    }).pipe(Effect.scoped)
+
+    const { finished, cleared } = await Effect.runPromise(program)
+
+    expect(finished).toBe(1)
+    expect(cleared).toEqual([track.id])
+  })
+
+  it('persists playback position as the track advances', async () => {
+    const program = Effect.gen(function* () {
+      const { engine, emit, setStatus } = yield* makeRecordingEngine()
+      const storage = makeRecordingStorage()
+      const reporter = makeRecordingReporter()
+
+      const core = yield* makePlayerCore({
+        onStatus: () => {},
+        onTrackFinished: () => {}
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(Layer.succeed(AudioEngine, engine), storage.layer, reporter.layer)
+        )
+      )
+
+      yield* core.requestPlayOnReady(track.id)
+      yield* setStatus({ isLoaded: true, duration: 300 })
+      yield* core.setSource(track)
+      yield* Effect.yieldNow
+      yield* emit({ playing: true, currentTime: 30 })
+      yield* Effect.yieldNow
+
+      return storage.saved
+    }).pipe(Effect.scoped)
+
+    const saved = await Effect.runPromise(program)
+    expect(saved.some((entry) => entry.id === track.id && entry.position === 30)).toBe(true)
+  })
+})

--- a/packages/player/src/playerCore.ts
+++ b/packages/player/src/playerCore.ts
@@ -1,6 +1,9 @@
-import { Effect } from 'effect'
-import type { AudioEngine, EngineStatus, NowPlayingMetadata } from './engine'
+import { Effect, Stream } from 'effect'
+import type { Scope } from 'effect/Scope'
+import { AudioEngine, type EngineStatus, type NowPlayingMetadata } from './engine'
 import type { QueueTrackType } from './persistedQueue'
+import { PlayReporter } from './playReporter'
+import { PlayerStorage } from './playerStorage'
 import {
   shouldPersistPosition,
   transitionPlaybackIntent,
@@ -12,20 +15,9 @@ import {
   type SourcePreparationEvent
 } from './playbackState'
 
-/** Storage operations the core needs, already provided with their runtime.
- *  Apps build this from the PlayerStorage service via `providePlayerStorage`. */
-export type PlayerCoreStorage = {
-  readonly loadPosition: (
-    trackId: string
-  ) => Effect.Effect<{ readonly position: number } | null, unknown, never>
-  readonly savePosition: (trackId: string, position: number) => Effect.Effect<void, unknown, never>
-  readonly clearPosition: (trackId: string) => Effect.Effect<void, unknown, never>
-}
-
 export type PlayerCoreCallbacks = {
   readonly onStatus: (status: EngineStatus) => void
   readonly onTrackFinished: () => void
-  readonly recordPlay: (trackId: string) => Effect.Effect<void, unknown, never>
   readonly onError?: (message: string, error: unknown) => void
 }
 
@@ -48,233 +40,286 @@ const buildMetadata = (track: QueueTrackType): NowPlayingMetadata => {
   }
 }
 
-/** Engine-agnostic playback session: source generations, checkpoint restore,
- *  play/pause intent reconciliation, position persistence, and end-of-track
- *  handling. Platform differences live behind the AudioEngine port. */
-export const createPlayerCore = (
-  engine: AudioEngine,
-  storage: PlayerCoreStorage,
-  callbacks: PlayerCoreCallbacks
-) => {
-  const onError =
-    callbacks.onError ?? ((message: string, error: unknown) => console.error(message, error))
-
-  let generationCounter = 0
-  let session: SourceSession | null = null
-  let playOnReady: string | null = null
-  let lastPositionPersist: { readonly id: string; readonly at: number } | null = null
-  let subscription: { readonly remove: () => void } | null = null
-
-  const run = (label: string, effect: Effect.Effect<void, unknown, never>) => {
-    Effect.runPromise(effect).catch((error: unknown) => onError(label, error))
-  }
-
-  const finishPreparing = (active: SourceSession) => {
-    if (session !== active || !active.preparation.preparing || active.started) return
-
-    const start = () => {
-      active.started = true
-      active.completion = { ...active.completion, started: true }
-      lastPositionPersist =
-        active.checkpoint === null ? null : { id: active.id, at: active.checkpoint }
-      if (!active.intent.desiredPlaying) return
-      active.intent = transitionPlaybackIntent(active.intent, { _tag: 'command', playing: true })
-      engine.play()
-      run('Unable to deliver audio play', callbacks.recordPlay(active.id))
-    }
-
-    const checkpoint = active.checkpoint
-    const shouldSeek =
-      checkpoint !== null &&
-      checkpoint > 1 &&
-      active.preparation.duration > 0 &&
-      checkpoint < active.preparation.duration - 5
-
-    if (!shouldSeek) {
-      start()
-      return
-    }
-
-    engine.seekTo(checkpoint).then(
-      () => {
-        if (session !== active) return
-        start()
-      },
-      (error: unknown) => {
-        if (session === active) start()
-        onError('Unable to restore audio position', error)
-      }
-    )
-  }
-
-  const advancePreparation = (active: SourceSession, event: SourcePreparationEvent) => {
-    const transition = transitionSourcePreparation(active.preparation, event)
-    active.preparation = transition.state
-    if (transition.shouldPrepare) finishPreparing(active)
-  }
-
-  const observeStatus = (active: SourceSession) => (status: EngineStatus) => {
-    if (session !== active) return
-    callbacks.onStatus(status)
-    advancePreparation(active, {
-      _tag: 'sourceStatus',
-      generation: active.generation,
-      isLoaded: status.isLoaded,
-      duration: status.duration
-    })
-    if (!status.isLoaded) return
-
-    const completion = transitionSourceCompletion(active.completion, {
-      generation: active.generation,
-      didJustFinish: status.didJustFinish,
-      playing: status.playing
-    })
-    active.completion = completion.state
-    if (completion.shouldFinish) {
-      active.intent = transitionPlaybackIntent(active.intent, { _tag: 'completed' })
-      run('Unable to clear completed audio position', storage.clearPosition(active.id))
-      callbacks.onTrackFinished()
-      return
-    }
-
-    if (active.started) {
-      active.intent = transitionPlaybackIntent(active.intent, {
-        _tag: 'status',
-        playing: status.playing
-      })
-    }
-
-    const previousPosition = lastPositionPersist?.id === active.id ? lastPositionPersist.at : null
-    if (!shouldPersistPosition(active.started, previousPosition, status.currentTime)) return
-    lastPositionPersist = { id: active.id, at: status.currentTime }
-    run('Unable to persist audio position', storage.savePosition(active.id, status.currentTime))
-  }
-
-  return {
-    /** Point the engine at a track (or nothing). Call when the queue's current
-     *  track changes; safe to call repeatedly for the same track. */
-    setSource: (track: QueueTrackType | null) => {
-      subscription?.remove()
-      subscription = null
-      const generation = ++generationCounter
-
-      if (!track) {
-        session = null
-        engine.setNowPlaying?.(null)
-        engine.pause()
-        callbacks.onStatus(engine.currentStatus())
-        lastPositionPersist = null
-        return
-      }
-
-      const active: SourceSession = {
-        generation,
-        id: track.id,
-        intent: { desiredPlaying: playOnReady === track.id, pendingPlaying: null },
-        preparation: {
-          generation,
-          sourceLoaded: false,
-          checkpointLoaded: false,
-          duration: 0,
-          preparing: false
-        },
-        completion: { generation, started: false, handled: false, completed: false },
-        checkpoint: null,
-        started: false
-      }
-      playOnReady = null
-      session = active
-      lastPositionPersist = null
-
-      // Pausing first stops engines that auto-resume on source replacement from
-      // playing the new track before its checkpoint has been restored.
-      engine.pause()
-      engine.replace(track.url)
-      engine.setNowPlaying?.(buildMetadata(track))
-
-      const listener = observeStatus(active)
-      subscription = engine.subscribe(listener)
-      listener(engine.currentStatus())
-
-      Effect.runPromise(storage.loadPosition(track.id)).then(
-        (saved) => {
-          if (session !== active) return
-          active.checkpoint = saved?.position ?? null
-          advancePreparation(active, { _tag: 'checkpointLoaded', generation })
-        },
-        (error: unknown) => {
-          if (session !== active) return
-          advancePreparation(active, { _tag: 'checkpointLoaded', generation })
-          onError('Unable to load audio position', error)
-        }
-      )
-    },
-
-    /** Resume or restart the loaded track. */
-    play: (trackId: string) => {
-      const active = session
-      if (!active || active.id !== trackId) return
-      active.intent = transitionPlaybackIntent(active.intent, { _tag: 'command', playing: true })
-      if (!active.started) return
-
-      const start = () => {
-        if (session !== active || !active.intent.desiredPlaying) return
-        engine.play()
-        run('Unable to deliver audio play', callbacks.recordPlay(trackId))
-      }
-
-      if (active.completion.completed) {
-        engine
-          .seekTo(0)
-          .then(start, (error: unknown) => onError('Unable to restart completed audio', error))
-        return
-      }
-      start()
-    },
-
-    pause: () => {
-      const active = session
-      if (!active) return
-      playOnReady = null
-      active.intent = transitionPlaybackIntent(active.intent, { _tag: 'command', playing: false })
-      engine.pause()
-    },
-
-    isDesiredPlaying: () => playOnReady !== null || session?.intent.desiredPlaying === true,
-
-    seekTo: (seconds: number) => {
-      const active = session
-      engine.seekTo(seconds).then(
-        () => {
-          if (session !== active || !active?.started) return
-          lastPositionPersist = { id: active.id, at: seconds }
-          run('Unable to persist audio position', storage.savePosition(active.id, seconds))
-        },
-        (error: unknown) => onError('Unable to seek audio', error)
-      )
-    },
-
-    /** Mark the next source change as user-initiated so it plays once ready. */
-    requestPlayOnReady: (trackId: string) => {
-      playOnReady = trackId
-    },
-
-    /** Stop the current source from firing end-of-track advance when it is
-     *  being replaced or removed deliberately. */
-    detachCurrentSource: () => {
-      if (session) {
-        session.completion = { ...session.completion, handled: true, completed: false }
-      }
-    },
-
-    currentTrackId: () => session?.id ?? null,
-
-    dispose: () => {
-      subscription?.remove()
-      subscription = null
-      session = null
-    }
-  }
+export interface PlayerCoreShape {
+  readonly setSource: (track: QueueTrackType | null) => Effect.Effect<void>
+  readonly play: (trackId: string) => Effect.Effect<void>
+  readonly pause: Effect.Effect<void>
+  readonly isDesiredPlaying: Effect.Effect<boolean>
+  readonly seekTo: (seconds: number) => Effect.Effect<void>
+  readonly requestPlayOnReady: (trackId: string) => Effect.Effect<void>
+  readonly detachCurrentSource: Effect.Effect<void>
+  readonly currentTrackId: Effect.Effect<string | null>
 }
 
-export type PlayerCore = ReturnType<typeof createPlayerCore>
+/** Engine-agnostic playback session: source generations, checkpoint restore,
+ *  play/pause intent reconciliation, position persistence, and end-of-track
+ *  handling. Platform differences live behind the AudioEngine service.
+ *
+ *  Built inside a scope: the status subscription is forked as a fiber and is
+ *  interrupted when the enclosing scope closes. */
+export const makePlayerCore = (
+  callbacks: PlayerCoreCallbacks
+): Effect.Effect<PlayerCoreShape, never, AudioEngine | PlayerStorage | PlayReporter | Scope> =>
+  Effect.gen(function* () {
+    const engine = yield* AudioEngine
+    const storage = yield* PlayerStorage
+    const playReporter = yield* PlayReporter
+
+    const onError =
+      callbacks.onError ?? ((message: string, error: unknown) => console.error(message, error))
+
+    let generationCounter = 0
+    let session: SourceSession | null = null
+    let playOnReady: string | null = null
+    let lastPositionPersist: { readonly id: string; readonly at: number } | null = null
+
+    const runDetached = (label: string, effect: Effect.Effect<void, unknown>) =>
+      effect.pipe(
+        Effect.catchCause((cause) => Effect.sync(() => onError(label, cause))),
+        Effect.forkDetach,
+        Effect.asVoid
+      )
+
+    /** Starts playback and reconciles intent when the platform refuses, so a
+     *  rejected play does not leave the core believing it is playing. */
+    const attemptPlay = (active: SourceSession) =>
+      engine.play.pipe(
+        Effect.flatMap(() =>
+          runDetached('Unable to deliver audio play', playReporter.recordPlay(active.id))
+        ),
+        Effect.catchTag('PlaybackRejected', (error) =>
+          Effect.sync(() => {
+            if (session === active) {
+              active.intent = transitionPlaybackIntent(active.intent, {
+                _tag: 'command',
+                playing: false
+              })
+            }
+            onError('Playback was refused by the platform', error)
+          })
+        )
+      )
+
+    const startSource = (active: SourceSession) =>
+      Effect.gen(function* () {
+        active.started = true
+        active.completion = { ...active.completion, started: true }
+        lastPositionPersist =
+          active.checkpoint === null ? null : { id: active.id, at: active.checkpoint }
+        if (!active.intent.desiredPlaying) return
+        active.intent = transitionPlaybackIntent(active.intent, { _tag: 'command', playing: true })
+        yield* attemptPlay(active)
+      })
+
+    const finishPreparing = (active: SourceSession) =>
+      Effect.gen(function* () {
+        if (session !== active || !active.preparation.preparing || active.started) return
+
+        const checkpoint = active.checkpoint
+        const shouldSeek =
+          checkpoint !== null &&
+          checkpoint > 1 &&
+          active.preparation.duration > 0 &&
+          checkpoint < active.preparation.duration - 5
+
+        if (!shouldSeek) {
+          yield* startSource(active)
+          return
+        }
+
+        yield* engine
+          .seekTo(checkpoint)
+          .pipe(
+            Effect.catchCause((cause) =>
+              Effect.sync(() => onError('Unable to restore audio position', cause))
+            )
+          )
+        if (session !== active) return
+        yield* startSource(active)
+      })
+
+    const advancePreparation = (active: SourceSession, event: SourcePreparationEvent) =>
+      Effect.suspend(() => {
+        const transition = transitionSourcePreparation(active.preparation, event)
+        active.preparation = transition.state
+        return transition.shouldPrepare ? finishPreparing(active) : Effect.void
+      })
+
+    const observeStatus = (status: EngineStatus) =>
+      Effect.gen(function* () {
+        const active = session
+        callbacks.onStatus(status)
+        if (!active) return
+
+        yield* advancePreparation(active, {
+          _tag: 'sourceStatus',
+          generation: active.generation,
+          isLoaded: status.isLoaded,
+          duration: status.duration
+        })
+        if (!status.isLoaded) return
+
+        const completion = transitionSourceCompletion(active.completion, {
+          generation: active.generation,
+          didJustFinish: status.didJustFinish,
+          playing: status.playing
+        })
+        active.completion = completion.state
+        if (completion.shouldFinish) {
+          active.intent = transitionPlaybackIntent(active.intent, { _tag: 'completed' })
+          yield* runDetached(
+            'Unable to clear completed audio position',
+            storage.clearPosition(active.id)
+          )
+          callbacks.onTrackFinished()
+          return
+        }
+
+        if (active.started) {
+          active.intent = transitionPlaybackIntent(active.intent, {
+            _tag: 'status',
+            playing: status.playing
+          })
+        }
+
+        const previousPosition =
+          lastPositionPersist?.id === active.id ? lastPositionPersist.at : null
+        if (!shouldPersistPosition(active.started, previousPosition, status.currentTime)) return
+        lastPositionPersist = { id: active.id, at: status.currentTime }
+        yield* runDetached(
+          'Unable to persist audio position',
+          storage.savePosition(active.id, status.currentTime)
+        )
+      })
+
+    yield* engine.changes.pipe(
+      Stream.runForEach(observeStatus),
+      Effect.catchCause((cause) => Effect.sync(() => onError('Audio status stream failed', cause))),
+      Effect.forkScoped
+    )
+
+    return {
+      setSource: (track: QueueTrackType | null) =>
+        Effect.gen(function* () {
+          const generation = ++generationCounter
+
+          if (!track) {
+            session = null
+            lastPositionPersist = null
+            yield* engine.setNowPlaying(null)
+            yield* engine.pause
+            callbacks.onStatus(yield* engine.currentStatus)
+            return
+          }
+
+          const active: SourceSession = {
+            generation,
+            id: track.id,
+            intent: { desiredPlaying: playOnReady === track.id, pendingPlaying: null },
+            preparation: {
+              generation,
+              sourceLoaded: false,
+              checkpointLoaded: false,
+              duration: 0,
+              preparing: false
+            },
+            completion: { generation, started: false, handled: false, completed: false },
+            checkpoint: null,
+            started: false
+          }
+          playOnReady = null
+          session = active
+          lastPositionPersist = null
+
+          // Pausing first stops engines that auto-resume on source replacement
+          // from playing the new track before its checkpoint is restored.
+          yield* engine.pause
+          yield* engine.replace(track.url)
+          yield* engine.setNowPlaying(buildMetadata(track))
+          yield* observeStatus(yield* engine.currentStatus)
+
+          const saved = yield* storage.loadPosition(track.id).pipe(
+            Effect.catchCause((cause) =>
+              Effect.sync(() => {
+                onError('Unable to load audio position', cause)
+                return null
+              })
+            )
+          )
+          if (session !== active) return
+          active.checkpoint = saved?.position ?? null
+          yield* advancePreparation(active, { _tag: 'checkpointLoaded', generation })
+          // The source may have finished loading while the checkpoint read was
+          // in flight; re-reading status covers events the stream missed.
+          yield* observeStatus(yield* engine.currentStatus)
+        }),
+
+      play: (trackId: string) =>
+        Effect.gen(function* () {
+          const active = session
+          if (!active || active.id !== trackId) return
+          active.intent = transitionPlaybackIntent(active.intent, {
+            _tag: 'command',
+            playing: true
+          })
+          if (!active.started) return
+
+          if (active.completion.completed) {
+            yield* engine
+              .seekTo(0)
+              .pipe(
+                Effect.catchCause((cause) =>
+                  Effect.sync(() => onError('Unable to restart completed audio', cause))
+                )
+              )
+          }
+          if (session !== active || !active.intent.desiredPlaying) return
+          yield* attemptPlay(active)
+        }),
+
+      pause: Effect.gen(function* () {
+        const active = session
+        if (!active) return
+        playOnReady = null
+        active.intent = transitionPlaybackIntent(active.intent, {
+          _tag: 'command',
+          playing: false
+        })
+        yield* engine.pause
+      }),
+
+      isDesiredPlaying: Effect.sync(
+        () => playOnReady !== null || session?.intent.desiredPlaying === true
+      ),
+
+      seekTo: (seconds: number) =>
+        Effect.gen(function* () {
+          const active = session
+          yield* engine.seekTo(seconds)
+          if (session !== active || !active?.started) return
+          lastPositionPersist = { id: active.id, at: seconds }
+          yield* runDetached(
+            'Unable to persist audio position',
+            storage.savePosition(active.id, seconds)
+          )
+        }).pipe(
+          Effect.catchCause((cause) => Effect.sync(() => onError('Unable to seek audio', cause)))
+        ),
+
+      /** Mark the next source change as user-initiated so it plays once ready. */
+      requestPlayOnReady: (trackId: string) =>
+        Effect.sync(() => {
+          playOnReady = trackId
+        }),
+
+      /** Stop the current source from firing end-of-track advance when it is
+       *  being replaced or removed deliberately. */
+      detachCurrentSource: Effect.sync(() => {
+        if (session) {
+          session.completion = { ...session.completion, handled: true, completed: false }
+        }
+      }),
+
+      currentTrackId: Effect.sync(() => session?.id ?? null)
+    }
+  })

--- a/packages/player/src/playerStorage.ts
+++ b/packages/player/src/playerStorage.ts
@@ -46,16 +46,6 @@ export const recordPlay = (trackId: string) =>
 export const isWithinDedupWindow = (trackId: string) =>
   Effect.andThen(PlayerStorage, (storage) => storage.isWithinDedupWindow(trackId))
 
-/** Binds the PlayerStorage service to a concrete context so the player core,
- *  which runs effects itself, can call storage without carrying requirements. */
-export const providePlayerStorage = (storage: PlayerStorageShape) => ({
-  loadPosition: (trackId: string) => storage.loadPosition(trackId),
-  savePosition: (trackId: string, position: number) => storage.savePosition(trackId, position),
-  clearPosition: (trackId: string) => storage.clearPosition(trackId),
-  loadQueue: () => storage.loadQueue(),
-  saveQueue: (queue: PersistedQueueType) => storage.saveQueue(queue)
-})
-
 export const PlayerStorageInMemory = Layer.sync(PlayerStorage, () => {
   let queue: PersistedQueueType | null = null
   const positions = new Map<string, PositionRecord>()


### PR DESCRIPTION
## Why

Follow-up to #216. That PR left `AudioEngine` as a plain factory while `PlayerStorage` was a `Context.Service` + `Layer`, so the package used two different idioms for the same kind of seam. This makes the engine a service too, and rewrites the core as an Effect program.

It also fixes four defects, three of which came out of the adversarial review of #216.

## The lifecycle problem, and how it is solved

An app-scope `Layer` cannot build the engine: on mobile `useAudioPlayer()` returns an object owned by the component, and on web `new Audio()` must happen after hydration. A layer builds once, before React mounts.

So each provider builds its **own `ManagedRuntime` scoped to that mount**:

```ts
const runtime = ManagedRuntime.make(
  Layer.mergeAll(HtmlAudioEngineLayer(audio), PlayReporterLive).pipe(
    Layer.provideMerge(Layer.mergeAll(PlayerStorageLive, MediaSessionServiceLive))
  )
)
```

The engine is a real service, acquisition and release are `Scope`, and the core's status loop is a fiber interrupted when the runtime is disposed. No mutable-ref smuggling, no manual `dispose()` bookkeeping.

## What changed

- `AudioEngine` is a `Context.Service`; methods return `Effect`, status is a `Stream` instead of a callback subscription.
- `createPlayerCore(engine, storage, callbacks)` → `makePlayerCore(callbacks)` requiring `AudioEngine | PlayerStorage | PlayReporter | Scope`.
- New `PlayReporter` service. Play tracking used to be an app-supplied callback; moving it behind a service keeps dedup and API delivery out of the core. Delivery is serialised with a `Semaphore` rather than a promise chain.
- The `playerStorage` bridge shrank to `queuePersistence` (queue load/save only), since the core now takes storage as a service. The pure state machines in `playbackState.ts` are untouched.

## Defect fixes

| | |
|---|---|
| **Play rejection was swallowed** | `play()` returned `void` and the web adapter caught the rejection. The core then recorded a play that never happened and left intent stuck at "playing", so the next toggle paused an already-paused element. Now typed as `PlaybackRejected`; the core reconciles intent and skips reporting. This is the Safari autoplay path. |
| **Hidden audio after clearing the queue** | The source effect returned early on `null`, so `setSource(null)` never ran. Queue and UI disappeared while the element kept playing and persisting position. |
| **Restored volume was cosmetic** | `volumeRef` was hardcoded to `{100, false}` while the atom restored the real value, so after reload the UI showed 42% and playback ran at 100%. |
| **Dropped status events** | `setSource` now re-reads engine status after the stored position resolves, covering a source that finished loading during that read. |

## Tests

`packages/player/src/playerCore.test.ts` is new: the core is driven through a recording `AudioEngine` and storage seam, covering checkpoint restore, the near-end no-seek case, play rejection, teardown, completion, and position persistence. This is what #216's review flagged as missing (S1) and it is only possible because the core takes services now.

`bun precommit` clean across all 10 workspaces from a cold cache, 232 tests + 32 in the player package.

## Test evidence

Verified in Chromium against a real mix (`gb#66`, a 146MB mp3 served 206 from the CDN), not a mock:

| step | result |
|---|---|
| hydrate queue | `gb#66`, duration `01:01:10` |
| play | advances to `00:06` → `00:23`, icon flips to pause |
| pause | holds at `00:23` |
| persisted | `{"position":23.438654,...}` |
| reload | restores `00:23`, volume slider `42` |
| play tracking | `POST /api/content/audio/.../play` → 200, dedup marker written; a second play within the window is correctly suppressed |

iOS bundle exports clean (`expo export --platform ios`), so Metro resolves the new services.

## Not verified

**Safari on a real device.** You merged #216 to test exactly this, and it is the one thing I cannot check from here. The play-rejection fix above is the code-level part of that problem; whether Safari now starts playback on first tap still needs your device.

## Review order

1. `packages/player/src/engine.ts` — the new service shape.
2. `packages/player/src/playerCore.ts` — the core as an Effect program. Worth reading `attemptPlay` closely.
3. Either provider — the `ManagedRuntime` mount/teardown is the same pattern on both.
4. `playerCore.test.ts` — the seam is now testable; this is the payoff.
