### PR TITLE
Mobile-first Shows directory and detail redesign

### DIFF
--- a/apps/www/src/components/Layout/AppShell.tsx
+++ b/apps/www/src/components/Layout/AppShell.tsx
@@ -37,7 +37,7 @@ export default function AppShell({ children }: Props) {
             id={MAIN_SCROLL_CONTAINER_ID}
             tabIndex={-1}
             style={{ overflowAnchor: 'none' }}
-            className='h-full min-w-0 overflow-x-hidden overflow-y-auto [&::-webkit-scrollbar]:hidden [scrollbar-width:none] bg-background focus:outline-none'>
+            className='h-full min-w-0 overflow-x-hidden overflow-y-auto pb-[calc(5.5rem+env(safe-area-inset-bottom))] [&::-webkit-scrollbar]:hidden [scrollbar-width:none] bg-background focus:outline-none'>
             {children}
           </main>
 

--- a/apps/www/src/components/MixListItem.tsx
+++ b/apps/www/src/components/MixListItem.tsx
@@ -31,23 +31,23 @@ export function MixListItem({ mix, actions }: MixListItemProps) {
     <article
       data-testid='mix-item'
       className={cn(
-        'group relative border border-border bg-card p-5 sm:p-6 transition-all duration-200 hover:border-foreground/50',
+        'group relative min-w-0 border border-border bg-card p-3 transition-colors hover:border-foreground/50 sm:p-4 lg:p-6',
         isActive && 'ring-1 ring-highlight bg-secondary'
       )}>
-      <div className='flex flex-col lg:flex-row gap-6'>
-        <div className='flex-1 min-w-0'>
-          <div className='flex justify-between items-start'>
+      <div className='grid min-w-0 grid-cols-[5.5rem_minmax(0,1fr)] gap-3 sm:grid-cols-[7rem_minmax(0,1fr)] sm:gap-4 lg:flex lg:flex-row lg:gap-6'>
+        <div className='min-w-0 lg:flex-1'>
+          <div className='flex min-w-0 justify-between items-start'>
             <Link
               to='/mixes/$mixId'
               params={{ mixId: mix.slug }}
-              className='block text-2xl font-black leading-tight line-clamp-2 text-foreground tracking-tight transition-colors'>
+              className='block min-w-0 text-base font-black leading-tight line-clamp-2 wrap-break-word text-foreground tracking-tight focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:text-lg lg:text-2xl'>
               {mix.title}
             </Link>
             <div className='shrink-0 ml-2'>{actions}</div>
           </div>
 
           {hasCreators && (
-            <p className='mt-1 text-xs tracking-widest text-highlight/80'>
+            <p className='mt-1 text-[10px] tracking-widest text-highlight/80 line-clamp-1 sm:text-xs'>
               <span className='opacity-60'>By </span>
               {mix.creators?.map((creator, index) => (
                 <span key={creator.id}>
@@ -70,13 +70,13 @@ export function MixListItem({ mix, actions }: MixListItemProps) {
           )}
 
           {mix.description && (
-            <p className='mt-4 text-sm leading-relaxed text-foreground/50 border-l-2 border-highlight/20 pl-4 py-1 italic line-clamp-2'>
+            <p className='hidden mt-4 text-sm leading-relaxed text-foreground/50 border-l-2 border-highlight/20 pl-4 py-1 italic line-clamp-2 lg:block'>
               {mix.description}
             </p>
           )}
 
           {mix.tags && mix.tags.length > 0 && (
-            <div className='flex flex-wrap items-center gap-1.5 mt-4'>
+            <div className='hidden flex-wrap items-center gap-1.5 mt-4 lg:flex'>
               {mix.tags.map((tag) => (
                 <Link key={tag} to='/mixes' search={{ tag }}>
                   <Badge
@@ -89,7 +89,7 @@ export function MixListItem({ mix, actions }: MixListItemProps) {
             </div>
           )}
 
-          <div className='mt-5 pt-4 border-t border-border/50 flex items-center gap-5'>
+          <div className='mt-3 pt-3 border-t border-border/50 flex min-w-0 items-center gap-3 lg:mt-5 lg:pt-4 lg:gap-5'>
             <PlayButton
               isActive={isActive}
               isPlaying={isPlaying}
@@ -97,7 +97,7 @@ export function MixListItem({ mix, actions }: MixListItemProps) {
               onClick={handlePlay}
             />
             {hasCreators && (
-              <span className='text-xs text-muted-foreground font-bold tracking-widest'>
+              <span className='hidden min-w-0 text-xs text-muted-foreground font-bold tracking-widest line-clamp-1 lg:block'>
                 By {mix.creators?.map((c) => c.name).join(' & ')}
               </span>
             )}
@@ -107,8 +107,12 @@ export function MixListItem({ mix, actions }: MixListItemProps) {
         <div className='relative shrink-0 order-first lg:order-last'>
           <img
             src={mix.thumbnailUrl || DEFAULT_IMAGE_URL}
-            alt={mix.title}
-            className='object-cover border w-full lg:w-48 h-48 border-border bg-background'
+            alt={`Artwork for ${mix.title}`}
+            width={192}
+            height={192}
+            loading='lazy'
+            sizes='(max-width: 639px) 88px, (max-width: 1023px) 112px, 192px'
+            className='object-cover border w-[5.5rem] aspect-square sm:w-28 lg:w-48 border-border bg-background'
           />
           {recencyLabel && (
             <span
@@ -145,7 +149,7 @@ function PlayButton({
       type='button'
       onClick={onClick}
       className={cn(
-        'flex items-center gap-2 px-5 py-2 text-sm font-bold border-2 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'flex min-h-11 min-w-11 items-center justify-center gap-2 px-3 py-2 text-sm font-bold border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:px-5',
         isActive && isPlaying
           ? 'bg-highlight text-highlight-foreground border-highlight'
           : 'border-border text-foreground/80 hover:border-highlight hover:text-highlight'
@@ -155,7 +159,10 @@ function PlayButton({
       ) : (
         <Play size={14} fill='currentColor' />
       )}
-      <span>{isActive && isPlaying ? 'playing' : `play ${playLabel}`}</span>
+      <span className='hidden sm:inline'>
+        {isActive && isPlaying ? 'playing' : `play ${playLabel}`}
+      </span>
+      <span className='sm:hidden'>{isActive && isPlaying ? 'pause' : 'play'}</span>
     </button>
   )
 }

--- a/apps/www/src/components/MixTimeline.tsx
+++ b/apps/www/src/components/MixTimeline.tsx
@@ -20,10 +20,10 @@ export function MixTimelineItem({ mix, children }: MixTimelineItemProps) {
   const isActive = currentTrack?.id === mix.id
 
   return (
-    <div className='group relative grid grid-cols-[1rem_1fr] gap-x-4 pb-6 last:pb-0 [&:first-child_.timeline-line]:top-3 [&:last-child_.timeline-line]:hidden'>
+    <div className='group relative grid min-w-0 grid-cols-[0.75rem_minmax(0,1fr)] gap-x-2.5 pb-4 last:pb-0 sm:grid-cols-[1rem_minmax(0,1fr)] sm:gap-x-4 sm:pb-6 [&:first-child_.timeline-line]:top-3 [&:last-child_.timeline-line]:hidden'>
       <div
         className={cn(
-          'timeline-line absolute left-2 top-0 bottom-0 w-px -translate-x-1/2 transition-opacity duration-300',
+          'timeline-line absolute left-1.5 top-0 bottom-0 w-px -translate-x-1/2 transition-opacity duration-300 sm:left-2',
           isActive ? 'bg-highlight/40 opacity-100' : 'bg-border opacity-75 group-hover:opacity-95'
         )}
       />
@@ -56,7 +56,7 @@ export function MixTimelineItem({ mix, children }: MixTimelineItemProps) {
       </span>
 
       <div />
-      <div className='pt-2 pb-1'>{children}</div>
+      <div className='min-w-0 pt-2 pb-1'>{children}</div>
     </div>
   )
 }

--- a/apps/www/src/components/shows/EpisodeGrid.tsx
+++ b/apps/www/src/components/shows/EpisodeGrid.tsx
@@ -49,8 +49,8 @@ export function EpisodeGrid({ showSlug }: EpisodeGridProps) {
   }
 
   return (
-    <div className='space-y-4'>
-      <h2 className='text-xl font-bold'>Episodes</h2>
+    <div className='min-w-0 space-y-3 sm:space-y-4'>
+      <h2 className='text-lg font-bold sm:text-xl'>Episodes</h2>
       <MixTimeline>
         {episodes.map((episode) => (
           <MixTimelineItem key={episode.id} mix={episode}>

--- a/apps/www/src/components/shows/ShowListItem.tsx
+++ b/apps/www/src/components/shows/ShowListItem.tsx
@@ -14,15 +14,20 @@ export function ShowListItem({ show, isSelected, onSelect }: ShowListItemProps) 
     <button
       type='button'
       onClick={onSelect}
-      className={`w-full flex items-center gap-3 p-2 rounded-sm border text-left transition-all ${
+      aria-pressed={isSelected}
+      className={`w-full min-h-11 flex items-center gap-2 p-2 rounded-sm border text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
         isSelected
           ? 'border-highlight bg-secondary ring-1 ring-highlight'
           : 'border-transparent hover:bg-muted/40 hover:border-border/60'
       }`}>
       <img
         src={show.thumbnailUrl || DEFAULT_IMAGE_URL}
-        alt={show.title}
-        className='w-16 h-16 object-cover rounded-sm border border-border bg-background shrink-0'
+        alt={`Artwork for ${show.title}`}
+        width={64}
+        height={64}
+        loading='lazy'
+        sizes='64px'
+        className='w-14 aspect-square object-cover rounded-sm border border-border bg-background shrink-0 lg:w-16'
       />
       <div className='min-w-0'>
         <p className='text-sm font-semibold text-foreground line-clamp-2'>{show.title}</p>

--- a/apps/www/src/components/shows/SubscribeButton.tsx
+++ b/apps/www/src/components/shows/SubscribeButton.tsx
@@ -58,7 +58,7 @@ export function SubscribeButton({ showId, showTitle }: SubscribeButtonProps) {
       onClick={handleClick}
       disabled={isLoading}
       variant={isSubscribed ? 'outline' : 'default'}
-      className='w-full gap-2'>
+      className='min-h-11 gap-2 px-5'>
       {isLoading ? (
         <Loader2 className='w-4 h-4 animate-spin' />
       ) : isSubscribed ? (

--- a/apps/www/src/routes/shows/$showSlug.tsx
+++ b/apps/www/src/routes/shows/$showSlug.tsx
@@ -81,26 +81,43 @@ function ShowPage() {
   const hostNames = data.hosts?.map((h) => h.name).join(', ')
 
   return (
-    <div className='max-w-7xl px-4 py-6 mx-auto overflow-hidden'>
-      <div className='grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,2.5fr)]'>
-        <div className='lg:col-span-1'>
-          <div className='sticky top-6'>
-            <div className='mb-4'>
+    <div className='max-w-7xl min-w-0 px-4 py-4 mx-auto sm:py-6'>
+      <div className='grid min-w-0 grid-cols-1 gap-5 sm:gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,2.5fr)]'>
+        <div className='min-w-0 lg:col-span-1'>
+          <div className='grid grid-cols-[7rem_minmax(0,1fr)] gap-x-4 gap-y-3 border-b border-border/40 pb-5 lg:sticky lg:top-6 lg:block lg:border-0 lg:pb-0'>
+            <div className='lg:mb-4'>
               <img
-                className='w-full rounded-sm'
+                className='w-28 aspect-square object-cover border border-border rounded-sm lg:w-full'
                 src={data.thumbnailUrl || '/fav.png'}
-                alt={`Thumbnail for ${data.title}`}
+                alt={`Artwork for ${data.title}`}
                 width={400}
                 height={400}
-                loading='lazy'
+                fetchPriority='high'
+                sizes='(max-width: 1023px) 112px, 30vw'
               />
             </div>
 
-            <div className='space-y-3 min-w-0'>
-              <h1 className='text-2xl font-bold wrap-break-word'>{data.title}</h1>
+            <div className='min-w-0 space-y-2 lg:space-y-3'>
+              <h1 className='text-xl font-black leading-tight tracking-tight wrap-break-word sm:text-2xl'>
+                {data.title}
+              </h1>
 
               {hostNames && <p className='text-sm text-muted-foreground'>Hosted by {hostNames}</p>}
 
+              <div className='flex gap-2 flex-wrap lg:hidden'>
+                <FavoriteButton
+                  contentType='show'
+                  contentId={data.id}
+                  contentTitle={data.title}
+                  className='min-h-11 min-w-11'
+                />
+                <ShareButton type='show' slug={showSlug} className='min-h-11 min-w-11' />
+                <ShowQRButton slug={showSlug} className='min-h-11 min-w-11' />
+                <ShowMetadataManager show={data} />
+              </div>
+            </div>
+
+            <div className='col-span-2 min-w-0 lg:mt-3'>
               {(data.description || data.compiledContent) && (
                 <ShowDescription
                   title={data.title}
@@ -109,10 +126,15 @@ function ShowPage() {
                 />
               )}
 
-              <div className='flex gap-2 flex-wrap'>
-                <FavoriteButton contentType='show' contentId={data.id} contentTitle={data.title} />
-                <ShareButton type='show' slug={showSlug} />
-                <ShowQRButton slug={showSlug} />
+              <div className='hidden gap-2 flex-wrap lg:flex'>
+                <FavoriteButton
+                  contentType='show'
+                  contentId={data.id}
+                  contentTitle={data.title}
+                  className='min-h-11 min-w-11'
+                />
+                <ShareButton type='show' slug={showSlug} className='min-h-11 min-w-11' />
+                <ShowQRButton slug={showSlug} className='min-h-11 min-w-11' />
                 <ShowMetadataManager show={data} />
               </div>
             </div>

--- a/apps/www/src/routes/shows/_components/-ShowMetadataManager.tsx
+++ b/apps/www/src/routes/shows/_components/-ShowMetadataManager.tsx
@@ -95,7 +95,7 @@ export function ShowMetadataManager({ show }: ShowMetadataManagerProps) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant='outline' size='sm'>
+        <Button variant='outline' size='sm' className='min-h-11'>
           <Settings2 className='w-4 h-4 mr-1.5' />
           Manage
         </Button>

--- a/apps/www/src/routes/shows/index.tsx
+++ b/apps/www/src/routes/shows/index.tsx
@@ -57,7 +57,7 @@ function ShowsListPage() {
   }
 
   return (
-    <div className='p-4 mx-auto max-w-7xl'>
+    <div className='px-4 py-4 mx-auto max-w-7xl sm:py-6'>
       <div className='grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr] lg:gap-8'>
         <aside className='hidden lg:block'>
           <nav className='sticky top-6 max-h-[calc(100vh-3rem)] overflow-y-auto space-y-2 pr-2 no-scrollbar'>
@@ -82,10 +82,15 @@ function ShowsListPage() {
           </nav>
         </aside>
 
-        <div className='lg:hidden'>
-          <nav className='flex gap-3 overflow-x-auto pb-3 no-scrollbar'>
+        <div className='min-w-0 lg:hidden'>
+          <p className='mb-2 text-[11px] font-mono font-bold tracking-widest text-highlight/80'>
+            SELECT A SHOW
+          </p>
+          <nav
+            aria-label='Select a show'
+            className='flex gap-2 -mx-4 px-4 pb-3 overflow-x-auto overscroll-x-contain snap-x snap-mandatory scroll-px-4 no-scrollbar'>
             {data.map((show) => (
-              <div key={show.id} className='min-w-[220px] max-w-[220px]'>
+              <div key={show.id} className='w-[172px] shrink-0 snap-start sm:w-[188px]'>
                 <ShowListItem
                   show={show}
                   isSelected={selectedShow?.id === show.id}
@@ -125,33 +130,41 @@ function SelectedShowPanel({ show }: { show: ShowWithHosts }) {
 
   return (
     <section>
-      <div className='flex flex-col sm:flex-row gap-6 items-start pt-2 mb-8 pb-8 border-b border-border/40'>
+      <div className='grid grid-cols-[7rem_minmax(0,1fr)] gap-x-4 gap-y-3 items-start mb-5 pb-5 border-b border-border/40 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-x-6 sm:pt-2 sm:mb-8 sm:pb-8'>
         <img
           src={show.thumbnailUrl || DEFAULT_IMAGE_URL}
-          alt={show.title}
-          className='w-40 h-40 object-cover border rounded-sm border-border bg-background shrink-0'
+          alt={`Artwork for ${show.title}`}
+          width={160}
+          height={160}
+          fetchPriority='high'
+          sizes='(max-width: 639px) 112px, 160px'
+          className='w-28 aspect-square object-cover border rounded-sm border-border bg-background shrink-0 sm:w-40'
         />
-        <div className='flex-1 min-w-0 space-y-3'>
-          <h2 className='text-3xl font-black tracking-tight mt-0'>{show.title}</h2>
+        <div className='min-w-0 space-y-2 sm:space-y-3'>
+          <h1 className='mt-0 text-xl font-black leading-tight tracking-tight wrap-break-word sm:text-3xl'>
+            {show.title}
+          </h1>
           {hostNames && (
             <Link
               to='/shows/$showSlug'
               params={{ showSlug: show.slug }}
-              className='text-sm text-muted-foreground hover:text-foreground transition-colors'>
+              className='inline-flex min-h-11 items-center text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:text-sm'>
               Hosted by {hostNames}
             </Link>
           )}
+        </div>
+        <div className='col-span-2 min-w-0 sm:col-span-1 sm:col-start-2'>
           {show.description && (
-            <p className='text-sm text-foreground/70 line-clamp-4'>{show.description}</p>
+            <p className='mb-3 text-sm leading-relaxed text-foreground/70 line-clamp-3 sm:line-clamp-4'>
+              {show.description}
+            </p>
           )}
-          <div className='flex flex-wrap items-center gap-3 pt-1'>
-            <div className='w-full sm:w-auto'>
-              <SubscribeButton showId={show.id} showTitle={show.title} />
-            </div>
+          <div className='flex flex-wrap items-center gap-2 sm:gap-3'>
+            <SubscribeButton showId={show.id} showTitle={show.title} />
             <Link
               to='/$slug'
               params={{ slug: show.slug }}
-              className='text-sm font-medium text-primary hover:opacity-80'>
+              className='inline-flex min-h-11 items-center px-2 text-sm font-medium text-primary hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'>
               View show page
             </Link>
           </div>


### PR DESCRIPTION
## Why

The Shows directory compressed the desktop composition on small screens: the switcher consumed too much width, show artwork and actions delayed episodes, and episode cards were difficult to scan. The floating menu also had no reserved content clearance.

This keeps goosebumps.fm's square-artwork, dark-blue/cyan, radio-terminal identity while making the directory and canonical show detail route intentionally mobile-first.

## What to look for

- The mobile show selector is an edge-aware, snap-scrolling rail with 172px cards and an explicit selected state; desktop keeps the sticky sidebar.
- Selected-show artwork is 112px on mobile, with title/host and primary actions grouped tightly enough to surface the first episode in the initial viewport.
- Shared episode cards use bounded media rows below `lg` and restore descriptions, tags, and 192px artwork on desktop. `minmax(0,1fr)`, `min-w-0`, and bounded image sizes prevent long content from widening the page.
- The shell reserves `5.5rem + safe-area` beneath scrollable content so the 56px floating menu cannot cover the final episode.
- Show, play, and metadata controls have at least 44px targets, visible focus treatment, descriptive artwork alt text, intrinsic dimensions, and responsive image hints.

## Test evidence

### Provenance

All screenshots below were freshly captured in isolated browser sessions on July 27, 2026. The BEFORE and AFTER mobile images use the same 375 × 812 viewport, dark theme, show, and production-backed data.

| Item | Provenance |
| --- | --- |
| PR branch | `feat/mobile-shows-directory-20260727` |
| Checked-out commit | `f2b8c233dcec9bf2d165e25313ffd06fcf35a4fc` |
| GitHub PR head | `f2b8c233dcec9bf2d165e25313ffd06fcf35a4fc` |
| AFTER frontend origin | `http://127.0.0.1:31396` — Vite serving the checked-out PR branch |
| BEFORE production origin | `https://goosebumps.fm` |
| API data source | `https://vps.goosebumps.fm` (proxied only for the local frontend); local `GET /api/shows?limit=3&offset=0` returned HTTP 200 |
| Capture tool | `agent-browser 0.32.3`, isolated `pr227-prod-dark` and `pr227-after-dark` sessions |
| Theme | `prefers-color-scheme: dark` plus `vite-ui-theme=dark`; both sessions reported `class="dark"` and body `rgb(22, 65, 90)` |

```text
$ git status --porcelain=v1
# empty
$ git branch --show-current
feat/mobile-shows-directory-20260727
$ git rev-parse HEAD
f2b8c233dcec9bf2d165e25313ffd06fcf35a4fc
$ git rev-parse origin/feat/mobile-shows-directory-20260727
f2b8c233dcec9bf2d165e25313ffd06fcf35a4fc
$ gh pr view 227 --json headRefOid --jq .headRefOid
f2b8c233dcec9bf2d165e25313ffd06fcf35a4fc
```

### Before / after — directory at 375 × 812, dark

**BEFORE:** `https://goosebumps.fm/shows?show=farendradio`  
**AFTER:** `http://127.0.0.1:31396/shows?show=farendradio`

The composite adds labels above two otherwise unchanged viewport captures. It shows the PR's smaller switcher cards and 112px hero, horizontal action hierarchy, earlier Episodes heading, compact media-row episode, and unobstructed first card.

![Side-by-side live production before and PR branch after at 375 by 812, dark theme](https://ampcode.com/user-content/artifacts/7f7c3a5d77502c33329a8545e0ff6bb05e37e862e493ff105e3e1c1b17fe840d-file.png)

<details>
<summary>Raw source captures used in the comparison</summary>

**BEFORE — live production, 375 × 812, dark, FAR END RADIO selected**

![Raw live production before capture](https://ampcode.com/user-content/artifacts/7bc7dba9d695f1a32070d69796fe6e2705c1d1e2a1e59bee8030fe8021eeb68c-file.png)

**AFTER — local PR branch at f2b8c23, 375 × 812, dark, FAR END RADIO selected, menu closed**

![Raw local PR branch after capture](https://ampcode.com/user-content/artifacts/4ce1b8ef702451fc2c8dd426cb2ced1b4da76fac4b952468dfef8183c68810d8-file.png)

</details>

### Narrow overflow — AFTER, 320 × 720, dark

Route: `http://127.0.0.1:31396/shows?show=farendradio`. The show rail remains intentionally scrollable while the page and app scroller both stay exactly 320px wide.

```text
documentElement clientWidth / scrollWidth: 320 / 320
main clientWidth / scrollWidth: 320 / 320
```

![PR branch at 320px with no page-level horizontal overflow](https://ampcode.com/user-content/artifacts/6ab44f76b8d270e480e0a66904febc8fc7fd433ef54981b846f1557f6dc2067e-file.png)

### Alternate show selection — AFTER, 375 × 812, dark

Route: `http://127.0.0.1:31396/shows?show=gbfm`. The selected outline moves to Main Show, the rail remains compact, and multiple episodes scan as bounded media rows.

![PR branch with Main Show selected](https://ampcode.com/user-content/artifacts/6ff5c6e6847870305e5cabf1c6cda8a7f1b188887e45a6a4c293dfdd45889104-file.png)

### Floating menu states — AFTER, 375 × 812, dark

**Open:** the existing full-screen navigation remains intact.

![PR branch floating menu open](https://ampcode.com/user-content/artifacts/f65d7ece1b8097268f38afd73f1a2f425709ab2e1d181a50def5b92d1dde2b91-file.png)

**Closed at the end of the episode list:** the app scroller reports `padding-bottom: 88px`; the final episode and load-more state remain above the 56px menu trigger rather than underneath it.

![PR branch menu closed with bottom content clearance](https://ampcode.com/user-content/artifacts/e9fa26f0e2b5a4ac8641a5a81fa193f94da22e8bfa0b19f53b6b4da90519d542-file.png)

### Tablet — AFTER, 768 × 900, dark

Route: `http://127.0.0.1:31396/shows?show=farendradio`. Tablet retains the compact rail and media-row episode while using the wider hero track.

![PR branch tablet directory](https://ampcode.com/user-content/artifacts/a3ceaabb6125bca33ae4df041eb9e7f036e32a5e0b16d8c1999cc5dc271a5d79-file.png)

### Desktop — AFTER, 1280 × 900, dark

Route: `http://127.0.0.1:31396/shows?show=farendradio`. Desktop preserves the sticky sidebar and richer editorial episode card with description, tag, and 192px square artwork.

![PR branch desktop directory](https://ampcode.com/user-content/artifacts/6e46db6c363e06403d3ce0d1bf1f71015f4e0d99527200711208d65e1da6df80-file.png)

### Canonical detail — AFTER, 375 × 812, dark

Route: `http://127.0.0.1:31396/shows/farendradio`. The canonical route has its own compressed detail hero and shares the compact EpisodeGrid behavior. Document and app scroller both measured 375 / 375 for client width / scroll width.

![PR branch canonical show detail](https://ampcode.com/user-content/artifacts/794514351653de2202af28fd85c20612ee6981d256846a019f92c8e8a6b2450f-file.png)

### Automated checks

```text
NODE22=... PATH="$(dirname "$NODE22"):$PATH" bun precommit
✓ oxfmt (1,485 files)
✓ oxlint (0 warnings, 0 errors)
✓ root + all workspace typechecks

vite build apps/www (Node 22)
✓ 3,848 modules transformed
✓ built in 2.42s
```

The production build retains pre-existing warnings for Lightning CSS parsing `@utility` and the main chunk exceeding 500 kB; neither is introduced by this change.