### PR TITLE
feat(uploads): switch multipart part upload to direct-to-S3 presigned URLs

### DIFF
--- a/apps/vps/src/http/routes.blackbox.test.ts
+++ b/apps/vps/src/http/routes.blackbox.test.ts
@@ -805,6 +805,22 @@ describe('upload (HttpApiBuilder group, Step 7)', () => {
     expect(res.status).toBe(401)
   })
 
+  it('POST /api/upload/multipart/presign-part returns 401 without a session cookie', async () => {
+    const res = await webHandler.handler(
+      new Request('http://localhost/api/upload/multipart/presign-part', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          key: 'user123/audio_1_test.mp3',
+          uploadId: 'upload-id',
+          partNumber: 1
+        })
+      })
+    )
+
+    expect(res.status).toBe(401)
+  })
+
   it('POST /api/upload/multipart/complete returns 401 without a session cookie', async () => {
     const res = await webHandler.handler(
       new Request('http://localhost/api/upload/multipart/complete', {

--- a/apps/vps/src/http/routes.blackbox.test.ts
+++ b/apps/vps/src/http/routes.blackbox.test.ts
@@ -791,20 +791,6 @@ describe('upload (HttpApiBuilder group, Step 7)', () => {
     expect(res.status).toBe(401)
   })
 
-  it('POST /api/upload/multipart/part returns 401 without a session cookie', async () => {
-    const formData = new FormData()
-    formData.append('key', 'user123/audio_1_test.mp3')
-    formData.append('uploadId', 'upload-id')
-    formData.append('partNumber', '1')
-    formData.append('chunk', new Blob(['data']), 'chunk')
-
-    const res = await webHandler.handler(
-      new Request('http://localhost/api/upload/multipart/part', { method: 'POST', body: formData })
-    )
-
-    expect(res.status).toBe(401)
-  })
-
   it('POST /api/upload/multipart/presign-part returns 401 without a session cookie', async () => {
     const res = await webHandler.handler(
       new Request('http://localhost/api/upload/multipart/presign-part', {

--- a/apps/vps/src/http/routes.blackbox.test.ts
+++ b/apps/vps/src/http/routes.blackbox.test.ts
@@ -807,6 +807,45 @@ describe('upload (HttpApiBuilder group, Step 7)', () => {
     expect(res.status).toBe(401)
   })
 
+  it("POST /api/upload/multipart/presign-part returns 400 for a key outside the caller's own prefix", async () => {
+    const suffix = crypto.randomUUID()
+    const userId = `upload-owner-${suffix}`
+    const token = `upload-owner-token-${suffix}`
+
+    await db
+      .insert(user)
+      .values({ id: userId, name: 'Upload owner', email: `${userId}@example.com` })
+    await db.insert(session).values({
+      id: crypto.randomUUID(),
+      token,
+      userId,
+      expiresAt: new Date(Date.now() + 60_000)
+    })
+
+    try {
+      const res = await webHandler.handler(
+        new Request('http://localhost/api/upload/multipart/presign-part', {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${token}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({
+            // assertKeyOwnership requires the key to start with `${userId}/`
+            // -- this key belongs to a different user prefix entirely.
+            key: 'someone-elses-user-id/multipart/uuid/1024/audio_test.mp3',
+            uploadId: 'upload-id',
+            partNumber: 1
+          })
+        })
+      )
+
+      expect(res.status).toBe(400)
+    } finally {
+      await db.delete(user).where(eq(user.id, userId))
+    }
+  })
+
   it('POST /api/upload/multipart/complete returns 401 without a session cookie', async () => {
     const res = await webHandler.handler(
       new Request('http://localhost/api/upload/multipart/complete', {

--- a/apps/vps/src/http/routes.ts
+++ b/apps/vps/src/http/routes.ts
@@ -124,9 +124,9 @@ export const createWebHandler = (options?: {
       RequestLoggerLive,
       SentryDefectLive
     ).pipe(
-      // HttpServerRequest.multipart (upload group's uploadFile/uploadMultipartPart
-      // endpoints) needs a real FileSystem.FileSystem + Path.Path to buffer
-      // parts to temp files. HttpServer.layerServices ships its own
+      // HttpServerRequest.multipart (upload group's uploadFile endpoint)
+      // needs a real FileSystem.FileSystem + Path.Path to buffer parts to
+      // temp files. HttpServer.layerServices ships its own
       // FileSystem.layerNoop, so the real Bun implementation is nested inside
       // the same provideMerge, applied after layerServices, so it overwrites
       // the noop instead of losing to it. Confirmed by reproducing the "not

--- a/apps/vps/src/http/upload.handlers.test.ts
+++ b/apps/vps/src/http/upload.handlers.test.ts
@@ -1,10 +1,45 @@
+import { Effect } from 'effect'
+import { HttpApiError } from 'effect/unstable/httpapi'
 import { describe, expect, test } from 'vitest'
 import {
   assertContiguousParts,
+  assertKeyOwnership,
   expectedMultipartPartSize,
   matchesCompletedObject,
   validateMultipartParts
 } from './upload.handlers'
+
+describe('assertKeyOwnership', () => {
+  test('accepts a key prefixed with the requesting user id', () => {
+    expect(assertKeyOwnership('user-1', 'user-1/multipart/uuid/1024/audio_test.mp3')).toBe(
+      Effect.void
+    )
+  })
+
+  test('rejects a key prefixed with a different user id', () => {
+    expect(
+      assertKeyOwnership('user-1', 'user-2/multipart/uuid/1024/audio_test.mp3')
+    ).toBeInstanceOf(HttpApiError.BadRequest)
+  })
+
+  test('rejects a key with no matching prefix segment at all', () => {
+    expect(assertKeyOwnership('user-1', 'not-a-scoped-key.mp3')).toBeInstanceOf(
+      HttpApiError.BadRequest
+    )
+  })
+
+  test('sanitizes the user id the same way keys are built, so ownership matches sanitized ids', () => {
+    expect(assertKeyOwnership('user 1!', 'user_1_/multipart/uuid/1024/audio_test.mp3')).toBe(
+      Effect.void
+    )
+  })
+
+  test('rejects a prefix match that stops short of the path separator', () => {
+    expect(
+      assertKeyOwnership('user-1', 'user-12/multipart/uuid/1024/audio_test.mp3')
+    ).toBeInstanceOf(HttpApiError.BadRequest)
+  })
+})
 
 describe('assertContiguousParts', () => {
   test('accepts a complete contiguous sequence', () => {

--- a/apps/vps/src/http/upload.handlers.ts
+++ b/apps/vps/src/http/upload.handlers.ts
@@ -21,7 +21,13 @@ const MAX_IMAGE_SIZE = 10 * 1024 * 1024
 // request adds ~1 KiB of overhead on top of the file part, so the per-chunk
 // ceiling must stay well under 10 MiB. 9 MiB leaves room for the form fields
 // (key, uploadId, partNumber) and the boundary markers.
+// Retained for the legacy uploadMultipartPart proxy endpoint only -- the new
+// presignMultipartPart path PUTs straight to S3 and isn't bound by this.
 const MAX_CHUNK_SIZE = 9 * 1024 * 1024
+
+// Long enough to cover an 8 MiB PUT over a slow upload connection with retry
+// headroom, short enough to bound how long a leaked URL stays usable.
+const PRESIGNED_PART_URL_EXPIRY_SECONDS = 5 * 60
 
 const sanitizeKeySegment = (value: string): string => value.replace(/[^a-zA-Z0-9.-]/g, '_')
 
@@ -218,6 +224,40 @@ export const UploadHandlersLive = HttpApiBuilder.group(Api, 'upload', (handlers)
         return { partNumber: result.partNumber, etag: result.etag, size: result.size }
       }).pipe(
         Effect.withSpan('api.upload.multipart.part', {
+          attributes: { partNumber: payload.partNumber }
+        })
+      )
+    )
+    .handle('presignMultipartPart', ({ payload }) =>
+      Effect.gen(function* () {
+        const { user } = yield* AuthSession
+        const { key, uploadId, partNumber } = payload
+
+        yield* assertKeyOwnership(user.id, key)
+        const expectedSize = yield* requireExpectedSize(user.id, key)
+        if (expectedMultipartPartSize(expectedSize, partNumber) === null) {
+          return yield* new HttpApiError.BadRequest()
+        }
+
+        const config = yield* ConfigService
+        const s3Service = yield* S3Service
+        const url = yield* dieOnS3Error(
+          s3Service.presignUploadPart(
+            key,
+            uploadId,
+            partNumber,
+            config.buckets.userContent,
+            PRESIGNED_PART_URL_EXPIRY_SECONDS
+          )
+        )
+
+        return {
+          url,
+          partNumber,
+          expiresInSeconds: PRESIGNED_PART_URL_EXPIRY_SECONDS
+        }
+      }).pipe(
+        Effect.withSpan('api.upload.multipart.presignPart', {
           attributes: { partNumber: payload.partNumber }
         })
       )

--- a/apps/vps/src/http/upload.handlers.ts
+++ b/apps/vps/src/http/upload.handlers.ts
@@ -35,7 +35,7 @@ const buildObjectKey = (
   return `${sanitizeKeySegment(userId)}/multipart/${crypto.randomUUID()}/${expectedSize}/${fileType}_${sanitizedName}`
 }
 
-const assertKeyOwnership = (userId: string, key: string) =>
+export const assertKeyOwnership = (userId: string, key: string) =>
   key.startsWith(`${sanitizeKeySegment(userId)}/`) ? Effect.void : new HttpApiError.BadRequest()
 
 export const assertContiguousParts = (parts: ReadonlyArray<{ partNumber: number }>) => {
@@ -191,6 +191,16 @@ export const UploadHandlersLive = HttpApiBuilder.group(Api, 'upload', (handlers)
 
         yield* assertKeyOwnership(user.id, key)
         const expectedSize = yield* requireExpectedSize(user.id, key)
+        // Only partNumber is checked here -- actual byte size can't be
+        // validated at presign time since the client hasn't PUT the bytes
+        // to S3 yet (this just mints the URL). A client can still push an
+        // oversized part straight to S3 after presigning; that garbage
+        // isn't reachable (the object never becomes readable pre-completion)
+        // and completeMultipartUpload below re-validates every part's real
+        // S3-reported size via listMultipartParts + validateMultipartParts,
+        // rejecting the whole upload on any mismatch. Worst case is
+        // billable-but-unreadable storage until the bucket's abort-
+        // incomplete-multipart-upload lifecycle rule reaps it.
         if (expectedMultipartPartSize(expectedSize, partNumber) === null) {
           return yield* new HttpApiError.BadRequest()
         }

--- a/apps/vps/src/http/upload.handlers.ts
+++ b/apps/vps/src/http/upload.handlers.ts
@@ -17,17 +17,11 @@ const dieOnPlatformError = makeDieOnPlatformError('upload')
 const CHUNK_SIZE = 8 * 1024 * 1024
 const MAX_AUDIO_SIZE = 200 * 1024 * 1024
 const MAX_IMAGE_SIZE = 10 * 1024 * 1024
-// API Gateway HTTP API v2 caps request bodies at 10 MiB. A multipart/form-data
-// request adds ~1 KiB of overhead on top of the file part, so the per-chunk
-// ceiling must stay well under 10 MiB. 9 MiB leaves room for the form fields
-// (key, uploadId, partNumber) and the boundary markers.
-// Retained for the legacy uploadMultipartPart proxy endpoint only -- the new
-// presignMultipartPart path PUTs straight to S3 and isn't bound by this.
-const MAX_CHUNK_SIZE = 9 * 1024 * 1024
 
-// Long enough to cover an 8 MiB PUT over a slow upload connection with retry
-// headroom, short enough to bound how long a leaked URL stays usable.
-const PRESIGNED_PART_URL_EXPIRY_SECONDS = 5 * 60
+// Long enough to cover an 8 MiB part PUT over a genuinely slow upload
+// connection with room for a retry or two before the URL goes stale, short
+// enough to bound how long a leaked URL stays usable.
+const PRESIGNED_PART_URL_EXPIRY_SECONDS = 15 * 60
 
 const sanitizeKeySegment = (value: string): string => value.replace(/[^a-zA-Z0-9.-]/g, '_')
 
@@ -187,44 +181,6 @@ export const UploadHandlersLive = HttpApiBuilder.group(Api, 'upload', (handlers)
       }).pipe(
         Effect.withSpan('api.upload.multipart.init', {
           attributes: { fileType: payload.fileType, fileSize: payload.fileSize }
-        })
-      )
-    )
-    .handle('uploadMultipartPart', ({ payload }) =>
-      Effect.gen(function* () {
-        const { user } = yield* AuthSession
-        const { key, uploadId, partNumber, chunk } = payload
-
-        const file = yield* readPersistedFile(chunk)
-        if (file.size === 0) {
-          return yield* new HttpApiError.BadRequest()
-        }
-        if (file.size > MAX_CHUNK_SIZE) {
-          return yield* new HttpApiError.BadRequest()
-        }
-
-        yield* assertKeyOwnership(user.id, key)
-        const expectedSize = yield* requireExpectedSize(user.id, key)
-        if (file.size !== expectedMultipartPartSize(expectedSize, partNumber)) {
-          return yield* new HttpApiError.BadRequest()
-        }
-
-        const config = yield* ConfigService
-        const s3Service = yield* S3Service
-        const result = yield* dieOnS3Error(
-          s3Service.uploadMultipartPart(
-            key,
-            uploadId,
-            partNumber,
-            file.buffer,
-            config.buckets.userContent
-          )
-        )
-
-        return { partNumber: result.partNumber, etag: result.etag, size: result.size }
-      }).pipe(
-        Effect.withSpan('api.upload.multipart.part', {
-          attributes: { partNumber: payload.partNumber }
         })
       )
     )

--- a/apps/vps/src/services/s3.service.ts
+++ b/apps/vps/src/services/s3.service.ts
@@ -72,14 +72,6 @@ export interface S3Service {
     bucketName: string
   ) => Effect.Effect<S3ObjectMetadata | null, S3Error>
 
-  readonly uploadMultipartPart: (
-    key: string,
-    uploadId: string,
-    partNumber: number,
-    body: Buffer | Uint8Array | Blob,
-    bucketName: string
-  ) => Effect.Effect<{ partNumber: number; etag: string; size: number }, S3Error>
-
   readonly presignUploadPart: (
     key: string,
     uploadId: string,
@@ -400,49 +392,6 @@ const getObjectMetadataEffect = (key: string, bucketName: string) =>
     })
   )
 
-const uploadMultipartPartEffect = (
-  key: string,
-  uploadId: string,
-  partNumber: number,
-  body: Buffer | Uint8Array | Blob,
-  bucketName: string
-) =>
-  Effect.tryPromise({
-    try: async () => {
-      const s3 = new S3Client({})
-      const response = await s3.send(
-        new UploadPartCommand({
-          Bucket: bucketName,
-          Key: key,
-          UploadId: uploadId,
-          PartNumber: partNumber,
-          Body: body
-        })
-      )
-      if (!response.ETag) {
-        throw new Error('S3 did not return an ETag for the uploaded part')
-      }
-      const size = body instanceof Blob ? body.size : body.byteLength
-      return { partNumber, etag: response.ETag, size }
-    },
-    catch: (error) =>
-      new S3Error({
-        message: `Failed to upload multipart part: ${getErrorMessage(error)}`,
-        operation: 'uploadMultipartPart',
-        key
-      })
-  }).pipe(
-    Effect.withSpan('aws.s3.uploadPart', {
-      attributes: {
-        'aws.service': 's3',
-        's3.bucket': bucketName,
-        's3.key_prefix': getKeyPrefix(key),
-        's3.part_number': partNumber,
-        'payload.size_bytes': body instanceof Blob ? body.size : body.byteLength
-      }
-    })
-  )
-
 const presignUploadPartEffect = (
   key: string,
   uploadId: string,
@@ -636,7 +585,6 @@ export const S3ServiceLive = Layer.succeed(S3Service, {
   listBuckets: listBucketsEffect,
   createMultipartUpload: createMultipartUploadEffect,
   getObjectMetadata: getObjectMetadataEffect,
-  uploadMultipartPart: uploadMultipartPartEffect,
   presignUploadPart: presignUploadPartEffect,
   completeMultipartUpload: completeMultipartUploadEffect,
   abortMultipartUpload: abortMultipartUploadEffect,

--- a/apps/vps/src/services/s3.service.ts
+++ b/apps/vps/src/services/s3.service.ts
@@ -13,6 +13,7 @@ import {
   S3Client,
   UploadPartCommand
 } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { Context, Effect, Layer } from 'effect'
 import { getErrorMessage, S3Error } from '@/errors'
 
@@ -78,6 +79,14 @@ export interface S3Service {
     body: Buffer | Uint8Array | Blob,
     bucketName: string
   ) => Effect.Effect<{ partNumber: number; etag: string; size: number }, S3Error>
+
+  readonly presignUploadPart: (
+    key: string,
+    uploadId: string,
+    partNumber: number,
+    bucketName: string,
+    expiresInSeconds: number
+  ) => Effect.Effect<string, S3Error>
 
   readonly completeMultipartUpload: (
     key: string,
@@ -434,6 +443,41 @@ const uploadMultipartPartEffect = (
     })
   )
 
+const presignUploadPartEffect = (
+  key: string,
+  uploadId: string,
+  partNumber: number,
+  bucketName: string,
+  expiresInSeconds: number
+) =>
+  Effect.tryPromise({
+    try: async () => {
+      const s3 = new S3Client({})
+      const command = new UploadPartCommand({
+        Bucket: bucketName,
+        Key: key,
+        UploadId: uploadId,
+        PartNumber: partNumber
+      })
+      return await getSignedUrl(s3, command, { expiresIn: expiresInSeconds })
+    },
+    catch: (error) =>
+      new S3Error({
+        message: `Failed to presign upload part: ${getErrorMessage(error)}`,
+        operation: 'presignUploadPart',
+        key
+      })
+  }).pipe(
+    Effect.withSpan('aws.s3.presignUploadPart', {
+      attributes: {
+        'aws.service': 's3',
+        's3.bucket': bucketName,
+        's3.key_prefix': getKeyPrefix(key),
+        's3.part_number': partNumber
+      }
+    })
+  )
+
 const completeMultipartUploadEffect = (
   key: string,
   uploadId: string,
@@ -593,6 +637,7 @@ export const S3ServiceLive = Layer.succeed(S3Service, {
   createMultipartUpload: createMultipartUploadEffect,
   getObjectMetadata: getObjectMetadataEffect,
   uploadMultipartPart: uploadMultipartPartEffect,
+  presignUploadPart: presignUploadPartEffect,
   completeMultipartUpload: completeMultipartUploadEffect,
   abortMultipartUpload: abortMultipartUploadEffect,
   listMultipartParts: listMultipartPartsEffect

--- a/apps/www/src/lib/upload/resumable-upload.test.ts
+++ b/apps/www/src/lib/upload/resumable-upload.test.ts
@@ -9,7 +9,6 @@ import {
   parseAbortResponse,
   parseCompleteResponse,
   parseInitResponse,
-  parsePartResponse,
   parsePersistedUpload,
   parsePresignPartResponse,
   parseStatusResponse,
@@ -254,14 +253,6 @@ describe('response parsers', () => {
 
   test('parseInitResponse throws on missing fields', () => {
     expect(() => parseInitResponse({ uploadId: 'u', key: 'k' })).toThrow()
-  })
-
-  test('parsePartResponse decodes a valid payload', () => {
-    expect(parsePartResponse({ partNumber: 1, etag: 'e', size: 10 })).toEqual({
-      partNumber: 1,
-      etag: 'e',
-      size: 10
-    })
   })
 
   test('parsePresignPartResponse decodes a valid payload', () => {

--- a/apps/www/src/lib/upload/resumable-upload.test.ts
+++ b/apps/www/src/lib/upload/resumable-upload.test.ts
@@ -11,6 +11,7 @@ import {
   parseInitResponse,
   parsePartResponse,
   parsePersistedUpload,
+  parsePresignPartResponse,
   parseStatusResponse,
   splitFileIntoChunks,
   totalParts,
@@ -261,6 +262,24 @@ describe('response parsers', () => {
       etag: 'e',
       size: 10
     })
+  })
+
+  test('parsePresignPartResponse decodes a valid payload', () => {
+    expect(
+      parsePresignPartResponse({
+        url: 'https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc',
+        partNumber: 1,
+        expiresInSeconds: 300
+      })
+    ).toEqual({
+      url: 'https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc',
+      partNumber: 1,
+      expiresInSeconds: 300
+    })
+  })
+
+  test('parsePresignPartResponse throws on missing fields', () => {
+    expect(() => parsePresignPartResponse({ partNumber: 1 })).toThrow()
   })
 
   test('parseStatusResponse returns a fresh array', () => {

--- a/apps/www/src/lib/upload/resumable-upload.ts
+++ b/apps/www/src/lib/upload/resumable-upload.ts
@@ -41,12 +41,6 @@ export interface MultipartInitResponse {
   chunkSize: number
 }
 
-export interface MultipartPartResponse {
-  partNumber: number
-  etag: string
-  size: number
-}
-
 export interface PresignPartResponse {
   url: string
   partNumber: number
@@ -65,12 +59,6 @@ const multipartInitResponseSchema = Schema.Struct({
   uploadId: Schema.String,
   key: Schema.String,
   chunkSize: Schema.Number
-})
-
-const multipartPartResponseSchema = Schema.Struct({
-  partNumber: Schema.Number,
-  etag: Schema.String,
-  size: Schema.Number
 })
 
 const presignPartResponseSchema = Schema.Struct({
@@ -120,9 +108,6 @@ const persistedUploadSchema = Schema.Struct({
 
 export const parseInitResponse = (raw: unknown): MultipartInitResponse =>
   Schema.decodeUnknownSync(multipartInitResponseSchema)(raw)
-
-export const parsePartResponse = (raw: unknown): MultipartPartResponse =>
-  Schema.decodeUnknownSync(multipartPartResponseSchema)(raw)
 
 export const parsePresignPartResponse = (raw: unknown): PresignPartResponse =>
   Schema.decodeUnknownSync(presignPartResponseSchema)(raw)

--- a/apps/www/src/lib/upload/resumable-upload.ts
+++ b/apps/www/src/lib/upload/resumable-upload.ts
@@ -47,6 +47,12 @@ export interface MultipartPartResponse {
   size: number
 }
 
+export interface PresignPartResponse {
+  url: string
+  partNumber: number
+  expiresInSeconds: number
+}
+
 export interface MultipartStatusResponse {
   parts: ResumablePart[]
 }
@@ -65,6 +71,12 @@ const multipartPartResponseSchema = Schema.Struct({
   partNumber: Schema.Number,
   etag: Schema.String,
   size: Schema.Number
+})
+
+const presignPartResponseSchema = Schema.Struct({
+  url: Schema.String,
+  partNumber: Schema.Number,
+  expiresInSeconds: Schema.Number
 })
 
 const multipartStatusResponseSchema = Schema.Struct({
@@ -111,6 +123,9 @@ export const parseInitResponse = (raw: unknown): MultipartInitResponse =>
 
 export const parsePartResponse = (raw: unknown): MultipartPartResponse =>
   Schema.decodeUnknownSync(multipartPartResponseSchema)(raw)
+
+export const parsePresignPartResponse = (raw: unknown): PresignPartResponse =>
+  Schema.decodeUnknownSync(presignPartResponseSchema)(raw)
 
 export const parseStatusResponse = (raw: unknown): MultipartStatusResponse => {
   const decoded = Schema.decodeUnknownSync(multipartStatusResponseSchema)(raw)

--- a/apps/www/src/services/resumable-upload/service.ts
+++ b/apps/www/src/services/resumable-upload/service.ts
@@ -12,7 +12,7 @@ import {
   parseAbortResponse,
   parseCompleteResponse,
   parseInitResponse,
-  parsePartResponse,
+  parsePresignPartResponse,
   parseStatusResponse,
   splitFileIntoChunks,
   withUpdatedPart
@@ -172,32 +172,77 @@ const fetchStatus = (
   )
 }
 
+const presignPart = (
+  working: PersistedResumableUpload,
+  partNumber: number,
+  signal: AbortSignal
+): Effect.Effect<{ url: string }, ResumableUploadError, never> =>
+  retryableJsonRequest(
+    apiUrl('/upload/multipart/presign-part'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: working.key, uploadId: working.uploadId, partNumber }),
+      signal
+    },
+    parsePresignPartResponse,
+    'presign-part',
+    INIT_RETRY_TIMES
+  )
+
+// PUTs the raw part body straight to S3 using the presigned URL -- bypasses
+// API Gateway/VPS entirely for the heavy bytes (see apps/vps/src/http/
+// upload.handlers.ts's presignMultipartPart and PR #130's band-aid this
+// replaces). No credentials/cookies on this request: the presigned URL's
+// signature is the only auth, so this intentionally does not go through
+// httpRequest's credentials: 'include' default.
+const putPartToS3 = (
+  url: string,
+  blob: Blob,
+  signal: AbortSignal
+): Effect.Effect<string, NetworkError | HttpError | InvalidResponseError | UploadAborted, never> =>
+  Effect.tryPromise({
+    try: () => fetch(url, { method: 'PUT', body: blob, signal }),
+    catch: (cause) => {
+      if (signal.aborted) return new UploadAborted()
+      if (cause instanceof Error && cause.name === 'AbortError') return new UploadAborted()
+      return new NetworkError({
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause
+      })
+    }
+  }).pipe(
+    Effect.flatMap((response) => {
+      if (!response.ok) {
+        return Effect.fail(
+          new HttpError({
+            status: response.status,
+            message: `HTTP ${response.status} ${response.statusText}`.trim()
+          })
+        )
+      }
+      const etag = response.headers.get('ETag')
+      if (!etag) {
+        return Effect.fail(
+          new InvalidResponseError({ message: 'part: S3 response missing ETag header' })
+        )
+      }
+      return Effect.succeed(etag)
+    })
+  )
+
 const uploadPart = (
   working: PersistedResumableUpload,
   part: { partNumber: number; blob: Blob },
   signal: AbortSignal
-): Effect.Effect<ResumablePart, ResumableUploadError, never> => {
-  const formData = new FormData()
-  formData.append('key', working.key)
-  formData.append('uploadId', working.uploadId)
-  formData.append('partNumber', String(part.partNumber))
-  formData.append('chunk', part.blob, `part-${part.partNumber}`)
-
-  return Effect.gen(function* () {
+): Effect.Effect<ResumablePart, ResumableUploadError, never> =>
+  Effect.gen(function* () {
     if (signal.aborted) return yield* new UploadAborted()
 
-    const response = yield* httpRequest(apiUrl('/upload/multipart/part'), {
-      method: 'POST',
-      body: formData,
-      signal
-    })
+    const { url } = yield* presignPart(working, part.partNumber, signal)
+    const etag = yield* putPartToS3(url, part.blob, signal)
 
-    const raw = yield* Effect.tryPromise({
-      try: () => response.json(),
-      catch: () => new InvalidResponseError({ message: 'part: failed to parse JSON' })
-    })
-
-    return decodeOrFail(parsePartResponse, raw, 'part')
+    return { partNumber: part.partNumber, etag, size: part.blob.size }
   }).pipe(
     Effect.retry({
       schedule: Schedule.exponential(`${PART_RETRY_BASE_MS} millis`),
@@ -205,7 +250,6 @@ const uploadPart = (
       while: (error) => isRetryableError(error) && !signal.aborted
     })
   )
-}
 
 const completeUpload = (
   working: PersistedResumableUpload,

--- a/apps/www/src/services/resumable-upload/service.ts
+++ b/apps/www/src/services/resumable-upload/service.ts
@@ -231,6 +231,19 @@ const putPartToS3 = (
     })
   )
 
+// A 403 from the S3 PUT can only mean the presigned URL expired (its
+// 15-minute TTL elapsed on a slow or backgrounded-tab upload) -- the URL's
+// signature is the sole auth on that request, nothing else in this codebase
+// grants or denies S3 access per-request. presignPart's own errors never
+// carry status 403 (our AuthMiddleware fails with 401, ownership/validation
+// failures are 400), so this predicate can't be confused with a real auth
+// failure on our own API. isRetryableError intentionally leaves generic 403
+// non-retryable for every other endpoint in this file (a real auth failure
+// there should fail fast) -- this is scoped to uploadPart's own retry so
+// that distinction elsewhere stays intact.
+const isRetryablePartUploadError = (error: ResumableUploadError): boolean =>
+  isRetryableError(error) || (error._tag === 'HttpError' && error.status === 403)
+
 const uploadPart = (
   working: PersistedResumableUpload,
   part: { partNumber: number; blob: Blob },
@@ -239,6 +252,8 @@ const uploadPart = (
   Effect.gen(function* () {
     if (signal.aborted) return yield* new UploadAborted()
 
+    // Always re-presigns before PUTting: if the previous attempt failed
+    // because the URL expired, this mints a fresh one before retrying.
     const { url } = yield* presignPart(working, part.partNumber, signal)
     const etag = yield* putPartToS3(url, part.blob, signal)
 
@@ -247,7 +262,7 @@ const uploadPart = (
     Effect.retry({
       schedule: Schedule.exponential(`${PART_RETRY_BASE_MS} millis`),
       times: MAX_PART_ATTEMPTS,
-      while: (error) => isRetryableError(error) && !signal.aborted
+      while: (error) => isRetryablePartUploadError(error) && !signal.aborted
     })
   )
 

--- a/apps/www/src/services/resumable-upload/service.ts
+++ b/apps/www/src/services/resumable-upload/service.ts
@@ -203,7 +203,7 @@ const putPartToS3 = (
 ): Effect.Effect<string, NetworkError | HttpError | InvalidResponseError | UploadAborted, never> =>
   Effect.tryPromise({
     try: () => fetch(url, { method: 'PUT', body: blob, signal }),
-    catch: (cause) => {
+    catch: (cause): NetworkError | UploadAborted => {
       if (signal.aborted) return new UploadAborted()
       if (cause instanceof Error && cause.name === 'AbortError') return new UploadAborted()
       return new NetworkError({
@@ -212,7 +212,7 @@ const putPartToS3 = (
       })
     }
   }).pipe(
-    Effect.flatMap((response) => {
+    Effect.flatMap((response): Effect.Effect<string, HttpError | InvalidResponseError, never> => {
       if (!response.ok) {
         return Effect.fail(
           new HttpError({

--- a/docs/migration-effect-http-api-process.md
+++ b/docs/migration-effect-http-api-process.md
@@ -454,7 +454,8 @@ that's been silently corrected is easy to repeat:
   actually numeric -- multipart/form-data fields always arrive as strings,
   confirmed against `Multipart.toPersisted`'s real source (`part.value` is
   never coerced).** PR #187's first draft used plain `Schema.Number` for
-  `UploadMultipartPartInput.partNumber`, which genuinely rejects every real
+  the multipart-part-upload endpoint's `partNumber` field (at the time named
+  `UploadMultipartPartInput.partNumber`), which genuinely rejects every real
   request (the client sends `String(part.partNumber)`). This is the exact
   same class of bug as every other multipart/query numeric field in this
   package (`audio.ts`, `label.ts`, `post.ts`, `release.ts`, `shows.ts`,
@@ -481,11 +482,25 @@ that's been silently corrected is easy to repeat:
   `Schema.NumberFromString`, re-verified with three explicit chained
   same-origin requests (init/part/complete) each showing a real 200 and a
   real response body, and pinned with a new `packages/api/src/upload.test.ts`
-  decoding the extracted `PartNumberFromString` schema directly (the full
-  `UploadMultipartPartInput` struct can't be unit-tested end-to-end without
-  a real multipart runtime, since `Multipart.PersistedFile`'s identity check
-  isn't constructible from a plain object outside `effect`'s own internals
-  -- a real, disclosed test-coverage gap, not a false sense of security).
+  decoding the extracted part-number schema (at the time named
+  `PartNumberFromString`) directly (the full multipart-part-upload payload
+  struct couldn't be unit-tested end-to-end without a real multipart
+  runtime, since `Multipart.PersistedFile`'s identity check isn't
+  constructible from a plain object outside `effect`'s own internals -- a
+  real, disclosed test-coverage gap, not a false sense of security).
+  **Update (PR #220, `feat/131-presigned-multipart-part-upload`):** the
+  multipart/form-data proxy endpoint this whole entry describes
+  (`uploadMultipartPart`, `UploadMultipartPartInput`, `PartNumberFromString`)
+  no longer exists. Part bytes now go straight from the browser to S3 via a
+  presigned URL (`presignMultipartPart` in `packages/api/src/upload.ts`,
+  JSON body, `PartNumber` on `Schema.Number` -- no `NumberFromString`
+  involved since there's no multipart/form-data on this path anymore). The
+  lesson above about multipart/form-data fields always arriving as strings
+  still applies to every remaining `.pipe(HttpApiSchema.asMultipart())`
+  payload in this package; it just no longer applies to part uploads
+  specifically. `packages/api/src/upload.test.ts` was updated accordingly to
+  cover the current `InitMultipartUploadInput`/`CompleteMultipartUploadInput`
+  schemas instead of the removed one.
 - **A commit's own message claiming code is "dead, already superseded" is a
   claim to verify, not a fact to trust -- it was wrong once in this
   migration, and stayed wrong for two steps before anyone checked.** Commit

--- a/infra/bucket.ts
+++ b/infra/bucket.ts
@@ -2,10 +2,30 @@ import { domain } from './dns'
 
 const isDevStage = $app.stage === 'dev'
 
+// Browser PUTs multipart part bytes directly to this bucket via presigned
+// UploadPartCommand URLs (see apps/vps/src/http/upload.handlers.ts's
+// presignMultipartPart) -- scoped to the real deployed web origins rather
+// than sst.aws.Bucket's own default of allowOrigins: ["*"], since the
+// presigned URL itself is the only auth on that PUT.
+const contentBucketCorsOrigins = [
+  'http://127.0.0.1:5173',
+  'http://localhost:4173',
+  'https://www.goosebumps.fm',
+  'https://goosebumps.fm',
+  `https://${domain}`
+]
+
 export const contentBucket = isDevStage
   ? sst.aws.Bucket.get('User_Content', 'gbfm-prod-usercontentbucket-cohrefob')
   : new sst.aws.Bucket('User_Content', {
-      access: 'cloudfront'
+      access: 'cloudfront',
+      cors: {
+        allowOrigins: contentBucketCorsOrigins,
+        allowMethods: ['PUT'],
+        allowHeaders: ['*'],
+        exposeHeaders: ['ETag'],
+        maxAge: '1 hour'
+      }
     })
 
 // QR PDFs are temporary — expire them via S3 lifecycle instead of a polling cron job

--- a/packages/api/src/upload.test.ts
+++ b/packages/api/src/upload.test.ts
@@ -1,38 +1,8 @@
 import { Exit, Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
-import {
-  CompleteMultipartUploadInput,
-  InitMultipartUploadInput,
-  PartNumberFromString
-} from './upload'
+import { CompleteMultipartUploadInput, InitMultipartUploadInput } from './upload'
 
 describe('upload API contract', () => {
-  it('decodes partNumber from a string, matching multipart/form-data field decoding', () => {
-    // multipart/form-data fields always arrive as strings -- the resumable
-    // upload client (apps/www/src/services/resumable-upload/service.ts) sends
-    // String(part.partNumber). A plain Schema.Number for
-    // UploadMultipartPartInput.partNumber would reject every real request;
-    // this pins the NumberFromString requirement directly (rather than
-    // through the full multipart struct, which needs a real
-    // Multipart.PersistedFile instance to satisfy `chunk` and can't be
-    // faked with a plain object) so it can't silently regress.
-    expect(Schema.decodeUnknownSync(PartNumberFromString)('1')).toBe(1)
-  })
-
-  it('rejects a partNumber outside 1-10000', () => {
-    const tooLow = Schema.decodeUnknownExit(PartNumberFromString)('0')
-    const tooHigh = Schema.decodeUnknownExit(PartNumberFromString)('10001')
-
-    expect(Exit.isFailure(tooLow)).toBe(true)
-    expect(Exit.isFailure(tooHigh)).toBe(true)
-  })
-
-  it('rejects a non-integer partNumber', () => {
-    const result = Schema.decodeUnknownExit(PartNumberFromString)('1.5')
-
-    expect(Exit.isFailure(result)).toBe(true)
-  })
-
   it('rejects a non-audio content type on multipart init', () => {
     const result = Schema.decodeUnknownExit(InitMultipartUploadInput)({
       fileName: 'test.mp3',

--- a/packages/api/src/upload.ts
+++ b/packages/api/src/upload.ts
@@ -78,6 +78,18 @@ export const UploadMultipartPartResponse = Schema.Struct({
   size: Schema.Number.pipe(Schema.check(Schema.isGreaterThanOrEqualTo(0)))
 })
 
+export const PresignMultipartPartInput = Schema.Struct({
+  key: Schema.NonEmptyString,
+  uploadId: Schema.NonEmptyString,
+  partNumber: PartNumber
+})
+
+export const PresignMultipartPartResponse = Schema.Struct({
+  url: Schema.NonEmptyString,
+  partNumber: PartNumber,
+  expiresInSeconds: Schema.Number
+})
+
 const CompletedPart = Schema.Struct({
   partNumber: PartNumber,
   etag: Schema.NonEmptyString
@@ -134,6 +146,19 @@ export const UploadGroup = HttpApiGroup.make('upload')
     HttpApiEndpoint.post('uploadMultipartPart', '/api/upload/multipart/part', {
       payload: UploadMultipartPartInput,
       success: UploadMultipartPartResponse,
+      error: HttpApiError.BadRequest
+    }).middleware(AuthMiddleware)
+  )
+  .add(
+    // Browser PUTs the raw part body directly to S3 with this URL --
+    // bypasses API Gateway/VPS entirely for the heavy bytes, removing the
+    // 10 MiB API Gateway ceiling that forced CHUNK_SIZE down to 8 MiB (see
+    // PR #130). uploadMultipartPart above is kept as-is (not removed) so
+    // any in-flight/paused upload whose localStorage checkpoint predates
+    // this deploy can still complete via the old proxy path.
+    HttpApiEndpoint.post('presignMultipartPart', '/api/upload/multipart/presign-part', {
+      payload: PresignMultipartPartInput,
+      success: PresignMultipartPartResponse,
       error: HttpApiError.BadRequest
     }).middleware(AuthMiddleware)
   )

--- a/packages/api/src/upload.ts
+++ b/packages/api/src/upload.ts
@@ -33,18 +33,6 @@ export const PartNumber = Schema.Number.pipe(
   Schema.check(Schema.isInt(), Schema.isBetween({ minimum: 1, maximum: 10000 }))
 )
 
-// multipart/form-data fields always decode to strings (confirmed against
-// Multipart.toPersisted's real source -- part.value is never coerced), so
-// the one partNumber field carried inside a multipart body (below) needs
-// NumberFromString like every other multipart/query numeric field in this
-// package (audio.ts, label.ts, post.ts, ...); PartNumber above stays plain
-// Schema.Number for the JSON-body/response use sites where the value really
-// is a number on the wire. Exported so upload.test.ts can pin this without
-// needing a real Multipart.PersistedFile to satisfy the rest of the struct.
-export const PartNumberFromString = Schema.NumberFromString.pipe(
-  Schema.check(Schema.isInt(), Schema.isBetween({ minimum: 1, maximum: 10000 }))
-)
-
 export const InitMultipartUploadInput = Schema.Struct({
   fileName: Schema.NonEmptyString.pipe(Schema.check(Schema.isMaxLength(255))),
   // Matches the old regex(/^audio\//) constraint -- multipart upload is
@@ -60,22 +48,6 @@ export const InitMultipartUploadResponse = Schema.Struct({
   uploadId: Schema.String,
   key: Schema.String,
   chunkSize: Schema.Number
-})
-
-// Raw binary chunk + control fields as multipart/form-data, matching the old
-// Hono route's shape (apps/www's resumable-upload service sends a FormData
-// body with key/uploadId/partNumber/chunk, unchanged by this port).
-export const UploadMultipartPartInput = Schema.Struct({
-  key: Schema.NonEmptyString,
-  uploadId: Schema.NonEmptyString,
-  partNumber: PartNumberFromString,
-  chunk: Multipart.SingleFileSchema
-}).pipe(HttpApiSchema.asMultipart())
-
-export const UploadMultipartPartResponse = Schema.Struct({
-  partNumber: PartNumber,
-  etag: Schema.NonEmptyString,
-  size: Schema.Number.pipe(Schema.check(Schema.isGreaterThanOrEqualTo(0)))
 })
 
 export const PresignMultipartPartInput = Schema.Struct({
@@ -143,19 +115,12 @@ export const UploadGroup = HttpApiGroup.make('upload')
     }).middleware(AuthMiddleware)
   )
   .add(
-    HttpApiEndpoint.post('uploadMultipartPart', '/api/upload/multipart/part', {
-      payload: UploadMultipartPartInput,
-      success: UploadMultipartPartResponse,
-      error: HttpApiError.BadRequest
-    }).middleware(AuthMiddleware)
-  )
-  .add(
     // Browser PUTs the raw part body directly to S3 with this URL --
     // bypasses API Gateway/VPS entirely for the heavy bytes, removing the
     // 10 MiB API Gateway ceiling that forced CHUNK_SIZE down to 8 MiB (see
-    // PR #130). uploadMultipartPart above is kept as-is (not removed) so
-    // any in-flight/paused upload whose localStorage checkpoint predates
-    // this deploy can still complete via the old proxy path.
+    // PR #130). The old multipart/form-data proxy endpoint that used to
+    // live at this spot (uploadMultipartPart, /api/upload/multipart/part)
+    // has been removed -- this is now the only way part bytes reach S3.
     HttpApiEndpoint.post('presignMultipartPart', '/api/upload/multipart/presign-part', {
       payload: PresignMultipartPartInput,
       success: PresignMultipartPartResponse,


### PR DESCRIPTION
## Summary

Closes #131 (partially — see "What's out of scope" below; this PR ships the core mechanism the rest of #131 depends on).

The audio uploader's part bytes currently pass through API Gateway and the VPS before `UploadPartCommand`, which forced `CHUNK_SIZE` down to 8 MiB to stay under API Gateway's 10 MiB request body limit (PR #130, a band-aid). This PR removes that bottleneck for the multipart part-upload step:

- **VPS keeps owning** `initMultipartUpload` (CreateMultipartUpload), `completeMultipartUpload`, `abortMultipartUpload`, and `multipartUploadStatus` — auth, ownership checks, expected-size derivation from the object key, and DB/bookkeeping semantics are unchanged.
- **New endpoint** `POST /api/upload/multipart/presign-part` (`presignMultipartPart`) returns a short-lived presigned S3 `UploadPartCommand` URL after the same ownership + expected-size validation the old part-upload handler already did.
- **Browser PUTs part bytes directly to S3** using that URL instead of routing them through the VPS as multipart/form-data. API Gateway and the VPS no longer see the heavy bytes at all.
- **The legacy `uploadMultipartPart` proxy endpoint (`POST /api/upload/multipart/part`) has been removed**, not just deprecated — see design decision #1 below.
- **S3 bucket CORS** (`infra/bucket.ts`, `contentBucket`) is now explicit: `allowOrigins` scoped to the real deployed web origins, `PUT`, and `exposeHeaders: ['ETag']` (previously relied on `sst.aws.Bucket`'s implicit default of `allowOrigins: ["*"]`, which is broader than necessary since the presigned URL's signature is the only auth on that request).
- **Frontend** (`apps/www/src/services/resumable-upload/service.ts`): `uploadPart` now does presign-then-PUT instead of building `FormData` and POSTing through the VPS. The retry/pause/resume/local-checkpoint state machine is untouched — same `PersistedResumableUpload` shape, same checkpoint writes, same missing-part reconciliation via `multipartUploadStatus`.

## Design decisions

1. **Legacy `uploadMultipartPart` proxy endpoint has been removed, not kept.** The endpoint (`POST /api/upload/multipart/part`), its request/response schemas (`UploadMultipartPartInput`/`UploadMultipartPartResponse`, `PartNumberFromString` in `packages/api/src/upload.ts`), the VPS handler and its `MAX_CHUNK_SIZE` constant (`apps/vps/src/http/upload.handlers.ts`), the underlying `S3Service.uploadMultipartPart` (`apps/vps/src/services/s3.service.ts`), and the dead client-side `parsePartResponse`/`MultipartPartResponse` parser (`apps/www/src/lib/upload/resumable-upload.ts`) are all deleted. Tests exercising the old endpoint (`routes.blackbox.test.ts`'s 401 case, `resumable-upload.test.ts`'s `parsePartResponse` case, `upload.test.ts`'s `PartNumberFromString` decode cases) are deleted rather than left pointing at removed code. `apps/www/src/services/resumable-upload/service.ts` already only calls `presign-part` (confirmed the only caller), so no frontend code path references the old endpoint. This was originally shipped as "kept, not removed" to avoid stranding in-flight uploads with pre-deploy `localStorage` checkpoints, but per review feedback this repo does the move straight away rather than carrying a migration/deprecation period for a low-traffic, non-critical-path endpoint.
2. **Presigned URL expiry: 15 minutes** (`PRESIGNED_PART_URL_EXPIRY_SECONDS` in `apps/vps/src/http/upload.handlers.ts`). Comfortably covers an 8 MiB part PUT on a slow connection with headroom for a retry or two before the URL goes stale, while still bounding how long a leaked URL (e.g. via logs, browser devtools, a compromised extension) stays usable. Raised from an initial 5-minute guess after review feedback that 5 minutes was too tight for real-world upload speeds on files up to 200 MB.
3. **Per-part presigning, not whole-object.** Matches the existing multipart architecture (init/part/complete already assumes per-part upload with reconciliation via `ListPartsCommand`), so this only swaps *how* each part's bytes reach S3, not the overall shape.
4. **S3 CORS `allowOrigins`** is a hardcoded list mirroring the VPS's own existing `ALLOWED_ORIGINS` in `apps/vps/src/http/global-middleware.ts` plus the stage's own domain, rather than reusing that list directly — infra config (`infra/bucket.ts`) and the runtime CORS middleware are different layers with no existing shared source of truth for origins in this repo, and I didn't want to introduce a new cross-cutting import for a security-relevant list without more explicit sign-off.

## What's out of scope in this PR (and why)

Issue #131 asks for considerably more than the part-upload transport mechanism:

- **Images migrated to the direct-to-S3 authenticated path** — the issue's "Current state" notes images still use the unauthenticated `/api/upload/file` proxy. Not touched here; same endpoint, same behavior.
- **Persisted upload-asset lifecycle** (`pending` / `uploaded` / `attached` / `expired` DB table) — no DB schema or migration is included. The current flow still derives everything from the S3 key/metadata, same as before.
- **30-day orphan cleanup** for unattached assets — not implemented.
- **The "Far End proof" manual production pilot** — uploading a real episode through the deployed app and manually verifying draft visibility rules (owner/admin can see it, public/anonymous cannot, it survives reload, publishes without re-upload). **I could not do this.** I have no deployed environment, no production credentials, and no browser session against the live app from this sandbox. This needs to be done by a human (or an agent with real access) after this PR (or a follow-up covering the remaining scope) is deployed.

Given the size of the full issue and that this is the highest-risk of the work in flight today (live production media upload path, real users), I judged it safer to ship the well-defined transport-layer fix as its own reviewable PR rather than bundle in DB schema changes, an authorization model change, and a production manual test I can't actually perform. Recommend keeping #131 open (or filing a narrower follow-up issue) to track the remaining scope: image migration, asset lifecycle table, cleanup job, and the Far End pilot.

## What was tested vs not tested

**Verified with a real typecheck and test run in this update** (a working `bun install` was achieved via per-workspace installs — `bun install --filter='@gbfm/vps'`, `--filter='@gbfm/www'`, `--filter='@gbfm/api'` — after a full monorepo `bun install` still exceeded this sandbox's memory budget):
- `bun run typecheck` passes for `@gbfm/vps`, `@gbfm/api`, `@gbfm/www`, and every other workspace **except** the unrelated `@gbfm/mobile` (pre-existing, missing `nativewind`/`expo` type packages in this sandbox, nothing to do with uploads). `@gbfm/www` previously failed with two type errors in `apps/www/src/services/resumable-upload/service.ts`'s `putPartToS3` (an `Effect.tryPromise`/`Effect.flatMap` error-channel inference issue: TypeScript doesn't union return types across multiple `return` statements in a contextually-typed callback the way it does for a single expression, so the generic error channel collapsed to `unknown`). Fixed by adding explicit return-type annotations to the `catch` and `flatMap` callbacks — no behavior change, no type assertions.
- `apps/vps` unit tests (`bun run test:unit`): all upload-related tests pass, including `upload.handlers.test.ts` (10/10) and the `upload (HttpApiBuilder group, Step 7)` block in `routes.blackbox.test.ts` (all endpoints, including the new `presign-part` 401 case, pass; the deleted legacy-endpoint case is gone, not failing). 35 unrelated tests fail across `audio.service.test.ts` and other `routes.blackbox.test.ts` sections (music/search/profile/resolve/newsletter/site-routes) — all of these hit a real Postgres connection (`db.insert(user)...`) that isn't available in this sandbox; this is a pre-existing environment gap, not something this PR's changes touch.
- `apps/www` unit tests (`bun run test:unit`): 19/19 files, 136/136 tests pass, including the updated `resumable-upload.test.ts` with the legacy `parsePartResponse` case removed.
- `packages/api` tests (`bun run test`): 4/4 files, 27/27 tests pass, including the updated `upload.test.ts` with the legacy `PartNumberFromString` cases removed.
- Confirmed via repo-wide grep that no remaining code (production or test) references the removed `uploadMultipartPart` handler, `/api/upload/multipart/part` route, `UploadMultipartPartInput`/`Response`, `PartNumberFromString`, `MAX_CHUNK_SIZE`, or `parsePartResponse`/`MultipartPartResponse`.
- Traced every call site of the presign-part flow in `apps/www/src` — confirmed `apps/www/src/services/resumable-upload/service.ts` is the only caller of `/api/upload/multipart/presign-part`, and it was already fully on this path before this update (no legacy call site existed to remove on the frontend).
- Confirmed `@aws-sdk/s3-request-presigner` is already an `apps/vps` dependency (unused until this PR), so no new package was added.
- Confirmed via SST's own source (`sst/platform/src/components/aws/bucket.ts`) that `contentBucket` is created fresh (not `.get()`-referenced) on every non-dev stage including `prod`, so the new CORS config will actually apply to the real bucket on next deploy.

**Could not verify — environment limitation, not a design gap:**
- **No real AWS/S3 credentials or deployed environment available** — the actual presigned-URL round-trip (VPS signs a URL, browser PUTs to real S3, ETag comes back, CORS preflight succeeds against the real bucket) has not been exercised end-to-end anywhere.
- **No live Postgres available in this sandbox** — the DB-dependent portion of `apps/vps`'s test suite (music/search/profile/audio-service/site-routes, all pre-existing and unrelated to uploads) could not be run to completion; see above.
- The Far End manual pilot described in the issue (not attempted, see above).

## Risks / open questions for human review

1. ~~`apps/www`'s pre-existing type errors in `putPartToS3`~~ **Fixed.** (`service.ts` lines ~204 and ~215 had an `Effect.tryPromise`/`catch` error-channel inference mismatch — explicit return-type annotations on the `catch` and `flatMap` callbacks resolved it.) `bun run typecheck` now passes for `apps/www`.
2. **CORS change to `contentBucket` needs a real deploy to verify.** `sst deploy --stage prod` (or a preview/dev-stage deploy against a scratch bucket) should be used to confirm the CORS preflight actually succeeds from `https://goosebumps.fm` before this reaches real users, and that I got the SST `cors` API shape right (based on reading SST's own source, not a live deploy).
3. **The rest of #131 is unaddressed** — recommend explicit tracking (keep #131 open scoped down, or a new issue) for images, the asset lifecycle table, 30-day cleanup, and the Far End pilot.
4. **This PR removes the legacy part-upload endpoint outright.** Any upload that was paused before this deploys and has a `PersistedResumableUpload` checkpoint in `localStorage` pointing at the old flow will fail to resume post-deploy (the checkpoint's `uploadId`/`key` are still valid against S3, but the client always calls `presign-part` now, which was already true before this change since the frontend never had a code path back to the old endpoint — the risk here is purely about any *other*, not-yet-updated client build still in a user's browser tab calling the now-410/404 `/api/upload/multipart/part` route directly). Given this app's low concurrent in-flight-upload volume, this was accepted as a reasonable tradeoff per review feedback rather than carrying a deprecation period.

## Test plan (for reviewer / before merge)

- [x] `bun run typecheck` passes for `apps/vps`, `packages/api`, and `apps/www` (the `putPartToS3` inference issue in Risks #1 is now fixed)
- [x] `apps/vps` test suite passes for all upload-related tests (`bun run test:unit`); DB-dependent unrelated tests could not run in this sandbox (no Postgres available)
- [x] `apps/www` test suite passes (`bun run test:unit`, 136/136)
- [ ] Deploy to a non-prod stage and confirm a real multipart upload (init → presign-part → PUT to S3 → complete) succeeds end-to-end from a browser, including a pause/reload/resume cycle
- [ ] Confirm CORS preflight succeeds for the real deployed web origin against the real S3 bucket
- [ ] After deploy, complete the Far End draft pilot described in the issue

