### PR TITLE
chore(vps): remove temporary sentry migration diagnostics

### DIFF
--- a/apps/vps/src/instrument.ts
+++ b/apps/vps/src/instrument.ts
@@ -44,6 +44,4 @@ if (enabled) {
       return hasLocalSentryContext(event) ? null : event
     }
   })
-
-  console.warn(`[sentry] preload init env=${environment} traces=1`)
 }

--- a/apps/vps/src/services/sentry-client.service.ts
+++ b/apps/vps/src/services/sentry-client.service.ts
@@ -28,9 +28,6 @@ export const SentryClientServiceLive = Layer.effect(
 
     const existingClient = Sentry.getClient()
     if (existingClient) {
-      yield* Effect.sync(() => {
-        console.warn(`[sentry] client already initialized env=${sentry.environment}`)
-      })
       return { client: existingClient, enabled: true }
     }
 
@@ -59,10 +56,6 @@ export const SentryClientServiceLive = Layer.effect(
           await Sentry.close(2000)
         })
     )
-
-    yield* Effect.sync(() => {
-      console.warn(`[sentry] init env=${sentry.environment} traces=1`)
-    })
 
     if (debugSentry) {
       yield* Effect.sync(() => {


### PR DESCRIPTION
## Summary
Partial cleanup for #110. Removes the temporary console diagnostics that were added to verify the Bun preload Sentry migration:
- `[sentry] preload init ...` in `apps/vps/src/instrument.ts`
- `[sentry] client already initialized ...` in `apps/vps/src/services/sentry-client.service.ts`
- `[sentry] init env=... traces=1` in the same file (same category, added in the same migration commit)

## What was intentionally NOT done, and why

Issue #110 also asked to remove `apps/vps/src/lib/otel.ts`, on the premise that it was dead code superseded by the Bun preload Sentry init. That premise no longer holds:

- `otel.ts` exports `OtlpLive`, which is currently **imported and wired into `AppLayer`** in `apps/vps/src/runtime/services.ts` (line 51).
- It was deliberately reintroduced on 2026-07-11 in `732e625a` ("wire OtlpLive into AppLayer to export traces"), over a month after this issue was filed, specifically because it "was fully implemented ... but never added to AppLayer, so no traces ever left the process." A same-day follow-up (`3a59df8a`) added motel dev-trace dual-export on top of it.
- `otel.ts` currently provides things `instrument.ts` does not: the `SentrySpanProcessor`/`SentrySampler` bridge, OTLP collector export gated on `OTEL_EXPORTER_OTLP_ENDPOINT`, and local dev/agent trace export to motel.

Deleting it now would remove live, currently-relied-upon tracing infrastructure, not dead code. I'm leaving `otel.ts`, the `otel` block in `config.service.ts`, and the OTel env vars in place and flagging this back on the issue rather than guessing.

Also checked `@sentry/node-core`: it is **not** a direct dependency of `apps/vps/package.json` in the current tree (only a transitive dep of `@sentry/node`, which isn't imported anywhere in this repo) — nothing to remove there.

## Verification
- `bun run typecheck` in `apps/vps`: same error set before/after (pre-existing, unrelated failure in `reminder-processor.ts` from environment dependency drift, not introduced by this change)
- `bun run test:unit` in `apps/vps`: identical pass/fail counts before/after (198 passed / 35 pre-existing failures / 5 skipped)
- oxlint/oxfmt clean on both changed files
- Smoke-tested `bun --preload ./src/instrument.ts` directly (with stubbed SST resource env vars) through both the Sentry-disabled and Sentry-enabled code paths — runs cleanly with no throw, confirming the removed log statements had no downstream effect

Closes #110