### PR TITLE
chore(vps): rename *ServiceLive exports to *ServiceLayer

### DIFF
--- a/apps/vps/scripts/migrate-mixes-to-main-show.ts
+++ b/apps/vps/scripts/migrate-mixes-to-main-show.ts
@@ -39,7 +39,7 @@ interface MigrationServiceShape {
 const DatabaseService = Context.Service<DatabaseServiceShape>('DatabaseService')
 const MigrationService = Context.Service<MigrationServiceShape>('MigrationService')
 
-const DatabaseServiceLive = Layer.effect(
+const DatabaseServiceLayer = Layer.effect(
   DatabaseService,
   Effect.gen(function* () {
     if (!process.env.PROD_DB_URL) {
@@ -99,7 +99,7 @@ const DatabaseServiceLive = Layer.effect(
   })
 )
 
-const MigrationServiceLive = Layer.effect(
+const MigrationServiceLayer = Layer.effect(
   MigrationService,
   Effect.gen(function* () {
     return {
@@ -177,7 +177,7 @@ const program = Effect.gen(function* () {
   return yield* migration.migrateMixesToMainShow()
 })
 
-const MainLayer = Layer.mergeAll(DatabaseServiceLive, MigrationServiceLive)
+const MainLayer = Layer.mergeAll(DatabaseServiceLayer, MigrationServiceLayer)
 
 Effect.runPromise(
   program.pipe(

--- a/apps/vps/src/examples/runtime-comparison.ts
+++ b/apps/vps/src/examples/runtime-comparison.ts
@@ -16,7 +16,7 @@ const ExpensiveService = Context.Service<ExpensiveService>('ExpensiveService')
 let initCount = 0
 let disposeCount = 0
 
-const ExpensiveServiceLive = Layer.effect(
+const ExpensiveServiceLayer = Layer.effect(
   ExpensiveService,
   Effect.gen(function* () {
     // Simulate expensive initialization (database connections, etc.)
@@ -43,7 +43,7 @@ async function _approachWithoutRuntime() {
 
   // Run 10 times (like your cron job running 10 times)
   for (let i = 0; i < 10; i++) {
-    await Effect.runPromise(myEffect.pipe(Effect.provide(ExpensiveServiceLive)))
+    await Effect.runPromise(myEffect.pipe(Effect.provide(ExpensiveServiceLayer)))
     // Service is created and destroyed EVERY TIME!
   }
 
@@ -64,7 +64,7 @@ async function _approachWithRuntime() {
 
   // Build services ONCE
   const scope = Scope.makeUnsafe()
-  const services = await Effect.runPromise(Layer.buildWithScope(ExpensiveServiceLive, scope))
+  const services = await Effect.runPromise(Layer.buildWithScope(ExpensiveServiceLayer, scope))
 
   // Run 10 times (like your cron job running 10 times)
   for (let i = 0; i < 10; i++) {

--- a/apps/vps/src/lib/mdx.ts
+++ b/apps/vps/src/lib/mdx.ts
@@ -56,7 +56,7 @@ const makeService = (fn: (content: string) => Promise<string>): Effect.Effect<Md
 
 // ── Live layer ────────────────────────────────────────────────────────────────
 
-export const MdxServiceLive: Layer.Layer<MdxService> = Layer.effect(
+export const MdxServiceLayer: Layer.Layer<MdxService> = Layer.effect(
   MdxService,
   makeService(defaultFn)
 )

--- a/apps/vps/src/runtime/services.ts
+++ b/apps/vps/src/runtime/services.ts
@@ -1,64 +1,64 @@
 import { Layer } from 'effect'
-import { MdxServiceLive } from '@/lib/mdx'
+import { MdxServiceLayer } from '@/lib/mdx'
 import { OtlpLive } from '@/lib/otel'
-import { DatabaseServiceLive } from '@/services/database.service'
+import { DatabaseServiceLayer } from '@/services/database.service'
 
-export { DatabaseService, DatabaseServiceLive } from '@/services/database.service'
+export { DatabaseService, DatabaseServiceLayer } from '@/services/database.service'
 
-import { AudioServiceLive } from '@/services/audio.service'
-import { ConfigServiceLive } from '@/services/config.service'
-import { EmailServiceLive } from '@/services/email.service'
-import { FavoriteServiceLive } from '@/services/favorite.service'
+import { AudioServiceLayer } from '@/services/audio.service'
+import { ConfigServiceLayer } from '@/services/config.service'
+import { EmailServiceLayer } from '@/services/email.service'
+import { FavoriteServiceLayer } from '@/services/favorite.service'
 import { AppLoggerLive } from '@/services/logger.service'
-import { MusicEntityServiceLive } from '@/services/music-entity'
-import { MusicLinkScraperServiceLive } from '@/services/music-link-scraper.service'
-import { MusicReminderServiceLive } from '@/services/music-reminder.service'
-import { PostServiceLive } from '@/services/post.service'
-import { ProfileServiceLive } from '@/services/profile.service'
-import { QRCodeServiceLive } from '@/services/qrcode.service'
-import { ReleaseServiceLive } from '@/services/release.service'
-import { ReminderSignalServiceLive } from '@/services/reminder-signal.service'
-import { ResolveServiceLive } from '@/services/resolve.service'
-import { S3ServiceLive } from '@/services/s3.service'
-import { SearchServiceLive } from '@/services/search.service'
-import { SentryServiceLive } from '@/services/sentry.service'
-import { SentryClientServiceLive } from '@/services/sentry-client.service'
-import { ShowServiceLive, ShowSubscriptionServiceLive } from '@/services/show.service'
-import { SpotifyServiceLive } from '@/services/spotify.service'
-import { UserServiceLive } from '@/services/user.service'
+import { MusicEntityServiceLayer } from '@/services/music-entity'
+import { MusicLinkScraperServiceLayer } from '@/services/music-link-scraper.service'
+import { MusicReminderServiceLayer } from '@/services/music-reminder.service'
+import { PostServiceLayer } from '@/services/post.service'
+import { ProfileServiceLayer } from '@/services/profile.service'
+import { QRCodeServiceLayer } from '@/services/qrcode.service'
+import { ReleaseServiceLayer } from '@/services/release.service'
+import { ReminderSignalServiceLayer } from '@/services/reminder-signal.service'
+import { ResolveServiceLayer } from '@/services/resolve.service'
+import { S3ServiceLayer } from '@/services/s3.service'
+import { SearchServiceLayer } from '@/services/search.service'
+import { SentryServiceLayer } from '@/services/sentry.service'
+import { SentryClientServiceLayer } from '@/services/sentry-client.service'
+import { ShowServiceLayer, ShowSubscriptionServiceLayer } from '@/services/show.service'
+import { SpotifyServiceLayer } from '@/services/spotify.service'
+import { UserServiceLayer } from '@/services/user.service'
 
 const DevToolsLive: Layer.Layer<never> = Layer.empty
 
-const SentryClientLive = SentryClientServiceLive.pipe(Layer.provide(ConfigServiceLive))
+const SentryClientLive = SentryClientServiceLayer.pipe(Layer.provide(ConfigServiceLayer))
 
 const BaseServicesLayer = Layer.mergeAll(
-  ConfigServiceLive,
-  DatabaseServiceLive,
-  EmailServiceLive,
-  FavoriteServiceLive,
-  SpotifyServiceLive,
-  MusicReminderServiceLive,
-  ReminderSignalServiceLive,
-  MusicLinkScraperServiceLive,
-  AudioServiceLive.pipe(Layer.provide(MdxServiceLive)),
-  PostServiceLive.pipe(Layer.provide(MdxServiceLive)),
-  ProfileServiceLive,
-  ResolveServiceLive,
-  ReleaseServiceLive,
-  S3ServiceLive,
-  SearchServiceLive,
-  SentryServiceLive.pipe(Layer.provide(SentryClientLive)),
-  OtlpLive.pipe(Layer.provide(SentryClientLive), Layer.provide(ConfigServiceLive)),
-  ShowServiceLive,
-  ShowSubscriptionServiceLive,
-  UserServiceLive,
+  ConfigServiceLayer,
+  DatabaseServiceLayer,
+  EmailServiceLayer,
+  FavoriteServiceLayer,
+  SpotifyServiceLayer,
+  MusicReminderServiceLayer,
+  ReminderSignalServiceLayer,
+  MusicLinkScraperServiceLayer,
+  AudioServiceLayer.pipe(Layer.provide(MdxServiceLayer)),
+  PostServiceLayer.pipe(Layer.provide(MdxServiceLayer)),
+  ProfileServiceLayer,
+  ResolveServiceLayer,
+  ReleaseServiceLayer,
+  S3ServiceLayer,
+  SearchServiceLayer,
+  SentryServiceLayer.pipe(Layer.provide(SentryClientLive)),
+  OtlpLive.pipe(Layer.provide(SentryClientLive), Layer.provide(ConfigServiceLayer)),
+  ShowServiceLayer,
+  ShowSubscriptionServiceLayer,
+  UserServiceLayer,
   DevToolsLive
 )
 
 const ServicesLayer = Layer.mergeAll(
   BaseServicesLayer,
-  QRCodeServiceLive.pipe(Layer.provide(BaseServicesLayer)),
-  MusicEntityServiceLive.pipe(Layer.provide(BaseServicesLayer))
+  QRCodeServiceLayer.pipe(Layer.provide(BaseServicesLayer)),
+  MusicEntityServiceLayer.pipe(Layer.provide(BaseServicesLayer))
 )
 
 export const AppLayer = ServicesLayer.pipe(Layer.provide(AppLoggerLive))

--- a/apps/vps/src/services/audio.service.test.ts
+++ b/apps/vps/src/services/audio.service.test.ts
@@ -5,9 +5,9 @@ import { beforeAll, describe, expect, test } from 'vitest'
 import { db } from '@/db'
 import { audioTable } from '@/db/audio.schema'
 import { user } from '@/db/auth.schema'
-import { MdxServiceLive } from '@/lib/mdx'
+import { MdxServiceLayer } from '@/lib/mdx'
 import { CryptoLive } from '@/lib/crypto'
-import { AudioService, AudioServiceLive, createAudioFingerprint } from './audio.service'
+import { AudioService, AudioServiceLayer, createAudioFingerprint } from './audio.service'
 
 const actorId = `audio-idempotency-${randomUUID()}`
 
@@ -23,7 +23,7 @@ const getService = () =>
   Effect.runPromise(
     Effect.gen(function* () {
       return yield* AudioService
-    }).pipe(Effect.provide(AudioServiceLive.pipe(Layer.provide(MdxServiceLive))))
+    }).pipe(Effect.provide(AudioServiceLayer.pipe(Layer.provide(MdxServiceLayer))))
   )
 
 beforeAll(async () => {

--- a/apps/vps/src/services/audio.service.ts
+++ b/apps/vps/src/services/audio.service.ts
@@ -642,7 +642,7 @@ const trackPlayEffect = (id: string, clientIp?: string) =>
     return { playCount: updated[0]?.playCount ?? 0 }
   })
 
-export const AudioServiceLive = Layer.effect(
+export const AudioServiceLayer = Layer.effect(
   AudioService,
   Effect.gen(function* () {
     const mdx = yield* MdxService

--- a/apps/vps/src/services/config.service.ts
+++ b/apps/vps/src/services/config.service.ts
@@ -209,7 +209,7 @@ export function createConfig(): ConfigService {
 // Create a singleton config instance for synchronous access
 export const config = createConfig()
 
-export const ConfigServiceLive = Layer.effect(
+export const ConfigServiceLayer = Layer.effect(
   ConfigService,
   Effect.sync(() => Schema.decodeUnknownSync(ConfigSchema)(config))
 )

--- a/apps/vps/src/services/database.service.ts
+++ b/apps/vps/src/services/database.service.ts
@@ -7,4 +7,4 @@ export interface DatabaseService {
 
 export const DatabaseService = Context.Service<DatabaseService>('DatabaseService')
 
-export const DatabaseServiceLive = Layer.succeed(DatabaseService, { db })
+export const DatabaseServiceLayer = Layer.succeed(DatabaseService, { db })

--- a/apps/vps/src/services/email.service.ts
+++ b/apps/vps/src/services/email.service.ts
@@ -20,7 +20,7 @@ export interface EmailService {
 export const EmailService = Context.Service<EmailService>('EmailService')
 
 // Implementation
-export const EmailServiceLive = Layer.effect(
+export const EmailServiceLayer = Layer.effect(
   EmailService,
   Effect.gen(function* () {
     return {

--- a/apps/vps/src/services/favorite.service.ts
+++ b/apps/vps/src/services/favorite.service.ts
@@ -479,7 +479,7 @@ const getFavoritesEffect = (
   )
 
 // Implementation - simple layer that provides access to the Effects
-export const FavoriteServiceLive = Layer.succeed(FavoriteService, {
+export const FavoriteServiceLayer = Layer.succeed(FavoriteService, {
   addFavorite: addFavoriteEffect,
   addShowFavorite: addShowFavoriteEffect,
   removeFavorite: removeFavoriteEffect,

--- a/apps/vps/src/services/music-entity/index.ts
+++ b/apps/vps/src/services/music-entity/index.ts
@@ -268,7 +268,7 @@ export interface MusicEntityService {
 
 export const MusicEntityService = Context.Service<MusicEntityService>('MusicEntityService')
 
-export const MusicEntityServiceLive = Layer.effect(
+export const MusicEntityServiceLayer = Layer.effect(
   MusicEntityService,
   Effect.gen(function* () {
     const scraper = yield* MusicLinkScraperServiceTag

--- a/apps/vps/src/services/music-link-scraper.service.ts
+++ b/apps/vps/src/services/music-link-scraper.service.ts
@@ -19,7 +19,7 @@
  *
  * Adding a new provider:
  *   1. Implement MusicDataProvider
- *   2. Add it to the providers array in MusicLinkScraperServiceLive
+ *   2. Add it to the providers array in MusicLinkScraperServiceLayer
  */
 
 import { Context, Data, Effect, Layer, Schema } from 'effect'
@@ -523,7 +523,7 @@ function makeScraperWithProviders(providers: MusicDataProvider[]): MusicLinkScra
 // Live layer — configure which providers are active
 // ---------------------------------------------------------------------------
 
-export const MusicLinkScraperServiceLive = Layer.sync(MusicLinkScraperService, () => {
+export const MusicLinkScraperServiceLayer = Layer.sync(MusicLinkScraperService, () => {
   const providers: MusicDataProvider[] = [new OdesliProvider(), new MusicBrainzProvider()]
 
   const firecrawlKey = process.env.FIRECRAWL_API_KEY

--- a/apps/vps/src/services/music-reminder.service.ts
+++ b/apps/vps/src/services/music-reminder.service.ts
@@ -199,7 +199,7 @@ const deleteEffect = (id: string, userId: string) =>
     })
   })
 
-export const MusicReminderServiceLive = Layer.succeed(MusicReminderService, {
+export const MusicReminderServiceLayer = Layer.succeed(MusicReminderService, {
   create: createEffect,
   getByUserId: getByUserIdEffect,
   update: updateEffect,

--- a/apps/vps/src/services/post.service.ts
+++ b/apps/vps/src/services/post.service.ts
@@ -742,7 +742,7 @@ const updateEffect = (
     return yield* buildPostWithCreators(updatedPost, mdx)
   })
 
-export const PostServiceLive = Layer.effect(
+export const PostServiceLayer = Layer.effect(
   PostService,
   Effect.gen(function* () {
     const mdx = yield* MdxService

--- a/apps/vps/src/services/profile.service.ts
+++ b/apps/vps/src/services/profile.service.ts
@@ -220,7 +220,7 @@ export const getPublicProfileEffect = (username: string) =>
     }
   })
 
-export const ProfileServiceLive = Layer.succeed(ProfileService, {
+export const ProfileServiceLayer = Layer.succeed(ProfileService, {
   getPublicProfile: (username) =>
     getPublicProfileEffect(username).pipe(
       Effect.withSpan('profile.getPublic', { attributes: { username } })

--- a/apps/vps/src/services/qrcode.service.ts
+++ b/apps/vps/src/services/qrcode.service.ts
@@ -320,7 +320,7 @@ const generateShowQRPdfEffect = (show: ShowData, s3Service: S3Service, force?: b
     return { url, cached: false }
   })
 
-export const QRCodeServiceLive = Layer.effect(
+export const QRCodeServiceLayer = Layer.effect(
   QRCodeService,
   Effect.gen(function* () {
     const s3Service = yield* S3Service

--- a/apps/vps/src/services/release.service.ts
+++ b/apps/vps/src/services/release.service.ts
@@ -330,7 +330,7 @@ const deleteEffect = (slug: string, userId: string, userRole: string) =>
     })
   })
 
-export const ReleaseServiceLive = Layer.succeed(ReleaseService, {
+export const ReleaseServiceLayer = Layer.succeed(ReleaseService, {
   getBySlug: (slug) =>
     getBySlugEffect(slug).pipe(Effect.withSpan('release.getBySlug', { attributes: { slug } })),
   getBySlugForEdit: (slug, userId, userRole) =>

--- a/apps/vps/src/services/reminder-signal.service.ts
+++ b/apps/vps/src/services/reminder-signal.service.ts
@@ -9,7 +9,7 @@ export interface ReminderSignalService {
 
 export const ReminderSignalService = Context.Service<ReminderSignalService>('ReminderSignalService')
 
-export const ReminderSignalServiceLive = Layer.effect(
+export const ReminderSignalServiceLayer = Layer.effect(
   ReminderSignalService,
   Effect.gen(function* () {
     // dropping(1): if the loop is already awake, extra signals are discarded

--- a/apps/vps/src/services/resolve.service.ts
+++ b/apps/vps/src/services/resolve.service.ts
@@ -149,7 +149,7 @@ const resolveEffect = (slug: string) =>
     })
   })
 
-export const ResolveServiceLive = Layer.succeed(ResolveService, {
+export const ResolveServiceLayer = Layer.succeed(ResolveService, {
   resolve: (slug) =>
     resolveEffect(slug).pipe(Effect.withSpan('resolve.slug', { attributes: { slug } }))
 })

--- a/apps/vps/src/services/s3.service.ts
+++ b/apps/vps/src/services/s3.service.ts
@@ -583,7 +583,7 @@ const listBucketsEffect = () =>
   )
 
 // Implementation - simple layer (effects are pure functions)
-export const S3ServiceLive = Layer.succeed(S3Service, {
+export const S3ServiceLayer = Layer.succeed(S3Service, {
   uploadFile: uploadFileEffect,
   deleteFile: deleteFileEffect,
   checkExists: checkExistsEffect,

--- a/apps/vps/src/services/search.service.ts
+++ b/apps/vps/src/services/search.service.ts
@@ -132,7 +132,7 @@ const searchEffect = (query: string, limit: number) =>
     return yield* Effect.all({ shows, audio, posts }, { concurrency: 'unbounded' })
   })
 
-export const SearchServiceLive = Layer.succeed(SearchService, {
+export const SearchServiceLayer = Layer.succeed(SearchService, {
   search: (query, limit) =>
     searchEffect(query, limit).pipe(Effect.withSpan('search.search', { attributes: { query } }))
 })

--- a/apps/vps/src/services/sentry-client.service.ts
+++ b/apps/vps/src/services/sentry-client.service.ts
@@ -13,7 +13,7 @@ export interface SentryClientService {
 
 export const SentryClientService = Context.Service<SentryClientService>('SentryClientService')
 
-export const SentryClientServiceLive = Layer.effect(
+export const SentryClientServiceLayer = Layer.effect(
   SentryClientService,
   Effect.gen(function* () {
     const { sentry } = yield* ConfigService

--- a/apps/vps/src/services/sentry.service.ts
+++ b/apps/vps/src/services/sentry.service.ts
@@ -12,7 +12,7 @@ export interface SentryService {
 
 export const SentryService = Context.Service<SentryService>('SentryService')
 
-export const SentryServiceLive = Layer.effect(
+export const SentryServiceLayer = Layer.effect(
   SentryService,
   Effect.gen(function* () {
     const { enabled } = yield* SentryClientService

--- a/apps/vps/src/services/show-subscription.service.ts
+++ b/apps/vps/src/services/show-subscription.service.ts
@@ -217,7 +217,7 @@ const getSubscribersEffect = (showId: string) =>
     return subscribers
   })
 
-export const ShowSubscriptionServiceLive = Layer.succeed(ShowSubscriptionService, {
+export const ShowSubscriptionServiceLayer = Layer.succeed(ShowSubscriptionService, {
   subscribe: (userId, showId) =>
     subscribeEffect(userId, showId).pipe(
       Effect.withSpan('showSubscription.subscribe', {

--- a/apps/vps/src/services/show.service.ts
+++ b/apps/vps/src/services/show.service.ts
@@ -21,7 +21,7 @@ import { requireCreatorOrAdmin } from '@/lib/authorization'
 import { compileMDX, isMDXCompilationResult } from '@/lib/mdx'
 import { createPaginationMetadata, type PaginationMetadata } from '@/lib/pagination'
 
-export { ShowSubscriptionService, ShowSubscriptionServiceLive } from './show-subscription.service'
+export { ShowSubscriptionService, ShowSubscriptionServiceLayer } from './show-subscription.service'
 
 type ShowWithHosts = SelectShow & {
   hosts: Array<{ id: string; name: string }>
@@ -518,7 +518,7 @@ const getEpisodesEffect = (showSlug: string, options: { limit: number; offset: n
     }
   })
 
-export const ShowServiceLive = Layer.succeed(ShowService, {
+export const ShowServiceLayer = Layer.succeed(ShowService, {
   getAll: (options) => getAllEffect(options).pipe(Effect.withSpan('show.getAll')),
   getAllForEdit: (options, userId, userRole) =>
     getAllEffect(options, { userId, userRole }).pipe(Effect.withSpan('show.getAllForEdit')),

--- a/apps/vps/src/services/spotify.service.ts
+++ b/apps/vps/src/services/spotify.service.ts
@@ -517,7 +517,7 @@ const enrichTrackFromUrlWithSpan = Effect.fn('spotify.enrichTrackFromUrl')(funct
   return result
 })
 
-export const SpotifyServiceLive = Layer.succeed(SpotifyService, {
+export const SpotifyServiceLayer = Layer.succeed(SpotifyService, {
   getTrack: getTrackWithSpan,
   getAlbum: getAlbumWithSpan,
   getPlaylist: getPlaylistWithSpan,

--- a/apps/vps/src/services/user.service.ts
+++ b/apps/vps/src/services/user.service.ts
@@ -367,7 +367,7 @@ const updateUserEmailPreferencesEffect = (
   })
 
 // Implementation - simple layer that provides access to the Effects
-export const UserServiceLive = Layer.succeed(UserService, {
+export const UserServiceLayer = Layer.succeed(UserService, {
   getUserById: (userId) =>
     getUserByIdEffect(userId).pipe(Effect.withSpan('user.getById', { attributes: { userId } })),
   searchUsers: (query) =>

--- a/apps/www/src/runtime/index.ts
+++ b/apps/www/src/runtime/index.ts
@@ -3,7 +3,7 @@ import { Effect, Layer, Scope } from 'effect'
 import { env } from '@/env'
 import { getSpotifyRedirectUri } from '@/lib/spotify-pkce'
 import { type Analytics, SentryAnalyticsLayer, NoopAnalyticsLayer } from '@/services/analytics'
-import { type MediaSessionService, MediaSessionServiceLive } from '@/services/media-session'
+import { type MediaSessionService, MediaSessionServiceLayer } from '@/services/media-session'
 import { PlayerStorage, type PersistedQueueType, type PlayerStorageShape } from '@gbfm/player'
 import { PlayerStorageLive } from '@/services/player/storage'
 import { log, type Logger, LoggerLive, NoopLogger } from '@/services/logger'
@@ -31,7 +31,7 @@ const spotifyLayer = Layer.suspend(() =>
 )
 
 const playerStorageLayer = PlayerStorageLive
-const mediaSessionLayer = MediaSessionServiceLive
+const mediaSessionLayer = MediaSessionServiceLayer
 const resumableUploadStorageLayer = ResumableUploadStorageLive
 const mixUploadDraftStorageLayer = MixUploadDraftStorageLive
 const loggerLayer = enableSentry ? LoggerLive : NoopLogger

--- a/apps/www/src/services/media-session.test.ts
+++ b/apps/www/src/services/media-session.test.ts
@@ -2,7 +2,7 @@ import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
 import {
   MediaSessionService,
-  MediaSessionServiceLive,
+  MediaSessionServiceLayer,
   type MediaSessionHandlers
 } from './media-session'
 
@@ -41,7 +41,7 @@ describe('MediaSessionService', () => {
         yield* media.setActionHandlers(handlers)
         yield* media.setPositionState(120, 12)
         yield* media.setActionHandlers(null)
-      }).pipe(Effect.provide(MediaSessionServiceLive), Effect.runPromise)
+      }).pipe(Effect.provide(MediaSessionServiceLayer), Effect.runPromise)
 
       expect(installed.filter((entry) => entry !== null).length).toBeGreaterThanOrEqual(5)
       expect(installed.filter((entry) => entry === null).length).toBeGreaterThanOrEqual(5)
@@ -69,7 +69,7 @@ describe('MediaSessionService', () => {
         yield* media.setPositionState(1, 0)
         yield* media.setActionHandlers(null)
         completed = true
-      }).pipe(Effect.provide(MediaSessionServiceLive), Effect.runPromise)
+      }).pipe(Effect.provide(MediaSessionServiceLayer), Effect.runPromise)
       expect(completed).toBe(true)
     } finally {
       Object.defineProperty(globalThis, 'navigator', {

--- a/apps/www/src/services/media-session.ts
+++ b/apps/www/src/services/media-session.ts
@@ -26,7 +26,7 @@ export class MediaSessionService extends Context.Service<
   MediaSessionServiceShape
 >()('@gbfm/www/MediaSessionService') {}
 
-export const MediaSessionServiceLive = Layer.sync(MediaSessionService, () => ({
+export const MediaSessionServiceLayer = Layer.sync(MediaSessionService, () => ({
   setMetadata: (title: string, artists: string[], artwork?: string) =>
     Effect.sync(() => {
       if (!hasMediaSession()) return

--- a/apps/www/src/services/player/PlayerProvider.tsx
+++ b/apps/www/src/services/player/PlayerProvider.tsx
@@ -18,7 +18,7 @@ import {
   useRef,
   type PropsWithChildren
 } from 'react'
-import { MediaSessionService, MediaSessionServiceLive } from '@/services/media-session'
+import { MediaSessionService, MediaSessionServiceLayer } from '@/services/media-session'
 import { PlayerStorageLive } from './storage'
 import {
   noneSource,
@@ -163,7 +163,7 @@ export const PlayerProvider = ({ children }: PropsWithChildren) => {
 
     const runtime = ManagedRuntime.make(
       Layer.mergeAll(HtmlAudioEngineLayer(audio), PlayReporterLive).pipe(
-        Layer.provideMerge(Layer.mergeAll(PlayerStorageLive, MediaSessionServiceLive))
+        Layer.provideMerge(Layer.mergeAll(PlayerStorageLive, MediaSessionServiceLayer))
       )
     )
     runtimeRef.current = runtime

--- a/docs/features/music-metadata.md
+++ b/docs/features/music-metadata.md
@@ -406,7 +406,7 @@ The `MusicLinkScraperService` uses a provider-first architecture. Providers are 
      fetchLinks(input: MusicScrapeInput): Effect.Effect<ProviderResult, MusicScraperError> { … }
    }
    ```
-2. Add it to the `providers` array in `MusicLinkScraperServiceLive` in `music-link-scraper.service.ts`.
+2. Add it to the `providers` array in `MusicLinkScraperServiceLayer` in `music-link-scraper.service.ts`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Renames all `*ServiceLive` layer exports to `*ServiceLayer` across `apps/vps/src` and `apps/www/src`, per the Effect v4 migration guide's convention of naming layers with `layer` instead of v3's `Default`/`Live`.
- Updates every import and call site (services, `runtime/services.ts`, tests, the `runtime-comparison.ts` example, and the standalone `migrate-mixes-to-main-show.ts` script).
- Pure mechanical rename — no behavior changes, no restructuring of service definitions.

24 exported layer constants renamed (23 in `apps/vps/src`, 1 in `apps/www/src`), plus 2 file-local (non-exported) `*ServiceLive` consts in `apps/vps/scripts/migrate-mixes-to-main-show.ts` and `apps/vps/src/examples/runtime-comparison.ts`. 88 total occurrences updated across 31 files.

Closes #104

## Test plan
- [x] `bun run typecheck` — clean for `@gbfm/vps` and `@gbfm/www` (root `tsgo` + per-workspace typecheck)
- [x] `bun run lint` (oxlint) — clean, no warnings
- [x] `bun run format:check` (oxfmt) — clean
- [x] `apps/www` unit tests (`bun run test:unit`) — 19 files / 135 tests pass, including `media-session.test.ts` which imports the renamed `MediaSessionServiceLayer`
- [x] `apps/vps` unit tests (`bun run test:unit`) — same 35 pre-existing failures reproduced identically on the unmodified baseline (all `ECONNREFUSED 127.0.0.1:5432` — no Postgres available in the sandbox); zero regressions introduced by this rename
- [x] Confirmed no other `ServiceLive` references remain anywhere in the repo (`grep -rn "ServiceLive"` returns nothing outside historical docs)