### PR TITLE
feat(music): add factual label affiliations

### DIFF
--- a/apps/vps/drizzle/0043_orange_alex_power.sql
+++ b/apps/vps/drizzle/0043_orange_alex_power.sql
@@ -13,6 +13,4 @@ CREATE TABLE "music_label_artists" (
 ALTER TABLE "music_label_albums" ADD CONSTRAINT "music_label_albums_label_id_music_labels_id_fk" FOREIGN KEY ("label_id") REFERENCES "public"."music_labels"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "music_label_albums" ADD CONSTRAINT "music_label_albums_album_id_music_albums_id_fk" FOREIGN KEY ("album_id") REFERENCES "public"."music_albums"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "music_label_artists" ADD CONSTRAINT "music_label_artists_label_id_music_labels_id_fk" FOREIGN KEY ("label_id") REFERENCES "public"."music_labels"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "music_label_artists" ADD CONSTRAINT "music_label_artists_artist_id_music_artists_id_fk" FOREIGN KEY ("artist_id") REFERENCES "public"."music_artists"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "music_label_albums_album_id_idx" ON "music_label_albums" USING btree ("album_id");--> statement-breakpoint
-CREATE INDEX "music_label_artists_artist_id_idx" ON "music_label_artists" USING btree ("artist_id");
+ALTER TABLE "music_label_artists" ADD CONSTRAINT "music_label_artists_artist_id_music_artists_id_fk" FOREIGN KEY ("artist_id") REFERENCES "public"."music_artists"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/vps/drizzle/0043_peaceful_gorgon.sql
+++ b/apps/vps/drizzle/0043_peaceful_gorgon.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "music_label_albums" (
+	"label_id" uuid NOT NULL,
+	"album_id" uuid NOT NULL,
+	CONSTRAINT "music_label_albums_label_id_album_id_pk" PRIMARY KEY("label_id","album_id")
+);
+--> statement-breakpoint
+CREATE TABLE "music_label_artists" (
+	"label_id" uuid NOT NULL,
+	"artist_id" uuid NOT NULL,
+	CONSTRAINT "music_label_artists_label_id_artist_id_pk" PRIMARY KEY("label_id","artist_id")
+);
+--> statement-breakpoint
+ALTER TABLE "music_label_albums" ADD CONSTRAINT "music_label_albums_label_id_music_labels_id_fk" FOREIGN KEY ("label_id") REFERENCES "public"."music_labels"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "music_label_albums" ADD CONSTRAINT "music_label_albums_album_id_music_albums_id_fk" FOREIGN KEY ("album_id") REFERENCES "public"."music_albums"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "music_label_artists" ADD CONSTRAINT "music_label_artists_label_id_music_labels_id_fk" FOREIGN KEY ("label_id") REFERENCES "public"."music_labels"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "music_label_artists" ADD CONSTRAINT "music_label_artists_artist_id_music_artists_id_fk" FOREIGN KEY ("artist_id") REFERENCES "public"."music_artists"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "music_label_albums_album_id_idx" ON "music_label_albums" USING btree ("album_id");--> statement-breakpoint
+CREATE INDEX "music_label_artists_artist_id_idx" ON "music_label_artists" USING btree ("artist_id");

--- a/apps/vps/drizzle/0044_true_the_leader.sql
+++ b/apps/vps/drizzle/0044_true_the_leader.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "music_label_albums_album_id_idx" ON "music_label_albums" USING btree ("album_id");--> statement-breakpoint
+CREATE INDEX "music_label_artists_artist_id_idx" ON "music_label_artists" USING btree ("artist_id");

--- a/apps/vps/drizzle/meta/0043_snapshot.json
+++ b/apps/vps/drizzle/meta/0043_snapshot.json
@@ -1,0 +1,3333 @@
+{
+  "id": "ab512790-689d-4d84-b4cf-3b3490db2bcc",
+  "prevId": "6b430fbf-ed18-42ef-9aca-2ef40867c978",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audio_creators": {
+      "name": "audio_creators",
+      "schema": "",
+      "columns": {
+        "audioId": {
+          "name": "audioId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creatorId": {
+          "name": "creatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audio_creators_audioId_audio_id_fk": {
+          "name": "audio_creators_audioId_audio_id_fk",
+          "tableFrom": "audio_creators",
+          "tableTo": "audio",
+          "columnsFrom": ["audioId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audio_creators_creatorId_user_id_fk": {
+          "name": "audio_creators_creatorId_user_id_fk",
+          "tableFrom": "audio_creators",
+          "tableTo": "user",
+          "columnsFrom": ["creatorId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audio_creators_audioId_creatorId_pk": {
+          "name": "audio_creators_audioId_creatorId_pk",
+          "columns": ["audioId", "creatorId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audio": {
+      "name": "audio",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnailUrl": {
+          "name": "thumbnailUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannerImageUrl": {
+          "name": "bannerImageUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "audio_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyActorId": {
+          "name": "idempotencyActorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyFingerprint": {
+          "name": "idempotencyFingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "showId": {
+          "name": "showId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "episodeNumber": {
+          "name": "episodeNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playCount": {
+          "name": "playCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "audio_slug_idx": {
+          "name": "audio_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_type_slug_unique": {
+          "name": "audio_type_slug_unique",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_actor_idempotency_unique": {
+          "name": "audio_actor_idempotency_unique",
+          "columns": [
+            {
+              "expression": "idempotencyActorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotencyKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_show_idx": {
+          "name": "audio_show_idx",
+          "columns": [
+            {
+              "expression": "showId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_type_created_idx": {
+          "name": "audio_type_created_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_tags_gin_idx": {
+          "name": "audio_tags_gin_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_showId_shows_id_fk": {
+          "name": "audio_showId_shows_id_fk",
+          "tableFrom": "audio",
+          "tableTo": "shows",
+          "columnsFrom": ["showId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "user_display_username_unique": {
+          "name": "user_display_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["display_username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_social_links": {
+      "name": "user_social_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_social_links_user_id_idx": {
+          "name": "user_social_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_social_links_user_position_uq": {
+          "name": "user_social_links_user_position_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_social_links_user_id_user_id_fk": {
+          "name": "user_social_links_user_id_user_id_fk",
+          "tableFrom": "user_social_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_delivery_logs": {
+      "name": "email_delivery_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientName": {
+          "name": "recipientName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailType": {
+          "name": "emailType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateName": {
+          "name": "templateName",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "sesMessageId": {
+          "name": "sesMessageId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bouncedAt": {
+          "name": "bouncedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complainedAt": {
+          "name": "complainedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_delivery_logs_userId_idx": {
+          "name": "email_delivery_logs_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_logs_recipientEmail_idx": {
+          "name": "email_delivery_logs_recipientEmail_idx",
+          "columns": [
+            {
+              "expression": "recipientEmail",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_logs_status_idx": {
+          "name": "email_delivery_logs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_logs_createdAt_idx": {
+          "name": "email_delivery_logs_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_delivery_logs_userId_user_id_fk": {
+          "name": "email_delivery_logs_userId_user_id_fk",
+          "tableFrom": "email_delivery_logs",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_email_preferences": {
+      "name": "user_email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mixReleaseEnabled": {
+          "name": "mixReleaseEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "promotionalEnabled": {
+          "name": "promotionalEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "systemEnabled": {
+          "name": "systemEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "globalUnsubscribe": {
+          "name": "globalUnsubscribe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "unsubscribeToken": {
+          "name": "unsubscribeToken",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_email_preferences_userId_user_id_fk": {
+          "name": "user_email_preferences_userId_user_id_fk",
+          "tableFrom": "user_email_preferences",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_preferences_userId_unique": {
+          "name": "user_email_preferences_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId"]
+        },
+        "user_email_preferences_unsubscribeToken_unique": {
+          "name": "user_email_preferences_unsubscribeToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["unsubscribeToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_id": {
+          "name": "audio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favorites_user_created_idx": {
+          "name": "favorites_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorites_user_id_user_id_fk": {
+          "name": "favorites_user_id_user_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_audio_id_audio_id_fk": {
+          "name": "favorites_audio_id_audio_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "audio",
+          "columnsFrom": ["audio_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_show_id_shows_id_fk": {
+          "name": "favorites_show_id_shows_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "shows",
+          "columnsFrom": ["show_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_audio": {
+          "name": "unique_user_audio",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "audio_id"]
+        },
+        "unique_user_show": {
+          "name": "unique_user_show",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "show_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_album_artists": {
+      "name": "music_album_artists",
+      "schema": "",
+      "columns": {
+        "albumId": {
+          "name": "albumId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artistId": {
+          "name": "artistId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayOrder": {
+          "name": "displayOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "music_album_artists_albumId_music_albums_id_fk": {
+          "name": "music_album_artists_albumId_music_albums_id_fk",
+          "tableFrom": "music_album_artists",
+          "tableTo": "music_albums",
+          "columnsFrom": ["albumId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_album_artists_artistId_music_artists_id_fk": {
+          "name": "music_album_artists_artistId_music_artists_id_fk",
+          "tableFrom": "music_album_artists",
+          "tableTo": "music_artists",
+          "columnsFrom": ["artistId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_album_artists_albumId_artistId_pk": {
+          "name": "music_album_artists_albumId_artistId_pk",
+          "columns": ["albumId", "artistId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_albums": {
+      "name": "music_albums",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artistNames": {
+          "name": "artistNames",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImageUrl": {
+          "name": "coverImageUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "albumType": {
+          "name": "albumType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_albums_slug_idx": {
+          "name": "music_albums_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_albums_createdById_user_id_fk": {
+          "name": "music_albums_createdById_user_id_fk",
+          "tableFrom": "music_albums",
+          "tableTo": "user",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_albums_slug_unique": {
+          "name": "music_albums_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_artists": {
+      "name": "music_artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_artists_slug_idx": {
+          "name": "music_artists_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_artists_createdById_user_id_fk": {
+          "name": "music_artists_createdById_user_id_fk",
+          "tableFrom": "music_artists",
+          "tableTo": "user",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_artists_slug_unique": {
+          "name": "music_artists_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_entity_links": {
+      "name": "music_entity_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "scrapedAt": {
+          "name": "scrapedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedBy": {
+          "name": "verifiedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_entity_links_entity_idx": {
+          "name": "music_entity_links_entity_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_entity_links_status_idx": {
+          "name": "music_entity_links_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_entity_links_platform_idx": {
+          "name": "music_entity_links_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_entity_links_entityType_music_entity_types_id_fk": {
+          "name": "music_entity_links_entityType_music_entity_types_id_fk",
+          "tableFrom": "music_entity_links",
+          "tableTo": "music_entity_types",
+          "columnsFrom": ["entityType"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "music_entity_links_platform_music_platforms_id_fk": {
+          "name": "music_entity_links_platform_music_platforms_id_fk",
+          "tableFrom": "music_entity_links",
+          "tableTo": "music_platforms",
+          "columnsFrom": ["platform"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "music_entity_links_verifiedBy_user_id_fk": {
+          "name": "music_entity_links_verifiedBy_user_id_fk",
+          "tableFrom": "music_entity_links",
+          "tableTo": "user",
+          "columnsFrom": ["verifiedBy"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_entity_links_unique_platform": {
+          "name": "music_entity_links_unique_platform",
+          "nullsNotDistinct": false,
+          "columns": ["entityType", "entityId", "platform"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_entity_types": {
+      "name": "music_entity_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_label_albums": {
+      "name": "music_label_albums",
+      "schema": "",
+      "columns": {
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "music_label_albums_album_id_idx": {
+          "name": "music_label_albums_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_label_albums_label_id_music_labels_id_fk": {
+          "name": "music_label_albums_label_id_music_labels_id_fk",
+          "tableFrom": "music_label_albums",
+          "tableTo": "music_labels",
+          "columnsFrom": ["label_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_label_albums_album_id_music_albums_id_fk": {
+          "name": "music_label_albums_album_id_music_albums_id_fk",
+          "tableFrom": "music_label_albums",
+          "tableTo": "music_albums",
+          "columnsFrom": ["album_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_label_albums_label_id_album_id_pk": {
+          "name": "music_label_albums_label_id_album_id_pk",
+          "columns": ["label_id", "album_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_label_artists": {
+      "name": "music_label_artists",
+      "schema": "",
+      "columns": {
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "music_label_artists_artist_id_idx": {
+          "name": "music_label_artists_artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_label_artists_label_id_music_labels_id_fk": {
+          "name": "music_label_artists_label_id_music_labels_id_fk",
+          "tableFrom": "music_label_artists",
+          "tableTo": "music_labels",
+          "columnsFrom": ["label_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_label_artists_artist_id_music_artists_id_fk": {
+          "name": "music_label_artists_artist_id_music_artists_id_fk",
+          "tableFrom": "music_label_artists",
+          "tableTo": "music_artists",
+          "columnsFrom": ["artist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_label_artists_label_id_artist_id_pk": {
+          "name": "music_label_artists_label_id_artist_id_pk",
+          "columns": ["label_id", "artist_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_label_creators": {
+      "name": "music_label_creators",
+      "schema": "",
+      "columns": {
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "music_label_creators_label_id_music_labels_id_fk": {
+          "name": "music_label_creators_label_id_music_labels_id_fk",
+          "tableFrom": "music_label_creators",
+          "tableTo": "music_labels",
+          "columnsFrom": ["label_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_label_creators_creator_id_user_id_fk": {
+          "name": "music_label_creators_creator_id_user_id_fk",
+          "tableFrom": "music_label_creators",
+          "tableTo": "user",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_label_creators_label_id_creator_id_pk": {
+          "name": "music_label_creators_label_id_creator_id_pk",
+          "columns": ["label_id", "creator_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_labels": {
+      "name": "music_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_image_url": {
+          "name": "banner_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_labels_slug_idx": {
+          "name": "music_labels_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_labels_created_by_id_user_id_fk": {
+          "name": "music_labels_created_by_id_user_id_fk",
+          "tableFrom": "music_labels",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_labels_slug_unique": {
+          "name": "music_labels_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_platforms": {
+      "name": "music_platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "websiteUrl": {
+          "name": "websiteUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iconUrl": {
+          "name": "iconUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_playlist_tracks": {
+      "name": "music_playlist_tracks",
+      "schema": "",
+      "columns": {
+        "playlistId": {
+          "name": "playlistId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trackId": {
+          "name": "trackId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_playlist_tracks_position_idx": {
+          "name": "music_playlist_tracks_position_idx",
+          "columns": [
+            {
+              "expression": "playlistId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_playlist_tracks_playlistId_music_playlists_id_fk": {
+          "name": "music_playlist_tracks_playlistId_music_playlists_id_fk",
+          "tableFrom": "music_playlist_tracks",
+          "tableTo": "music_playlists",
+          "columnsFrom": ["playlistId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_playlist_tracks_trackId_music_tracks_id_fk": {
+          "name": "music_playlist_tracks_trackId_music_tracks_id_fk",
+          "tableFrom": "music_playlist_tracks",
+          "tableTo": "music_tracks",
+          "columnsFrom": ["trackId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_playlist_tracks_playlistId_trackId_pk": {
+          "name": "music_playlist_tracks_playlistId_trackId_pk",
+          "columns": ["playlistId", "trackId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_playlists": {
+      "name": "music_playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImageUrl": {
+          "name": "coverImageUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curatorId": {
+          "name": "curatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_playlists_slug_idx": {
+          "name": "music_playlists_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_playlists_curatorId_user_id_fk": {
+          "name": "music_playlists_curatorId_user_id_fk",
+          "tableFrom": "music_playlists",
+          "tableTo": "user",
+          "columnsFrom": ["curatorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "music_playlists_createdById_user_id_fk": {
+          "name": "music_playlists_createdById_user_id_fk",
+          "tableFrom": "music_playlists",
+          "tableTo": "user",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_playlists_slug_unique": {
+          "name": "music_playlists_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_track_artists": {
+      "name": "music_track_artists",
+      "schema": "",
+      "columns": {
+        "trackId": {
+          "name": "trackId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artistId": {
+          "name": "artistId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayOrder": {
+          "name": "displayOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "music_track_artists_trackId_music_tracks_id_fk": {
+          "name": "music_track_artists_trackId_music_tracks_id_fk",
+          "tableFrom": "music_track_artists",
+          "tableTo": "music_tracks",
+          "columnsFrom": ["trackId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_track_artists_artistId_music_artists_id_fk": {
+          "name": "music_track_artists_artistId_music_artists_id_fk",
+          "tableFrom": "music_track_artists",
+          "tableTo": "music_artists",
+          "columnsFrom": ["artistId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_track_artists_trackId_artistId_pk": {
+          "name": "music_track_artists_trackId_artistId_pk",
+          "columns": ["trackId", "artistId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_tracks": {
+      "name": "music_tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artistNames": {
+          "name": "artistNames",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImageUrl": {
+          "name": "coverImageUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "albumId": {
+          "name": "albumId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trackNumber": {
+          "name": "trackNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_tracks_slug_idx": {
+          "name": "music_tracks_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_tracks_albumId_music_albums_id_fk": {
+          "name": "music_tracks_albumId_music_albums_id_fk",
+          "tableFrom": "music_tracks",
+          "tableTo": "music_albums",
+          "columnsFrom": ["albumId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "music_tracks_createdById_user_id_fk": {
+          "name": "music_tracks_createdById_user_id_fk",
+          "tableFrom": "music_tracks",
+          "tableTo": "user",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_tracks_slug_unique": {
+          "name": "music_tracks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_reminder": {
+      "name": "music_reminder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "music_title": {
+          "name": "music_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "music_url": {
+          "name": "music_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_cover_url": {
+          "name": "album_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_date": {
+          "name": "reminder_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "reminder_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_sent": {
+          "name": "is_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_reminder_user_id_idx": {
+          "name": "music_reminder_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_reminder_reminder_date_idx": {
+          "name": "music_reminder_reminder_date_idx",
+          "columns": [
+            {
+              "expression": "reminder_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_reminder_is_sent_idx": {
+          "name": "music_reminder_is_sent_idx",
+          "columns": [
+            {
+              "expression": "is_sent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_reminder_status_idx": {
+          "name": "music_reminder_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_reminder_user_id_user_id_fk": {
+          "name": "music_reminder_user_id_user_id_fk",
+          "tableFrom": "music_reminder",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribeToken": {
+          "name": "unsubscribeToken",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "unsubscribedAt": {
+          "name": "unsubscribedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_email_idx": {
+          "name": "newsletter_subscribers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_subscribers_userId_idx": {
+          "name": "newsletter_subscribers_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "newsletter_subscribers_userId_user_id_fk": {
+          "name": "newsletter_subscribers_userId_user_id_fk",
+          "tableFrom": "newsletter_subscribers",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscribers_email_unique": {
+          "name": "newsletter_subscribers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "newsletter_subscribers_unsubscribeToken_unique": {
+          "name": "newsletter_subscribers_unsubscribeToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["unsubscribeToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_creators": {
+      "name": "post_creators",
+      "schema": "",
+      "columns": {
+        "postId": {
+          "name": "postId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creatorId": {
+          "name": "creatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_creators_postId_posts_id_fk": {
+          "name": "post_creators_postId_posts_id_fk",
+          "tableFrom": "post_creators",
+          "tableTo": "posts",
+          "columnsFrom": ["postId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_creators_creatorId_user_id_fk": {
+          "name": "post_creators_creatorId_user_id_fk",
+          "tableFrom": "post_creators",
+          "tableTo": "user",
+          "columnsFrom": ["creatorId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_creators_postId_creatorId_pk": {
+          "name": "post_creators_postId_creatorId_pk",
+          "columns": ["postId", "creatorId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnailUrl": {
+          "name": "thumbnailUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannerImageUrl": {
+          "name": "bannerImageUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "music_entity_type": {
+          "name": "music_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "music_entity_id": {
+          "name": "music_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "posts_slug_idx": {
+          "name": "posts_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_music_entity_idx": {
+          "name": "posts_music_entity_idx",
+          "columns": [
+            {
+              "expression": "music_entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "music_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_type_created_idx": {
+          "name": "posts_type_created_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_tags_gin_idx": {
+          "name": "posts_tags_gin_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.releases": {
+      "name": "releases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnailUrl": {
+          "name": "thumbnailUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannerImageUrl": {
+          "name": "bannerImageUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamingLinks": {
+          "name": "streamingLinks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "releases_slug_idx": {
+          "name": "releases_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "releases_labelId_music_labels_id_fk": {
+          "name": "releases_labelId_music_labels_id_fk",
+          "tableFrom": "releases",
+          "tableTo": "music_labels",
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.show_creators": {
+      "name": "show_creators",
+      "schema": "",
+      "columns": {
+        "showId": {
+          "name": "showId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creatorId": {
+          "name": "creatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "show_creators_showId_shows_id_fk": {
+          "name": "show_creators_showId_shows_id_fk",
+          "tableFrom": "show_creators",
+          "tableTo": "shows",
+          "columnsFrom": ["showId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_creators_creatorId_user_id_fk": {
+          "name": "show_creators_creatorId_user_id_fk",
+          "tableFrom": "show_creators",
+          "tableTo": "user",
+          "columnsFrom": ["creatorId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "show_creators_showId_creatorId_pk": {
+          "name": "show_creators_showId_creatorId_pk",
+          "columns": ["showId", "creatorId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.show_subscriptions": {
+      "name": "show_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "showId": {
+          "name": "showId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "show_subscriptions_user_idx": {
+          "name": "show_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "show_subscriptions_show_idx": {
+          "name": "show_subscriptions_show_idx",
+          "columns": [
+            {
+              "expression": "showId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_subscriptions_userId_user_id_fk": {
+          "name": "show_subscriptions_userId_user_id_fk",
+          "tableFrom": "show_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_subscriptions_showId_shows_id_fk": {
+          "name": "show_subscriptions_showId_shows_id_fk",
+          "tableFrom": "show_subscriptions",
+          "tableTo": "shows",
+          "columnsFrom": ["showId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "show_subscriptions_user_show_unique": {
+          "name": "show_subscriptions_user_show_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "showId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shows": {
+      "name": "shows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnailUrl": {
+          "name": "thumbnailUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannerImageUrl": {
+          "name": "bannerImageUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "shows_slug_idx": {
+          "name": "shows_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.audio_type": {
+      "name": "audio_type",
+      "schema": "public",
+      "values": ["mix", "track", "misc"]
+    },
+    "public.reminder_status": {
+      "name": "reminder_status",
+      "schema": "public",
+      "values": ["pending", "processing", "sent", "failed"]
+    },
+    "public.post_type": {
+      "name": "post_type",
+      "schema": "public",
+      "values": ["post", "micro"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/vps/drizzle/meta/0044_snapshot.json
+++ b/apps/vps/drizzle/meta/0044_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "2446c294-af40-4e7b-ba41-49e80d04c718",
-  "prevId": "6b430fbf-ed18-42ef-9aca-2ef40867c978",
+  "id": "9c0bbe9f-5e84-46a3-afba-6e481227cf4d",
+  "prevId": "2446c294-af40-4e7b-ba41-49e80d04c718",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1711,7 +1711,23 @@
           "notNull": true
         }
       },
-      "indexes": {},
+      "indexes": {
+        "music_label_albums_album_id_idx": {
+          "name": "music_label_albums_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "music_label_albums_label_id_music_labels_id_fk": {
           "name": "music_label_albums_label_id_music_labels_id_fk",
@@ -1760,7 +1776,23 @@
           "notNull": true
         }
       },
-      "indexes": {},
+      "indexes": {
+        "music_label_artists_artist_id_idx": {
+          "name": "music_label_artists_artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "music_label_artists_label_id_music_labels_id_fk": {
           "name": "music_label_artists_label_id_music_labels_id_fk",

--- a/apps/vps/drizzle/meta/_journal.json
+++ b/apps/vps/drizzle/meta/_journal.json
@@ -285,8 +285,15 @@
     {
       "idx": 43,
       "version": "7",
-      "when": 1785028966750,
-      "tag": "0043_peaceful_gorgon",
+      "when": 1785026779857,
+      "tag": "0043_orange_alex_power",
+      "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1785029760298,
+      "tag": "0044_true_the_leader",
       "breakpoints": true
     }
   ]

--- a/apps/vps/drizzle/meta/_journal.json
+++ b/apps/vps/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1784994044309,
       "tag": "0042_sudden_natasha_romanoff",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1785028966750,
+      "tag": "0043_peaceful_gorgon",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/vps/src/db/label-music-entity-migration.test.ts
+++ b/apps/vps/src/db/label-music-entity-migration.test.ts
@@ -11,6 +11,25 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const drizzleRoot = path.resolve(__dirname, '../../drizzle')
 
+const APPLIED_0043_SQL = `
+CREATE TABLE "music_label_albums" (
+  "label_id" uuid NOT NULL,
+  "album_id" uuid NOT NULL,
+  CONSTRAINT "music_label_albums_label_id_album_id_pk" PRIMARY KEY("label_id","album_id")
+);
+CREATE TABLE "music_label_artists" (
+  "label_id" uuid NOT NULL,
+  "artist_id" uuid NOT NULL,
+  CONSTRAINT "music_label_artists_label_id_artist_id_pk" PRIMARY KEY("label_id","artist_id")
+);
+ALTER TABLE "music_label_albums" ADD CONSTRAINT "music_label_albums_label_id_music_labels_id_fk" FOREIGN KEY ("label_id") REFERENCES "public"."music_labels"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "music_label_albums" ADD CONSTRAINT "music_label_albums_album_id_music_albums_id_fk" FOREIGN KEY ("album_id") REFERENCES "public"."music_albums"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "music_label_artists" ADD CONSTRAINT "music_label_artists_label_id_music_labels_id_fk" FOREIGN KEY ("label_id") REFERENCES "public"."music_labels"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "music_label_artists" ADD CONSTRAINT "music_label_artists_artist_id_music_artists_id_fk" FOREIGN KEY ("artist_id") REFERENCES "public"."music_artists"("id") ON DELETE cascade ON UPDATE no action;
+`
+
+const APPLIED_0043_AT = 1785026779857
+
 const PRE_0041_SCHEMA = `
 CREATE TABLE "user" (
   "id" text PRIMARY KEY,
@@ -144,8 +163,7 @@ function splitStatements(sql: string): string[] {
     .filter((part) => part.length > 0)
 }
 
-async function applyMigrationFile(pool: Pool, tag: string) {
-  const sql = migrationSql(tag)
+async function applyMigrationSql(pool: Pool, sql: string, createdAt = Date.now()) {
   const hash = createHash('sha256').update(sql).digest('hex')
   const client = await pool.connect()
   try {
@@ -155,7 +173,7 @@ async function applyMigrationFile(pool: Pool, tag: string) {
     }
     await client.query(
       `INSERT INTO drizzle.__drizzle_migrations ("hash", "created_at") VALUES ($1, $2)`,
-      [hash, Date.now()]
+      [hash, createdAt]
     )
     await client.query('COMMIT')
   } catch (error) {
@@ -164,6 +182,10 @@ async function applyMigrationFile(pool: Pool, tag: string) {
   } finally {
     client.release()
   }
+}
+
+async function applyMigrationFile(pool: Pool, tag: string) {
+  await applyMigrationSql(pool, migrationSql(tag))
 }
 
 async function ensureMigrationTable(pool: Pool) {
@@ -504,6 +526,37 @@ describe('label music-entity migrations 0041-0042', () => {
     `)
     expect(releaseFk.rows).toEqual([
       { conname: 'releases_labelId_labels_id_fk', referenced_table: 'labels' }
+    ])
+  }, 120_000)
+
+  it('continues after the originally deployed 0043 affiliation migration', async () => {
+    await resetToPre0041()
+    await seedRepresentativeLabels(pool)
+    await applyMigrationSql(pool, migrationSql('0041_loving_hobgoblin'), 1784994030001)
+    await applyMigrationSql(pool, migrationSql('0042_sudden_natasha_romanoff'), 1784994044309)
+    await applyMigrationSql(pool, APPLIED_0043_SQL, APPLIED_0043_AT)
+
+    const db = drizzle(pool)
+    await expect(
+      migratePostgres(db, {
+        migrationsFolder: drizzleRoot,
+        migrationsTable: '__drizzle_migrations',
+        migrationsSchema: 'drizzle'
+      })
+    ).resolves.toBeUndefined()
+
+    const indexes = await pool.query(`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE indexname IN (
+        'music_label_artists_artist_id_idx',
+        'music_label_albums_album_id_idx'
+      )
+      ORDER BY indexname
+    `)
+    expect(indexes.rows).toEqual([
+      { indexname: 'music_label_albums_album_id_idx' },
+      { indexname: 'music_label_artists_artist_id_idx' }
     ])
   }, 120_000)
 

--- a/apps/vps/src/db/label-music-entity-migration.test.ts
+++ b/apps/vps/src/db/label-music-entity-migration.test.ts
@@ -75,6 +75,14 @@ CREATE TABLE "releases" (
 
 CREATE INDEX "releases_slug_idx" ON "releases" USING btree ("slug");
 
+CREATE TABLE "music_artists" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL
+);
+
+CREATE TABLE "music_albums" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL
+);
+
 CREATE TABLE "music_entity_types" (
   "id" varchar(50) PRIMARY KEY NOT NULL,
   "displayName" varchar(100) NOT NULL
@@ -499,7 +507,7 @@ describe('label music-entity migrations 0041-0042', () => {
     ])
   }, 120_000)
 
-  it('applies 0041-0042 through the drizzle migrator seam', async () => {
+  it('applies the label cutover and later affiliations through the drizzle migrator seam', async () => {
     await resetToPre0041()
     await seedRepresentativeLabels(pool)
 
@@ -523,14 +531,18 @@ describe('label music-entity migrations 0041-0042', () => {
         (SELECT count(*)::int FROM music_label_creators) AS creators,
         (SELECT count(*)::int FROM music_entity_links WHERE "entityType" = 'label') AS links,
         (SELECT count(*)::int FROM music_labels WHERE created_by_id IS NOT NULL) AS with_creator,
-        to_regclass('public.labels') AS legacy_labels
+        to_regclass('public.labels') AS legacy_labels,
+        to_regclass('public.music_label_artists') AS label_artists,
+        to_regclass('public.music_label_albums') AS label_albums
     `)
     expect(result.rows[0]).toEqual({
       labels: 9,
       creators: 6,
       links: 7,
       with_creator: 0,
-      legacy_labels: null
+      legacy_labels: null,
+      label_artists: 'music_label_artists',
+      label_albums: 'music_label_albums'
     })
   }, 120_000)
 })

--- a/apps/vps/src/db/music-entity.schema.ts
+++ b/apps/vps/src/db/music-entity.schema.ts
@@ -188,6 +188,38 @@ export const musicLabelCreatorsTable = pgTable(
   (table) => [primaryKey({ columns: [table.labelId, table.creatorId] })]
 )
 
+export const musicLabelArtistsTable = pgTable(
+  'music_label_artists',
+  {
+    labelId: uuid('label_id')
+      .notNull()
+      .references(() => musicLabelsTable.id, { onDelete: 'cascade' }),
+    artistId: uuid('artist_id')
+      .notNull()
+      .references(() => musicArtistsTable.id, { onDelete: 'cascade' })
+  },
+  (table) => [
+    primaryKey({ columns: [table.labelId, table.artistId] }),
+    index('music_label_artists_artist_id_idx').on(table.artistId)
+  ]
+)
+
+export const musicLabelAlbumsTable = pgTable(
+  'music_label_albums',
+  {
+    labelId: uuid('label_id')
+      .notNull()
+      .references(() => musicLabelsTable.id, { onDelete: 'cascade' }),
+    albumId: uuid('album_id')
+      .notNull()
+      .references(() => musicAlbumsTable.id, { onDelete: 'cascade' })
+  },
+  (table) => [
+    primaryKey({ columns: [table.labelId, table.albumId] }),
+    index('music_label_albums_album_id_idx').on(table.albumId)
+  ]
+)
+
 // ---------------------------------------------------------------------------
 // Many-to-many: artists ↔ albums and artists ↔ tracks
 // ---------------------------------------------------------------------------
@@ -327,12 +359,14 @@ export type InsertMusicEntityLink = InferInsertModel<typeof musicEntityLinksTabl
 
 export const musicArtistsRelations = relations(musicArtistsTable, ({ many }) => ({
   albumArtists: many(musicAlbumArtistsTable),
-  trackArtists: many(musicTrackArtistsTable)
+  trackArtists: many(musicTrackArtistsTable),
+  labelArtists: many(musicLabelArtistsTable)
 }))
 
 export const musicAlbumsRelations = relations(musicAlbumsTable, ({ many }) => ({
   albumArtists: many(musicAlbumArtistsTable),
-  tracks: many(musicTracksTable)
+  tracks: many(musicTracksTable),
+  labelAlbums: many(musicLabelAlbumsTable)
 }))
 
 export const musicTracksRelations = relations(musicTracksTable, ({ one, many }) => ({
@@ -375,7 +409,9 @@ export const musicPlaylistsRelations = relations(musicPlaylistsTable, ({ one, ma
 }))
 
 export const musicLabelsRelations = relations(musicLabelsTable, ({ many }) => ({
-  creators: many(musicLabelCreatorsTable)
+  creators: many(musicLabelCreatorsTable),
+  artists: many(musicLabelArtistsTable),
+  albums: many(musicLabelAlbumsTable)
 }))
 
 export const musicLabelCreatorsRelations = relations(musicLabelCreatorsTable, ({ one }) => ({
@@ -386,6 +422,28 @@ export const musicLabelCreatorsRelations = relations(musicLabelCreatorsTable, ({
   creator: one(user, {
     fields: [musicLabelCreatorsTable.creatorId],
     references: [user.id]
+  })
+}))
+
+export const musicLabelArtistsRelations = relations(musicLabelArtistsTable, ({ one }) => ({
+  label: one(musicLabelsTable, {
+    fields: [musicLabelArtistsTable.labelId],
+    references: [musicLabelsTable.id]
+  }),
+  artist: one(musicArtistsTable, {
+    fields: [musicLabelArtistsTable.artistId],
+    references: [musicArtistsTable.id]
+  })
+}))
+
+export const musicLabelAlbumsRelations = relations(musicLabelAlbumsTable, ({ one }) => ({
+  label: one(musicLabelsTable, {
+    fields: [musicLabelAlbumsTable.labelId],
+    references: [musicLabelsTable.id]
+  }),
+  album: one(musicAlbumsTable, {
+    fields: [musicLabelAlbumsTable.albumId],
+    references: [musicAlbumsTable.id]
   })
 }))
 

--- a/apps/vps/src/http/music.handlers.ts
+++ b/apps/vps/src/http/music.handlers.ts
@@ -313,6 +313,14 @@ export const MusicHandlersLive = HttpApiBuilder.group(Api, 'music', (handlers) =
         )
       })
     )
+    .handle('listArtistLabels', ({ params }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        const rows = yield* dieOnDatabaseError(svc.getLabelsForArtist(params.artistId))
+        return rows.map(toLabelResponse)
+      })
+    )
     .handle('addArtistToAlbum', ({ params, payload }) =>
       Effect.gen(function* () {
         yield* requireAdmin
@@ -394,6 +402,14 @@ export const MusicHandlersLive = HttpApiBuilder.group(Api, 'music', (handlers) =
             .deleteAlbum(params.id)
             .pipe(Effect.catchTag('NotFoundError', () => new HttpApiError.NotFound()))
         )
+      })
+    )
+    .handle('listAlbumLabels', ({ params }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        const rows = yield* dieOnDatabaseError(svc.getLabelsForAlbum(params.albumId))
+        return rows.map(toLabelResponse)
       })
     )
     // -----------------------------------------------------------------
@@ -540,7 +556,17 @@ export const MusicHandlersLive = HttpApiBuilder.group(Api, 'music', (handlers) =
             .getLabelBySlug(params.slug)
             .pipe(Effect.catchTag('NotFoundError', () => new HttpApiError.NotFound()))
         )
-        return toLabelResponse(row)
+        const [artists, albums] = yield* dieOnDatabaseError(
+          Effect.all([
+            svc.getPublishedArtistsForLabel(row.id),
+            svc.getPublishedAlbumsForLabel(row.id)
+          ])
+        )
+        return {
+          ...toLabelResponse(row),
+          affiliatedArtists: artists.map(toArtistResponse),
+          affiliatedAlbums: albums.map(toAlbumResponse)
+        }
       })
     )
     .handle('getLabel', ({ params }) =>
@@ -576,6 +602,58 @@ export const MusicHandlersLive = HttpApiBuilder.group(Api, 'music', (handlers) =
             .deleteLabel(params.id)
             .pipe(Effect.catchTag('NotFoundError', () => new HttpApiError.NotFound()))
         )
+      })
+    )
+    .handle('listLabelArtists', ({ params }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        const rows = yield* dieOnDatabaseError(svc.getArtistsForLabel(params.labelId))
+        return rows.map(toArtistResponse)
+      })
+    )
+    .handle('listLabelAlbums', ({ params }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        const rows = yield* dieOnDatabaseError(svc.getAlbumsForLabel(params.labelId))
+        return rows.map(toAlbumResponse)
+      })
+    )
+    .handle('affiliateArtistWithLabel', ({ params }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        yield* dieOnDatabaseError(
+          svc
+            .affiliateArtistWithLabel(params.labelId, params.artistId)
+            .pipe(Effect.catchTag('NotFoundError', () => new HttpApiError.NotFound()))
+        )
+      })
+    )
+    .handle('unaffiliateArtistFromLabel', ({ params }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        yield* dieOnDatabaseError(svc.unaffiliateArtistFromLabel(params.labelId, params.artistId))
+      })
+    )
+    .handle('affiliateAlbumWithLabel', ({ params }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        yield* dieOnDatabaseError(
+          svc
+            .affiliateAlbumWithLabel(params.labelId, params.albumId)
+            .pipe(Effect.catchTag('NotFoundError', () => new HttpApiError.NotFound()))
+        )
+      })
+    )
+    .handle('unaffiliateAlbumFromLabel', ({ params }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin
+        const svc = yield* MusicEntityService
+        yield* dieOnDatabaseError(svc.unaffiliateAlbumFromLabel(params.labelId, params.albumId))
       })
     )
     // -----------------------------------------------------------------

--- a/apps/vps/src/http/routes.blackbox.test.ts
+++ b/apps/vps/src/http/routes.blackbox.test.ts
@@ -3,6 +3,7 @@ import {
   AlbumListResponse,
   ArtistListResponse,
   LabelListResponse,
+  LabelResponse,
   PlaylistListResponse,
   TrackListResponse
 } from '@gbfm/api/music'
@@ -13,7 +14,14 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { db } from '@/db'
 import { audioTable } from '@/db/audio.schema'
 import { session, user } from '@/db/auth.schema'
-import { musicLabelCreatorsTable, musicLabelsTable } from '@/db/music-entity.schema'
+import {
+  musicAlbumsTable,
+  musicArtistsTable,
+  musicLabelAlbumsTable,
+  musicLabelArtistsTable,
+  musicLabelCreatorsTable,
+  musicLabelsTable
+} from '@/db/music-entity.schema'
 import { postCreators, postsTable } from '@/db/post.schema'
 import { releasesTable } from '@/db/release.schema'
 import { showsTable } from '@/db/show.schema'
@@ -178,6 +186,22 @@ describe('music artists (HttpApiBuilder group, Step 4)', () => {
 
     expect(res.status).toBe(401)
   })
+
+  it('requires authentication to read and change label affiliations', async () => {
+    const id = '00000000-0000-0000-0000-000000000000'
+    const requests = [
+      new Request(`http://localhost/api/music/labels/${id}/artists`),
+      new Request(`http://localhost/api/music/labels/${id}/albums`),
+      new Request(`http://localhost/api/music/artists/${id}/labels`),
+      new Request(`http://localhost/api/music/albums/${id}/labels`),
+      new Request(`http://localhost/api/music/labels/${id}/artists/${id}`, { method: 'PUT' }),
+      new Request(`http://localhost/api/music/labels/${id}/albums/${id}`, { method: 'PUT' })
+    ]
+
+    const responses = await Promise.all(requests.map((request) => webHandler.handler(request)))
+
+    expect(responses.map((response) => response.status)).toEqual([401, 401, 401, 401, 401, 401])
+  })
 })
 
 describe('music labels', () => {
@@ -200,6 +224,137 @@ describe('music labels', () => {
     const res = await webHandler.handler(new Request('http://localhost/api/music/labels/manage'))
 
     expect(res.status).toBe(401)
+  })
+
+  it('manages factual affiliations reciprocally while publishing only visible entities', async () => {
+    const suffix = crypto.randomUUID()
+    const adminId = `affiliation-admin-${suffix}`
+    const adminToken = `affiliation-admin-token-${suffix}`
+    const now = new Date()
+    const future = new Date(now.getTime() + 86_400_000)
+
+    await db.insert(user).values({
+      id: adminId,
+      name: 'Affiliation admin',
+      email: `${adminId}@example.com`,
+      role: 'admin'
+    })
+    await db.insert(session).values({
+      id: crypto.randomUUID(),
+      token: adminToken,
+      userId: adminId,
+      expiresAt: new Date(now.getTime() + 60_000)
+    })
+    const [label] = await db
+      .insert(musicLabelsTable)
+      .values({
+        name: 'Affiliation label',
+        slug: `affiliation-label-${suffix}`,
+        content: '',
+        publishedAt: now
+      })
+      .returning()
+    const [publishedArtist, draftArtist] = await db
+      .insert(musicArtistsTable)
+      .values([
+        { name: 'Alpha Artist', slug: `alpha-artist-${suffix}`, publishedAt: now },
+        { name: 'Draft Artist', slug: `draft-artist-${suffix}` }
+      ])
+      .returning()
+    const [publishedAlbum, futureAlbum] = await db
+      .insert(musicAlbumsTable)
+      .values([
+        {
+          title: 'Published Album',
+          slug: `published-album-${suffix}`,
+          releaseDate: now,
+          publishedAt: now
+        },
+        {
+          title: 'Future Album',
+          slug: `future-album-${suffix}`,
+          releaseDate: future,
+          publishedAt: future
+        }
+      ])
+      .returning()
+    if (!label || !publishedArtist || !draftArtist || !publishedAlbum || !futureAlbum) {
+      throw new Error('Failed to seed label affiliation test')
+    }
+
+    const adminRequest = (path: string, method = 'GET') =>
+      new Request(`http://localhost${path}`, {
+        method,
+        headers: { authorization: `Bearer ${adminToken}` }
+      })
+
+    const publishedArtistPath = `/api/music/labels/${label.id}/artists/${publishedArtist.id}`
+    const draftArtistPath = `/api/music/labels/${label.id}/artists/${draftArtist.id}`
+    const publishedAlbumPath = `/api/music/labels/${label.id}/albums/${publishedAlbum.id}`
+    const futureAlbumPath = `/api/music/labels/${label.id}/albums/${futureAlbum.id}`
+
+    try {
+      const writes = await Promise.all(
+        [
+          publishedArtistPath,
+          draftArtistPath,
+          publishedAlbumPath,
+          futureAlbumPath,
+          publishedArtistPath,
+          publishedAlbumPath
+        ].map((path) => webHandler.handler(adminRequest(path, 'PUT')))
+      )
+      expect(writes.map((response) => response.status)).toEqual([204, 204, 204, 204, 204, 204])
+
+      const [labelArtists, labelAlbums, artistLabels, albumLabels, publicLabel] = await Promise.all(
+        [
+          webHandler.handler(adminRequest(`/api/music/labels/${label.id}/artists`)),
+          webHandler.handler(adminRequest(`/api/music/labels/${label.id}/albums`)),
+          webHandler.handler(adminRequest(`/api/music/artists/${publishedArtist.id}/labels`)),
+          webHandler.handler(adminRequest(`/api/music/albums/${publishedAlbum.id}/labels`)),
+          webHandler.handler(new Request(`http://localhost/api/music/labels/slug/${label.slug}`))
+        ]
+      )
+
+      expect(labelArtists.status).toBe(200)
+      expect(labelAlbums.status).toBe(200)
+      expect(artistLabels.status).toBe(200)
+      expect(albumLabels.status).toBe(200)
+      const labelArtistsBody = await decodeResponseBody(ArtistListResponse, labelArtists)
+      const labelAlbumsBody = await decodeResponseBody(AlbumListResponse, labelAlbums)
+      const artistLabelsBody = await decodeResponseBody(LabelListResponse, artistLabels)
+      const albumLabelsBody = await decodeResponseBody(LabelListResponse, albumLabels)
+      expect(labelArtistsBody.map((artist) => artist.name)).toEqual([
+        'Alpha Artist',
+        'Draft Artist'
+      ])
+      expect(labelAlbumsBody.map((album) => album.title)).toEqual([
+        'Future Album',
+        'Published Album'
+      ])
+      expect(artistLabelsBody.map((row) => row.id)).toEqual([label.id])
+      expect(albumLabelsBody.map((row) => row.id)).toEqual([label.id])
+
+      const publicBody = await decodeResponseBody(LabelResponse, publicLabel)
+      expect(publicBody.affiliatedArtists?.map((artist) => artist.id)).toEqual([publishedArtist.id])
+      expect(publicBody.affiliatedAlbums?.map((album) => album.id)).toEqual([publishedAlbum.id])
+
+      const removed = await webHandler.handler(adminRequest(publishedArtistPath, 'DELETE'))
+      const afterRemove = await webHandler.handler(
+        adminRequest(`/api/music/artists/${publishedArtist.id}/labels`)
+      )
+      expect(removed.status).toBe(204)
+      await expect(decodeResponseBody(LabelListResponse, afterRemove)).resolves.toEqual([])
+    } finally {
+      await db.delete(musicLabelArtistsTable).where(eq(musicLabelArtistsTable.labelId, label.id))
+      await db.delete(musicLabelAlbumsTable).where(eq(musicLabelAlbumsTable.labelId, label.id))
+      await db.delete(musicAlbumsTable).where(eq(musicAlbumsTable.id, publishedAlbum.id))
+      await db.delete(musicAlbumsTable).where(eq(musicAlbumsTable.id, futureAlbum.id))
+      await db.delete(musicArtistsTable).where(eq(musicArtistsTable.id, publishedArtist.id))
+      await db.delete(musicArtistsTable).where(eq(musicArtistsTable.id, draftArtist.id))
+      await db.delete(musicLabelsTable).where(eq(musicLabelsTable.id, label.id))
+      await db.delete(user).where(eq(user.id, adminId))
+    }
   })
 })
 

--- a/apps/vps/src/services/music-entity/index.ts
+++ b/apps/vps/src/services/music-entity/index.ts
@@ -16,6 +16,18 @@ import type { DatabaseError, NotFoundError, SpotifyError } from '@/errors'
 import { ConfigService as ConfigServiceTag } from '@/services/config.service'
 import { DatabaseService } from '@/services/database.service'
 import {
+  affiliateAlbumWithLabelEffect,
+  affiliateArtistWithLabelEffect,
+  getAlbumsForLabelEffect,
+  getArtistsForLabelEffect,
+  getLabelsForAlbumEffect,
+  getLabelsForArtistEffect,
+  getPublishedAlbumsForLabelEffect,
+  getPublishedArtistsForLabelEffect,
+  unaffiliateAlbumFromLabelEffect,
+  unaffiliateArtistFromLabelEffect
+} from './label-affiliation.service'
+import {
   type CreateLabelInput,
   createLabelEffect,
   deleteLabelEffect,
@@ -164,6 +176,37 @@ export interface MusicEntityService {
   ) => Effect.Effect<SelectMusicLabel, DatabaseError | NotFoundError>
   readonly deleteLabel: (id: string) => Effect.Effect<void, DatabaseError | NotFoundError>
 
+  readonly getArtistsForLabel: (
+    labelId: string
+  ) => Effect.Effect<SelectMusicArtist[], DatabaseError>
+  readonly getPublishedArtistsForLabel: (
+    labelId: string
+  ) => Effect.Effect<SelectMusicArtist[], DatabaseError>
+  readonly getAlbumsForLabel: (labelId: string) => Effect.Effect<SelectMusicAlbum[], DatabaseError>
+  readonly getPublishedAlbumsForLabel: (
+    labelId: string
+  ) => Effect.Effect<SelectMusicAlbum[], DatabaseError>
+  readonly getLabelsForArtist: (
+    artistId: string
+  ) => Effect.Effect<SelectMusicLabel[], DatabaseError>
+  readonly getLabelsForAlbum: (albumId: string) => Effect.Effect<SelectMusicLabel[], DatabaseError>
+  readonly affiliateArtistWithLabel: (
+    labelId: string,
+    artistId: string
+  ) => Effect.Effect<void, DatabaseError | NotFoundError>
+  readonly unaffiliateArtistFromLabel: (
+    labelId: string,
+    artistId: string
+  ) => Effect.Effect<void, DatabaseError>
+  readonly affiliateAlbumWithLabel: (
+    labelId: string,
+    albumId: string
+  ) => Effect.Effect<void, DatabaseError | NotFoundError>
+  readonly unaffiliateAlbumFromLabel: (
+    labelId: string,
+    albumId: string
+  ) => Effect.Effect<void, DatabaseError>
+
   readonly getPlaylistTracks: (playlistId: string) => Effect.Effect<
     Array<{
       track: SelectMusicTrack
@@ -308,6 +351,17 @@ export const MusicEntityServiceLive = Layer.effect(
       getLabelBySlug: getLabelBySlugEffect(db),
       updateLabel: updateLabelEffect(db),
       deleteLabel: deleteLabelEffect(db),
+
+      getArtistsForLabel: getArtistsForLabelEffect(db),
+      getPublishedArtistsForLabel: getPublishedArtistsForLabelEffect(db),
+      getAlbumsForLabel: getAlbumsForLabelEffect(db),
+      getPublishedAlbumsForLabel: getPublishedAlbumsForLabelEffect(db),
+      getLabelsForArtist: getLabelsForArtistEffect(db),
+      getLabelsForAlbum: getLabelsForAlbumEffect(db),
+      affiliateArtistWithLabel: affiliateArtistWithLabelEffect(db),
+      unaffiliateArtistFromLabel: unaffiliateArtistFromLabelEffect(db),
+      affiliateAlbumWithLabel: affiliateAlbumWithLabelEffect(db),
+      unaffiliateAlbumFromLabel: unaffiliateAlbumFromLabelEffect(db),
 
       getPlaylistTracks: getPlaylistTracksEffect(db),
       addTrackToPlaylist: addTrackToPlaylistEffect(db),

--- a/apps/vps/src/services/music-entity/label-affiliation.service.ts
+++ b/apps/vps/src/services/music-entity/label-affiliation.service.ts
@@ -1,0 +1,276 @@
+import { and, asc, eq, lte, sql } from 'drizzle-orm'
+import { Effect } from 'effect'
+import type { db as DbType } from '@/db'
+import {
+  musicAlbumsTable,
+  musicArtistsTable,
+  musicLabelAlbumsTable,
+  musicLabelArtistsTable,
+  musicLabelsTable
+} from '@/db/music-entity.schema'
+import { DatabaseError, getErrorMessage } from '@/errors'
+import { requireOne } from './shared'
+
+const findRequiredEntity = (
+  db: typeof DbType,
+  entity: 'MusicLabel' | 'MusicArtist' | 'MusicAlbum',
+  id: string
+) => {
+  const table =
+    entity === 'MusicLabel'
+      ? musicLabelsTable
+      : entity === 'MusicArtist'
+        ? musicArtistsTable
+        : musicAlbumsTable
+  const tableName =
+    entity === 'MusicLabel'
+      ? 'music_labels'
+      : entity === 'MusicArtist'
+        ? 'music_artists'
+        : 'music_albums'
+
+  return Effect.gen(function* () {
+    const rows = yield* Effect.tryPromise({
+      try: () => db.select({ id: table.id }).from(table).where(eq(table.id, id)).limit(1),
+      catch: (cause) =>
+        new DatabaseError({
+          message: `Failed to find affiliation entity: ${getErrorMessage(cause)}`,
+          operation: 'select',
+          table: tableName
+        })
+    })
+    return yield* requireOne(rows, entity, id)
+  })
+}
+
+/** Lists all artists affiliated with a label for administrative management. */
+export const getArtistsForLabelEffect = (db: typeof DbType) => (labelId: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const rows = await db
+        .select({ artist: musicArtistsTable })
+        .from(musicLabelArtistsTable)
+        .innerJoin(musicArtistsTable, eq(musicLabelArtistsTable.artistId, musicArtistsTable.id))
+        .where(eq(musicLabelArtistsTable.labelId, labelId))
+        .orderBy(asc(musicArtistsTable.name))
+      return rows.map(({ artist }) => artist)
+    },
+    catch: (cause) =>
+      new DatabaseError({
+        message: `Failed to list label artists: ${getErrorMessage(cause)}`,
+        operation: 'select',
+        table: 'music_label_artists'
+      })
+  }).pipe(Effect.withSpan('musicEntity.getArtistsForLabel', { attributes: { labelId } }))
+
+/** Lists published artists affiliated with a label for public rendering. */
+export const getPublishedArtistsForLabelEffect = (db: typeof DbType) => (labelId: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const rows = await db
+        .select({ artist: musicArtistsTable })
+        .from(musicLabelArtistsTable)
+        .innerJoin(musicArtistsTable, eq(musicLabelArtistsTable.artistId, musicArtistsTable.id))
+        .where(
+          and(
+            eq(musicLabelArtistsTable.labelId, labelId),
+            lte(musicArtistsTable.publishedAt, new Date())
+          )
+        )
+        .orderBy(asc(musicArtistsTable.name))
+      return rows.map(({ artist }) => artist)
+    },
+    catch: (cause) =>
+      new DatabaseError({
+        message: `Failed to list published label artists: ${getErrorMessage(cause)}`,
+        operation: 'select',
+        table: 'music_label_artists'
+      })
+  }).pipe(Effect.withSpan('musicEntity.getPublishedArtistsForLabel', { attributes: { labelId } }))
+
+/** Lists all albums affiliated with a label for administrative management. */
+export const getAlbumsForLabelEffect = (db: typeof DbType) => (labelId: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const rows = await db
+        .select({ album: musicAlbumsTable })
+        .from(musicLabelAlbumsTable)
+        .innerJoin(musicAlbumsTable, eq(musicLabelAlbumsTable.albumId, musicAlbumsTable.id))
+        .where(eq(musicLabelAlbumsTable.labelId, labelId))
+        .orderBy(sql`${musicAlbumsTable.releaseDate} DESC NULLS LAST`, asc(musicAlbumsTable.title))
+      return rows.map(({ album }) => album)
+    },
+    catch: (cause) =>
+      new DatabaseError({
+        message: `Failed to list label albums: ${getErrorMessage(cause)}`,
+        operation: 'select',
+        table: 'music_label_albums'
+      })
+  }).pipe(Effect.withSpan('musicEntity.getAlbumsForLabel', { attributes: { labelId } }))
+
+/** Lists published albums affiliated with a label for public rendering. */
+export const getPublishedAlbumsForLabelEffect = (db: typeof DbType) => (labelId: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const rows = await db
+        .select({ album: musicAlbumsTable })
+        .from(musicLabelAlbumsTable)
+        .innerJoin(musicAlbumsTable, eq(musicLabelAlbumsTable.albumId, musicAlbumsTable.id))
+        .where(
+          and(
+            eq(musicLabelAlbumsTable.labelId, labelId),
+            lte(musicAlbumsTable.publishedAt, new Date())
+          )
+        )
+        .orderBy(sql`${musicAlbumsTable.releaseDate} DESC NULLS LAST`, asc(musicAlbumsTable.title))
+      return rows.map(({ album }) => album)
+    },
+    catch: (cause) =>
+      new DatabaseError({
+        message: `Failed to list published label albums: ${getErrorMessage(cause)}`,
+        operation: 'select',
+        table: 'music_label_albums'
+      })
+  }).pipe(Effect.withSpan('musicEntity.getPublishedAlbumsForLabel', { attributes: { labelId } }))
+
+/** Lists every label affiliated with an artist. */
+export const getLabelsForArtistEffect = (db: typeof DbType) => (artistId: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const rows = await db
+        .select({ label: musicLabelsTable })
+        .from(musicLabelArtistsTable)
+        .innerJoin(musicLabelsTable, eq(musicLabelArtistsTable.labelId, musicLabelsTable.id))
+        .where(eq(musicLabelArtistsTable.artistId, artistId))
+        .orderBy(asc(musicLabelsTable.name))
+      return rows.map(({ label }) => label)
+    },
+    catch: (cause) =>
+      new DatabaseError({
+        message: `Failed to list artist labels: ${getErrorMessage(cause)}`,
+        operation: 'select',
+        table: 'music_label_artists'
+      })
+  }).pipe(Effect.withSpan('musicEntity.getLabelsForArtist', { attributes: { artistId } }))
+
+/** Lists every label affiliated with an album. */
+export const getLabelsForAlbumEffect = (db: typeof DbType) => (albumId: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const rows = await db
+        .select({ label: musicLabelsTable })
+        .from(musicLabelAlbumsTable)
+        .innerJoin(musicLabelsTable, eq(musicLabelAlbumsTable.labelId, musicLabelsTable.id))
+        .where(eq(musicLabelAlbumsTable.albumId, albumId))
+        .orderBy(asc(musicLabelsTable.name))
+      return rows.map(({ label }) => label)
+    },
+    catch: (cause) =>
+      new DatabaseError({
+        message: `Failed to list album labels: ${getErrorMessage(cause)}`,
+        operation: 'select',
+        table: 'music_label_albums'
+      })
+  }).pipe(Effect.withSpan('musicEntity.getLabelsForAlbum', { attributes: { albumId } }))
+
+/** Creates an idempotent factual affiliation between a label and an artist. */
+export const affiliateArtistWithLabelEffect =
+  (db: typeof DbType) => (labelId: string, artistId: string) =>
+    Effect.gen(function* () {
+      yield* Effect.all([
+        findRequiredEntity(db, 'MusicLabel', labelId),
+        findRequiredEntity(db, 'MusicArtist', artistId)
+      ])
+      yield* Effect.tryPromise({
+        try: () =>
+          db.insert(musicLabelArtistsTable).values({ labelId, artistId }).onConflictDoNothing(),
+        catch: (cause) =>
+          new DatabaseError({
+            message: `Failed to affiliate artist with label: ${getErrorMessage(cause)}`,
+            operation: 'insert',
+            table: 'music_label_artists'
+          })
+      })
+    }).pipe(
+      Effect.asVoid,
+      Effect.withSpan('musicEntity.affiliateArtistWithLabel', {
+        attributes: { labelId, artistId }
+      })
+    )
+
+/** Removes a factual affiliation between a label and an artist. */
+export const unaffiliateArtistFromLabelEffect =
+  (db: typeof DbType) => (labelId: string, artistId: string) =>
+    Effect.tryPromise({
+      try: () =>
+        db
+          .delete(musicLabelArtistsTable)
+          .where(
+            and(
+              eq(musicLabelArtistsTable.labelId, labelId),
+              eq(musicLabelArtistsTable.artistId, artistId)
+            )
+          ),
+      catch: (cause) =>
+        new DatabaseError({
+          message: `Failed to remove artist label affiliation: ${getErrorMessage(cause)}`,
+          operation: 'delete',
+          table: 'music_label_artists'
+        })
+    }).pipe(
+      Effect.asVoid,
+      Effect.withSpan('musicEntity.unaffiliateArtistFromLabel', {
+        attributes: { labelId, artistId }
+      })
+    )
+
+/** Creates an idempotent factual affiliation between a label and an album. */
+export const affiliateAlbumWithLabelEffect =
+  (db: typeof DbType) => (labelId: string, albumId: string) =>
+    Effect.gen(function* () {
+      yield* Effect.all([
+        findRequiredEntity(db, 'MusicLabel', labelId),
+        findRequiredEntity(db, 'MusicAlbum', albumId)
+      ])
+      yield* Effect.tryPromise({
+        try: () =>
+          db.insert(musicLabelAlbumsTable).values({ labelId, albumId }).onConflictDoNothing(),
+        catch: (cause) =>
+          new DatabaseError({
+            message: `Failed to affiliate album with label: ${getErrorMessage(cause)}`,
+            operation: 'insert',
+            table: 'music_label_albums'
+          })
+      })
+    }).pipe(
+      Effect.asVoid,
+      Effect.withSpan('musicEntity.affiliateAlbumWithLabel', {
+        attributes: { labelId, albumId }
+      })
+    )
+
+/** Removes a factual affiliation between a label and an album. */
+export const unaffiliateAlbumFromLabelEffect =
+  (db: typeof DbType) => (labelId: string, albumId: string) =>
+    Effect.tryPromise({
+      try: () =>
+        db
+          .delete(musicLabelAlbumsTable)
+          .where(
+            and(
+              eq(musicLabelAlbumsTable.labelId, labelId),
+              eq(musicLabelAlbumsTable.albumId, albumId)
+            )
+          ),
+      catch: (cause) =>
+        new DatabaseError({
+          message: `Failed to remove album label affiliation: ${getErrorMessage(cause)}`,
+          operation: 'delete',
+          table: 'music_label_albums'
+        })
+    }).pipe(
+      Effect.asVoid,
+      Effect.withSpan('musicEntity.unaffiliateAlbumFromLabel', {
+        attributes: { labelId, albumId }
+      })
+    )

--- a/apps/www/src/lib/http.ts
+++ b/apps/www/src/lib/http.ts
@@ -1661,13 +1661,39 @@ export interface MusicLabel {
   updatedAt: string
   compiledContent?: string
   creators?: Array<{ id: string; name: string }>
+  affiliatedArtists?: MusicArtist[]
+  affiliatedAlbums?: MusicAlbum[]
 }
+
+type MusicArtistInput = Omit<MusicArtist, 'genres'> & {
+  readonly genres: ReadonlyArray<string> | null
+}
+
+type MusicAlbumInput = Omit<MusicAlbum, 'artistNames' | 'genres'> & {
+  readonly artistNames: ReadonlyArray<string> | null
+  readonly genres: ReadonlyArray<string> | null
+}
+
+const mapMusicArtist = (artist: MusicArtistInput): MusicArtist => ({
+  ...artist,
+  genres: artist.genres ? [...artist.genres] : null
+})
+
+const mapMusicAlbum = (album: MusicAlbumInput): MusicAlbum => ({
+  ...album,
+  artistNames: album.artistNames ? [...album.artistNames] : null,
+  genres: album.genres ? [...album.genres] : null
+})
 
 const mapMusicLabel = (label: LabelResponse): MusicLabel => ({
   ...label,
   tags: label.tags ? [...label.tags] : null,
   genres: label.genres ? [...label.genres] : null,
-  creators: label.creators ? [...label.creators] : undefined
+  creators: label.creators ? [...label.creators] : undefined,
+  affiliatedArtists: label.affiliatedArtists
+    ? label.affiliatedArtists.map(mapMusicArtist)
+    : undefined,
+  affiliatedAlbums: label.affiliatedAlbums ? label.affiliatedAlbums.map(mapMusicAlbum) : undefined
 })
 
 export function useLabels() {
@@ -1774,6 +1800,7 @@ export function useDeleteAdminLabel() {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['admin', 'labels'] })
+      qc.invalidateQueries({ queryKey: ['admin', 'affiliations'] })
       qc.invalidateQueries({ queryKey: ['labels'] })
     }
   })
@@ -1806,7 +1833,7 @@ export function useAdminArtists() {
             Effect.tapError((error) => captureException(error, { endpoint: 'music.listArtists' }))
           )
       )
-      return artists.map((a) => ({ ...a, genres: a.genres ? [...a.genres] : null }))
+      return artists.map(mapMusicArtist)
     }
   })
 }
@@ -1823,7 +1850,7 @@ export function useAdminArtist(id: string) {
             Effect.tapError((error) => captureException(error, { endpoint: 'music.getArtist' }))
           )
       )
-      return { ...artist, genres: artist.genres ? [...artist.genres] : null }
+      return mapMusicArtist(artist)
     },
     enabled: Boolean(id)
   })
@@ -1841,7 +1868,7 @@ export function useUpdateAdminArtist() {
             Effect.tapError((error) => captureException(error, { endpoint: 'music.updateArtist' }))
           )
       )
-      return { ...artist, genres: artist.genres ? [...artist.genres] : null }
+      return mapMusicArtist(artist)
     },
     onSuccess: (_, { id }) => {
       qc.invalidateQueries({ queryKey: ['admin', 'artists', id] })
@@ -1863,7 +1890,10 @@ export function useDeleteAdminArtist() {
           )
       )
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['admin', 'artists'] })
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['admin', 'artists'] })
+      qc.invalidateQueries({ queryKey: ['admin', 'affiliations'] })
+    }
   })
 }
 
@@ -1901,7 +1931,118 @@ export function useDeleteAdminAlbum() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (id: string) => fetcher(apiUrl(`/music/albums/${id}`), { method: 'DELETE' }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['admin', 'albums'] })
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['admin', 'albums'] })
+      qc.invalidateQueries({ queryKey: ['admin', 'affiliations'] })
+    }
+  })
+}
+
+const affiliationQueryKey = (
+  entityType: 'label' | 'artist' | 'album',
+  id: string,
+  target: string
+) => ['admin', 'affiliations', entityType, id, target] as const
+
+export function useLabelArtists(labelId: string) {
+  return useQuery<MusicArtist[]>({
+    queryKey: affiliationQueryKey('label', labelId, 'artists'),
+    queryFn: async () =>
+      (await fetcher<MusicArtist[]>(apiUrl(`/music/labels/${labelId}/artists`))).map(
+        mapMusicArtist
+      ),
+    enabled: Boolean(labelId)
+  })
+}
+
+export function useLabelAlbums(labelId: string) {
+  return useQuery<MusicAlbum[]>({
+    queryKey: affiliationQueryKey('label', labelId, 'albums'),
+    queryFn: async () =>
+      (await fetcher<MusicAlbum[]>(apiUrl(`/music/labels/${labelId}/albums`))).map(mapMusicAlbum),
+    enabled: Boolean(labelId)
+  })
+}
+
+export function useArtistLabels(artistId: string) {
+  return useQuery<MusicLabel[]>({
+    queryKey: affiliationQueryKey('artist', artistId, 'labels'),
+    queryFn: async () =>
+      (await fetcher<LabelResponse[]>(apiUrl(`/music/artists/${artistId}/labels`))).map(
+        mapMusicLabel
+      ),
+    enabled: Boolean(artistId)
+  })
+}
+
+export function useAlbumLabels(albumId: string) {
+  return useQuery<MusicLabel[]>({
+    queryKey: affiliationQueryKey('album', albumId, 'labels'),
+    queryFn: async () =>
+      (await fetcher<LabelResponse[]>(apiUrl(`/music/albums/${albumId}/labels`))).map(
+        mapMusicLabel
+      ),
+    enabled: Boolean(albumId)
+  })
+}
+
+const invalidateArtistAffiliations = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  labelId: string,
+  artistId: string
+) => {
+  queryClient.invalidateQueries({ queryKey: affiliationQueryKey('label', labelId, 'artists') })
+  queryClient.invalidateQueries({ queryKey: affiliationQueryKey('artist', artistId, 'labels') })
+  queryClient.invalidateQueries({ queryKey: ['label'] })
+}
+
+const invalidateAlbumAffiliations = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  labelId: string,
+  albumId: string
+) => {
+  queryClient.invalidateQueries({ queryKey: affiliationQueryKey('label', labelId, 'albums') })
+  queryClient.invalidateQueries({ queryKey: affiliationQueryKey('album', albumId, 'labels') })
+  queryClient.invalidateQueries({ queryKey: ['label'] })
+}
+
+export function useAffiliateArtistWithLabel() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ labelId, artistId }: { labelId: string; artistId: string }) =>
+      fetcher(apiUrl(`/music/labels/${labelId}/artists/${artistId}`), { method: 'PUT' }),
+    onSuccess: (_, { labelId, artistId }) =>
+      invalidateArtistAffiliations(queryClient, labelId, artistId)
+  })
+}
+
+export function useUnaffiliateArtistFromLabel() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ labelId, artistId }: { labelId: string; artistId: string }) =>
+      fetcher(apiUrl(`/music/labels/${labelId}/artists/${artistId}`), { method: 'DELETE' }),
+    onSuccess: (_, { labelId, artistId }) =>
+      invalidateArtistAffiliations(queryClient, labelId, artistId)
+  })
+}
+
+export function useAffiliateAlbumWithLabel() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ labelId, albumId }: { labelId: string; albumId: string }) =>
+      fetcher(apiUrl(`/music/labels/${labelId}/albums/${albumId}`), { method: 'PUT' }),
+    onSuccess: (_, { labelId, albumId }) =>
+      invalidateAlbumAffiliations(queryClient, labelId, albumId)
+  })
+}
+
+export function useUnaffiliateAlbumFromLabel() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ labelId, albumId }: { labelId: string; albumId: string }) =>
+      fetcher(apiUrl(`/music/labels/${labelId}/albums/${albumId}`), { method: 'DELETE' }),
+    onSuccess: (_, { labelId, albumId }) =>
+      invalidateAlbumAffiliations(queryClient, labelId, albumId)
   })
 }
 

--- a/apps/www/src/routes/admin/_components/-AffiliationPanel.tsx
+++ b/apps/www/src/routes/admin/_components/-AffiliationPanel.tsx
@@ -1,0 +1,152 @@
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle, Input } from '@gbfm/ui'
+import { Plus, X } from 'lucide-react'
+import { useId, useMemo, useState } from 'react'
+
+export interface AffiliationOption {
+  readonly id: string
+  readonly name: string
+  readonly publishedAt: string | null
+  readonly detail?: string
+}
+
+interface Props {
+  readonly title: string
+  readonly description: string
+  readonly items: readonly AffiliationOption[]
+  readonly candidates: readonly AffiliationOption[]
+  readonly isLoading: boolean
+  readonly error: Error | null
+  readonly isMutating: boolean
+  readonly onAdd: (id: string) => Promise<void>
+  readonly onRemove: (id: string) => Promise<void>
+}
+
+export function AffiliationPanel({
+  title,
+  description,
+  items,
+  candidates,
+  isLoading,
+  error,
+  isMutating,
+  onAdd,
+  onRemove
+}: Props) {
+  const searchId = useId()
+  const [search, setSearch] = useState('')
+  const [mutationError, setMutationError] = useState<string | null>(null)
+  const itemIds = useMemo(() => new Set(items.map(({ id }) => id)), [items])
+  const available = useMemo(() => {
+    const query = search.trim().toLocaleLowerCase()
+    return candidates
+      .filter(({ id }) => !itemIds.has(id))
+      .filter(
+        ({ name, detail }) =>
+          query.length === 0 ||
+          name.toLocaleLowerCase().includes(query) ||
+          detail?.toLocaleLowerCase().includes(query)
+      )
+      .slice(0, 8)
+  }, [candidates, itemIds, search])
+
+  const runMutation = async (mutation: () => Promise<void>, clearSearch = false) => {
+    setMutationError(null)
+    try {
+      await mutation()
+      if (clearSearch) setSearch('')
+    } catch (cause: unknown) {
+      setMutationError(
+        cause instanceof Error ? cause.message : 'The affiliation could not be saved.'
+      )
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className='space-y-1'>
+        <CardTitle className='text-sm font-medium'>{title}</CardTitle>
+        <p className='text-sm text-muted-foreground'>{description}</p>
+      </CardHeader>
+      <CardContent className='space-y-5'>
+        {error && (
+          <p role='alert' className='text-sm text-destructive'>
+            Could not load affiliations: {error.message}
+          </p>
+        )}
+        {mutationError && (
+          <p role='alert' className='text-sm text-destructive'>
+            {mutationError}
+          </p>
+        )}
+        {isLoading ? (
+          <p className='text-sm text-muted-foreground'>Loading affiliations…</p>
+        ) : items.length === 0 ? (
+          <p className='text-sm text-muted-foreground'>No affiliations yet.</p>
+        ) : (
+          <ul className='space-y-2' aria-label={`Current ${title.toLocaleLowerCase()}`}>
+            {items.map((item) => (
+              <li key={item.id} className='flex items-center gap-3 rounded-md border px-3 py-2'>
+                <div className='min-w-0 flex-1'>
+                  <p className='truncate text-sm font-medium'>{item.name}</p>
+                  {item.detail && (
+                    <p className='truncate text-xs text-muted-foreground'>{item.detail}</p>
+                  )}
+                </div>
+                <Badge variant={item.publishedAt ? 'default' : 'secondary'}>
+                  {item.publishedAt ? 'Published' : 'Draft'}
+                </Badge>
+                <Button
+                  type='button'
+                  size='icon'
+                  variant='ghost'
+                  aria-label={`Remove ${item.name}`}
+                  disabled={isMutating}
+                  onClick={() => void runMutation(() => onRemove(item.id))}>
+                  <X className='h-4 w-4' />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className='space-y-2'>
+          <label htmlFor={searchId} className='text-sm font-medium'>
+            Add {title.toLocaleLowerCase()}
+          </label>
+          <Input
+            id={searchId}
+            type='search'
+            placeholder={`Search ${title.toLocaleLowerCase()}…`}
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+          <ul className='max-h-64 space-y-1 overflow-y-auto' aria-label={`Available ${title}`}>
+            {available.map((option) => (
+              <li key={option.id}>
+                <Button
+                  type='button'
+                  variant='ghost'
+                  className='h-auto w-full justify-start gap-3 px-3 py-2 text-left'
+                  disabled={isMutating}
+                  onClick={() => void runMutation(() => onAdd(option.id), true)}>
+                  <Plus className='h-4 w-4 shrink-0' />
+                  <span className='min-w-0'>
+                    <span className='block truncate text-sm font-medium'>{option.name}</span>
+                    {option.detail && (
+                      <span className='block truncate text-xs text-muted-foreground'>
+                        {option.detail}
+                      </span>
+                    )}
+                  </span>
+                </Button>
+              </li>
+            ))}
+          </ul>
+          {!isLoading && available.length === 0 && (
+            <p className='text-xs text-muted-foreground'>No matching entities available.</p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/www/src/routes/admin/_components/-MusicEntityDetailPage.tsx
+++ b/apps/www/src/routes/admin/_components/-MusicEntityDetailPage.tsx
@@ -21,23 +21,35 @@ import {
   useAddArtistToAlbum,
   useAddArtistToTrack,
   useAdminAlbum,
+  useAdminAlbums,
   useAdminArtist,
+  useAdminArtists,
   useAdminLabel,
+  useAdminLabels,
   useAdminEntityLinks,
   useAdminTrack,
+  useAffiliateAlbumWithLabel,
+  useAffiliateArtistWithLabel,
+  useAlbumLabels,
+  useArtistLabels,
   useDeleteAdminAlbum,
   useDeleteAdminArtist,
   useDeleteAdminLabel,
   useDeleteAdminEntityLink,
   useDeleteAdminTrack,
+  useLabelAlbums,
+  useLabelArtists,
   useRemoveArtistFromAlbum,
   useRemoveArtistFromTrack,
+  useUnaffiliateAlbumFromLabel,
+  useUnaffiliateArtistFromLabel,
   useUpdateAdminAlbum,
   useUpdateAdminArtist,
   useUpdateAdminLabel,
   useUpdateAdminEntityLinkStatus,
   useUpdateAdminTrack
 } from '@/lib/http'
+import { AffiliationPanel, type AffiliationOption } from './-AffiliationPanel'
 
 interface Props {
   entityType: MusicEntityType
@@ -131,6 +143,7 @@ function ArtistDetailPage({ id }: { id: string }) {
           deleteLink={deleteLink}
         />
       }
+      relationshipsSlot={<ArtistLabelAffiliations artistId={id} />}
     />
   )
 }
@@ -202,11 +215,14 @@ function AlbumDetailPage({ id }: { id: string }) {
         />
       }
       relationshipsSlot={
-        <MusicEntityArtistsPanel
-          artists={artistJunctions}
-          onAdd={(artistId, role) => addArtist.mutate({ albumId: id, artistId, role })}
-          onRemove={(artistId) => removeArtist.mutate({ albumId: id, artistId })}
-        />
+        <div className='space-y-6'>
+          <MusicEntityArtistsPanel
+            artists={artistJunctions}
+            onAdd={(artistId, role) => addArtist.mutate({ albumId: id, artistId, role })}
+            onRemove={(artistId) => removeArtist.mutate({ albumId: id, artistId })}
+          />
+          <AlbumLabelAffiliations albumId={id} />
+        </div>
       }
     />
   )
@@ -368,6 +384,132 @@ function LabelDetailPage({ id }: { id: string }) {
           deleteLink={deleteLink}
         />
       }
+      relationshipsSlot={<LabelAffiliations labelId={id} />}
+    />
+  )
+}
+
+const toArtistAffiliationOption = (artist: MusicArtist): AffiliationOption => ({
+  id: artist.id,
+  name: artist.name,
+  publishedAt: artist.publishedAt,
+  detail: artist.genres?.join(', ') || artist.slug
+})
+
+const toAlbumAffiliationOption = (album: MusicAlbum): AffiliationOption => ({
+  id: album.id,
+  name: album.title,
+  publishedAt: album.publishedAt,
+  detail: album.artistNames?.join(', ') || album.albumType || album.slug
+})
+
+const toLabelAffiliationOption = (label: MusicLabel): AffiliationOption => ({
+  id: label.id,
+  name: label.name,
+  publishedAt: label.publishedAt,
+  detail: label.slug
+})
+
+function LabelAffiliations({ labelId }: { labelId: string }) {
+  const artists = useLabelArtists(labelId)
+  const albums = useLabelAlbums(labelId)
+  const artistCandidates = useAdminArtists()
+  const albumCandidates = useAdminAlbums()
+  const affiliateArtist = useAffiliateArtistWithLabel()
+  const unaffiliateArtist = useUnaffiliateArtistFromLabel()
+  const affiliateAlbum = useAffiliateAlbumWithLabel()
+  const unaffiliateAlbum = useUnaffiliateAlbumFromLabel()
+
+  return (
+    <div className='space-y-6'>
+      <AffiliationPanel
+        title='Roster artists'
+        description='Artists factually affiliated with this label.'
+        items={(artists.data ?? []).map(toArtistAffiliationOption)}
+        candidates={(artistCandidates.data ?? []).map(toArtistAffiliationOption)}
+        isLoading={artists.isLoading || artistCandidates.isLoading}
+        error={artists.error ?? artistCandidates.error}
+        isMutating={affiliateArtist.isPending || unaffiliateArtist.isPending}
+        onAdd={async (artistId) => {
+          await affiliateArtist.mutateAsync({ labelId, artistId })
+          toast({ title: 'Artist affiliated with label' })
+        }}
+        onRemove={async (artistId) => {
+          await unaffiliateArtist.mutateAsync({ labelId, artistId })
+          toast({ title: 'Artist affiliation removed' })
+        }}
+      />
+      <AffiliationPanel
+        title='Catalog albums'
+        description='Albums factually issued by this label.'
+        items={(albums.data ?? []).map(toAlbumAffiliationOption)}
+        candidates={(albumCandidates.data ?? []).map(toAlbumAffiliationOption)}
+        isLoading={albums.isLoading || albumCandidates.isLoading}
+        error={albums.error ?? albumCandidates.error}
+        isMutating={affiliateAlbum.isPending || unaffiliateAlbum.isPending}
+        onAdd={async (albumId) => {
+          await affiliateAlbum.mutateAsync({ labelId, albumId })
+          toast({ title: 'Album affiliated with label' })
+        }}
+        onRemove={async (albumId) => {
+          await unaffiliateAlbum.mutateAsync({ labelId, albumId })
+          toast({ title: 'Album affiliation removed' })
+        }}
+      />
+    </div>
+  )
+}
+
+function ArtistLabelAffiliations({ artistId }: { artistId: string }) {
+  const labels = useArtistLabels(artistId)
+  const candidates = useAdminLabels()
+  const affiliate = useAffiliateArtistWithLabel()
+  const unaffiliate = useUnaffiliateArtistFromLabel()
+
+  return (
+    <AffiliationPanel
+      title='Labels'
+      description='Labels whose roster includes this artist.'
+      items={(labels.data ?? []).map(toLabelAffiliationOption)}
+      candidates={(candidates.data ?? []).map(toLabelAffiliationOption)}
+      isLoading={labels.isLoading || candidates.isLoading}
+      error={labels.error ?? candidates.error}
+      isMutating={affiliate.isPending || unaffiliate.isPending}
+      onAdd={async (labelId) => {
+        await affiliate.mutateAsync({ labelId, artistId })
+        toast({ title: 'Label affiliation added' })
+      }}
+      onRemove={async (labelId) => {
+        await unaffiliate.mutateAsync({ labelId, artistId })
+        toast({ title: 'Label affiliation removed' })
+      }}
+    />
+  )
+}
+
+function AlbumLabelAffiliations({ albumId }: { albumId: string }) {
+  const labels = useAlbumLabels(albumId)
+  const candidates = useAdminLabels()
+  const affiliate = useAffiliateAlbumWithLabel()
+  const unaffiliate = useUnaffiliateAlbumFromLabel()
+
+  return (
+    <AffiliationPanel
+      title='Labels'
+      description='Labels that issued this album.'
+      items={(labels.data ?? []).map(toLabelAffiliationOption)}
+      candidates={(candidates.data ?? []).map(toLabelAffiliationOption)}
+      isLoading={labels.isLoading || candidates.isLoading}
+      error={labels.error ?? candidates.error}
+      isMutating={affiliate.isPending || unaffiliate.isPending}
+      onAdd={async (labelId) => {
+        await affiliate.mutateAsync({ labelId, albumId })
+        toast({ title: 'Label affiliation added' })
+      }}
+      onRemove={async (labelId) => {
+        await unaffiliate.mutateAsync({ labelId, albumId })
+        toast({ title: 'Label affiliation removed' })
+      }}
     />
   )
 }

--- a/apps/www/src/routes/labels/$labelSlug.tsx
+++ b/apps/www/src/routes/labels/$labelSlug.tsx
@@ -35,7 +35,20 @@ export const Route = createFileRoute('/labels/$labelSlug')({
         ...label,
         tags: label.tags ? [...label.tags] : null,
         genres: label.genres ? [...label.genres] : null,
-        creators: label.creators ? [...label.creators] : undefined
+        creators: label.creators ? [...label.creators] : undefined,
+        affiliatedArtists: label.affiliatedArtists
+          ? label.affiliatedArtists.map((artist) => ({
+              ...artist,
+              genres: artist.genres ? [...artist.genres] : null
+            }))
+          : [],
+        affiliatedAlbums: label.affiliatedAlbums
+          ? label.affiliatedAlbums.map((album) => ({
+              ...album,
+              artistNames: album.artistNames ? [...album.artistNames] : null,
+              genres: album.genres ? [...album.genres] : null
+            }))
+          : []
       },
       links: links.map((link) => ({ ...link }))
     }
@@ -132,10 +145,97 @@ function LabelPage() {
             </div>
           </div>
         </aside>
-        <main className='prose prose-neutral max-w-none dark:prose-invert lg:col-span-2'>
-          <MDXRendrr mdxString={label.compiledContent ?? label.content} />
+        <main className='space-y-10 lg:col-span-2'>
+          <div className='prose prose-neutral max-w-none dark:prose-invert'>
+            <MDXRendrr mdxString={label.compiledContent ?? label.content} />
+          </div>
+          <PublicLabelAffiliations
+            artists={label.affiliatedArtists}
+            albums={label.affiliatedAlbums}
+          />
         </main>
       </div>
+    </div>
+  )
+}
+
+interface PublicLabelAffiliationsProps {
+  readonly artists: ReadonlyArray<{
+    readonly id: string
+    readonly name: string
+    readonly imageUrl: string | null
+    readonly genres: ReadonlyArray<string> | null
+  }>
+  readonly albums: ReadonlyArray<{
+    readonly id: string
+    readonly title: string
+    readonly coverImageUrl: string | null
+    readonly artistNames: ReadonlyArray<string> | null
+    readonly releaseDate: string | null
+  }>
+}
+
+function PublicLabelAffiliations({ artists, albums }: PublicLabelAffiliationsProps) {
+  if (artists.length === 0 && albums.length === 0) return null
+
+  return (
+    <div className='space-y-10'>
+      {artists.length > 0 && (
+        <section aria-labelledby='label-roster-heading'>
+          <h2 id='label-roster-heading' className='mb-4 text-xl font-semibold'>
+            Roster
+          </h2>
+          <ul className='grid gap-3 sm:grid-cols-2'>
+            {artists.map((artist) => (
+              <li key={artist.id} className='flex items-center gap-3 rounded-md border p-3'>
+                <img
+                  src={artist.imageUrl || '/fav.png'}
+                  alt=''
+                  className='h-14 w-14 rounded-sm object-cover'
+                />
+                <div className='min-w-0'>
+                  <p className='truncate font-medium'>{artist.name}</p>
+                  {artist.genres && artist.genres.length > 0 && (
+                    <p className='truncate text-sm text-muted-foreground'>
+                      {artist.genres.join(', ')}
+                    </p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {albums.length > 0 && (
+        <section aria-labelledby='label-catalog-heading'>
+          <h2 id='label-catalog-heading' className='mb-4 text-xl font-semibold'>
+            Catalog
+          </h2>
+          <ul className='grid gap-4 sm:grid-cols-2'>
+            {albums.map((album) => (
+              <li key={album.id} className='overflow-hidden rounded-md border'>
+                <img
+                  src={album.coverImageUrl || '/fav.png'}
+                  alt=''
+                  className='aspect-square w-full object-cover'
+                />
+                <div className='space-y-1 p-3'>
+                  <p className='font-medium'>{album.title}</p>
+                  {album.artistNames && album.artistNames.length > 0 && (
+                    <p className='text-sm text-muted-foreground'>{album.artistNames.join(', ')}</p>
+                  )}
+                  {album.releaseDate && (
+                    <p className='text-xs text-muted-foreground'>
+                      {new Date(album.releaseDate).getFullYear()}
+                    </p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
     </div>
   )
 }

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -122,6 +122,12 @@ A curated list of tracks.
 - **Meaning:** A row in `music_playlists`. Can be imported from Spotify and enriched with links to other platforms.
 - **Used in:** `music_playlists`, `music_playlist_tracks`.
 
+### Label Affiliation
+A factual, many-to-many relationship between labels and their rosters or catalogs: an artist may be affiliated with multiple labels, and an album may be issued by multiple labels. It is not an editorial recommendation; tracks inherit affiliation through their album, standalone labeled singles are represented as single-type albums, and playlists have no label affiliation.
+
+- **Used in:** label roster and catalog relationships.
+- **Avoid:** "Related entity", "featured entity", or using affiliation for editorial curation.
+
 ### Platform Link / Entity Link
 A URL that links a music entity to a specific streaming or social platform.
 

--- a/packages/api/src/music.ts
+++ b/packages/api/src/music.ts
@@ -207,7 +207,9 @@ export const LabelResponse = Schema.Struct({
   createdAt: Schema.String,
   updatedAt: Schema.String,
   compiledContent: Schema.optional(Schema.String),
-  creators: Schema.optional(Schema.Array(LabelCreatorResponse))
+  creators: Schema.optional(Schema.Array(LabelCreatorResponse)),
+  affiliatedArtists: Schema.optional(Schema.Array(ArtistResponse)),
+  affiliatedAlbums: Schema.optional(Schema.Array(AlbumResponse))
 })
 export type LabelResponse = typeof LabelResponse.Type
 
@@ -418,6 +420,13 @@ export const MusicGroup = HttpApiGroup.make('music')
     }).middleware(AuthMiddleware)
   )
   .add(
+    HttpApiEndpoint.get('listArtistLabels', '/api/music/artists/:artistId/labels', {
+      params: { artistId: Schema.String },
+      success: LabelListResponse,
+      error: HttpApiError.Forbidden
+    }).middleware(AuthMiddleware)
+  )
+  .add(
     HttpApiEndpoint.put('addArtistToAlbum', '/api/music/albums/:albumId/artists/:artistId', {
       params: { albumId: Schema.String, artistId: Schema.String },
       payload: ArtistJunctionInput,
@@ -486,6 +495,13 @@ export const MusicGroup = HttpApiGroup.make('music')
       params: albumIdParam,
       success: HttpApiSchema.NoContent,
       error: [HttpApiError.NotFound, HttpApiError.Forbidden]
+    }).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.get('listAlbumLabels', '/api/music/albums/:albumId/labels', {
+      params: { albumId: Schema.String },
+      success: LabelListResponse,
+      error: HttpApiError.Forbidden
     }).middleware(AuthMiddleware)
   )
   // ---------------------------------------------------------------------
@@ -598,6 +614,60 @@ export const MusicGroup = HttpApiGroup.make('music')
       success: HttpApiSchema.NoContent,
       error: [HttpApiError.NotFound, HttpApiError.Forbidden]
     }).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.get('listLabelArtists', '/api/music/labels/:labelId/artists', {
+      params: { labelId: Schema.String },
+      success: ArtistListResponse,
+      error: HttpApiError.Forbidden
+    }).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.get('listLabelAlbums', '/api/music/labels/:labelId/albums', {
+      params: { labelId: Schema.String },
+      success: AlbumListResponse,
+      error: HttpApiError.Forbidden
+    }).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.put(
+      'affiliateArtistWithLabel',
+      '/api/music/labels/:labelId/artists/:artistId',
+      {
+        params: { labelId: Schema.String, artistId: Schema.String },
+        success: HttpApiSchema.NoContent,
+        error: [HttpApiError.NotFound, HttpApiError.Forbidden]
+      }
+    ).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.delete(
+      'unaffiliateArtistFromLabel',
+      '/api/music/labels/:labelId/artists/:artistId',
+      {
+        params: { labelId: Schema.String, artistId: Schema.String },
+        success: HttpApiSchema.NoContent,
+        error: HttpApiError.Forbidden
+      }
+    ).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.put('affiliateAlbumWithLabel', '/api/music/labels/:labelId/albums/:albumId', {
+      params: { labelId: Schema.String, albumId: Schema.String },
+      success: HttpApiSchema.NoContent,
+      error: [HttpApiError.NotFound, HttpApiError.Forbidden]
+    }).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.delete(
+      'unaffiliateAlbumFromLabel',
+      '/api/music/labels/:labelId/albums/:albumId',
+      {
+        params: { labelId: Schema.String, albumId: Schema.String },
+        success: HttpApiSchema.NoContent,
+        error: HttpApiError.Forbidden
+      }
+    ).middleware(AuthMiddleware)
   )
   // ---------------------------------------------------------------------
   // Playlist tracks


### PR DESCRIPTION
## Summary

- model factual many-to-many affiliations between labels and artists/albums with FK-backed junction tables
- expose reciprocal admin reads and idempotent add/remove operations through the Effect HTTP API
- add searchable affiliation management to label, artist, and album detail pages
- render published roster artists and catalog albums on public label pages

## Domain rules

- affiliations are factual roster/catalog relationships, not editorial recommendations
- tracks inherit label affiliation through albums; standalone labeled singles remain single-type albums
- playlists do not participate in label affiliations

## Implementation notes

- composite primary keys prevent duplicate affiliations
- cascading foreign keys remove affiliations with either entity
- reverse-column indexes support artist→labels and album→labels queries
- public label responses filter draft/future affiliations, order artists alphabetically, and order albums by release date descending

## Adversarial review

`openai/gpt-5.4-mini` reviewed the branch against `prod` along standards and spec axes. The review found missing reverse-column indexes; these were added to the schema and migration. A follow-up adversarial pass verified the migration/index fix. Idempotent no-op deletes remain intentional.

## Verification

- `bun precommit`
- `cd apps/vps && bun run test` — 240 passed
- `cd packages/api && bun run test` — 30 passed
- `cd apps/www && bun run build`
- browser-tested reciprocal label/artist management and public roster/catalog rendering with `agent-browser`

## Test evidence

An authenticated label Relationships tab shows factual roster and catalog affiliations, searchable candidates, publication state, and remove controls.

![Label affiliation management in the admin music catalog](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/219/label-affiliations-admin.png)

The public label page renders only published roster artists and catalog albums from those affiliations.

![Published label roster and catalog](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/219/label-affiliations-public.png)

The API response backing the public page was also verified directly:

```text
GET /api/music/labels/slug/<label-slug> -> 200
artists: Lumen Static, Mara Vale
albums: Signals After Midnight
browser console errors: none
```
