### PR TITLE
fix(vps): use Drizzle relational queries for creators/hosts

### DIFF
--- a/apps/vps/src/db/index.ts
+++ b/apps/vps/src/db/index.ts
@@ -2,6 +2,7 @@ import { config } from '@/services/config.service'
 import 'dotenv/config'
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { Pool } from 'pg'
+import * as schema from './exports'
 
 const stage = config.app.stage
 
@@ -30,4 +31,4 @@ console.log(
 const pool = new Pool(dbConfig)
 
 export { pool }
-export const db = drizzle(pool)
+export const db = drizzle(pool, { schema })

--- a/apps/vps/src/services/audio.service.test.ts
+++ b/apps/vps/src/services/audio.service.test.ts
@@ -131,3 +131,30 @@ describe('AudioService.create idempotency', () => {
     ).rejects.toMatchObject({ _tag: 'ConflictError' })
   })
 })
+
+describe('AudioService creators', () => {
+  test('getByType and getBySlug attach the creator for each audio row', async () => {
+    const service = await getService()
+    const slug = `creators-${randomUUID()}`
+
+    const created = await Effect.runPromise(
+      service.create(makeAudio(slug), [actorId], {
+        actorId,
+        idempotencyKey: randomUUID()
+      })
+    )
+
+    const bySlug = await Effect.runPromise(service.getBySlug('mix', slug))
+    expect(bySlug.creators).toEqual([
+      expect.objectContaining({ id: actorId, name: 'Audio idempotency actor' })
+    ])
+
+    const { data: byType } = await Effect.runPromise(
+      service.getByType('mix', { limit: 100, offset: 0 })
+    )
+    const match = byType.find((audio) => audio.id === created.id)
+    expect(match?.creators).toEqual([
+      expect.objectContaining({ id: actorId, name: 'Audio idempotency actor' })
+    ])
+  })
+})

--- a/apps/vps/src/services/audio.service.ts
+++ b/apps/vps/src/services/audio.service.ts
@@ -1,4 +1,4 @@
-import { and, arrayContains, count, desc, eq, exists, inArray, sql } from 'drizzle-orm'
+import { and, arrayContains, count, desc, eq, exists, sql } from 'drizzle-orm'
 import { Context, Crypto, Effect, Encoding, Layer } from 'effect'
 import { db } from '@/db'
 import {
@@ -8,7 +8,6 @@ import {
   type SelectAudio,
   type SelectMdxCompiledAudio
 } from '@/db/audio.schema'
-import { user as usersTable } from '@/db/auth.schema'
 import { timeQuery } from '@/db/query-timer'
 import { showsTable } from '@/db/show.schema'
 import {
@@ -171,13 +170,17 @@ const getByTypeEffect = (
       try: () =>
         timeQuery(
           () =>
-            db
-              .select()
-              .from(audioTable)
-              .where(whereCondition)
-              .limit(limit)
-              .offset(offset)
-              .orderBy(desc(audioTable.createdAt)),
+            db.query.audioTable.findMany({
+              where: whereCondition,
+              limit,
+              offset,
+              orderBy: desc(audioTable.createdAt),
+              with: {
+                audioCreators: {
+                  with: { creator: true }
+                }
+              }
+            }),
           'get-audio-by-type-data'
         ),
       catch: (error) =>
@@ -188,56 +191,13 @@ const getByTypeEffect = (
         })
     })
 
-    const audioIds = audioItems.map((a) => a.id)
-
-    const creatorsData =
-      audioIds.length > 0
-        ? yield* Effect.tryPromise({
-            try: () =>
-              db
-                .select({
-                  audioId: audioCreators.audioId,
-                  creatorId: usersTable.id,
-                  creatorName: usersTable.name,
-                  creatorUsername: usersTable.username
-                })
-                .from(audioCreators)
-                .innerJoin(usersTable, eq(audioCreators.creatorId, usersTable.id))
-                .where(inArray(audioCreators.audioId, audioIds)),
-            catch: (error) =>
-              new DatabaseError({
-                message: `Failed to fetch creators: ${getErrorMessage(error)}`,
-                operation: 'select',
-                table: 'audio_creators'
-              })
-          })
-        : []
-
-    const creatorsByAudioId: Record<
-      string,
-      Array<{
-        id: string
-        name: string
-        username: string | null
-      }>
-    > = {}
-    for (const row of creatorsData) {
-      const existing = creatorsByAudioId[row.audioId]
-      const creatorInfo = {
-        id: row.creatorId,
-        name: row.creatorName,
-        username: row.creatorUsername
-      }
-      if (existing) {
-        existing.push(creatorInfo)
-      } else {
-        creatorsByAudioId[row.audioId] = [creatorInfo]
-      }
-    }
-
-    const data = audioItems.map((audio) => ({
+    const data = audioItems.map(({ audioCreators: creators, ...audio }) => ({
       ...audio,
-      creators: creatorsByAudioId[audio.id] || []
+      creators: creators.map(({ creator }) => ({
+        id: creator.id,
+        name: creator.name,
+        username: creator.username
+      }))
     }))
 
     return {
@@ -272,21 +232,22 @@ const getTagsEffect = (type: AudioType) =>
 
 const getBySlugEffect = (type: AudioType, slug: string, mdx: MdxService, includeDrafts = false) =>
   Effect.gen(function* () {
-    const audioRecords = yield* Effect.tryPromise({
+    const audio = yield* Effect.tryPromise({
       try: () =>
-        db
-          .select()
-          .from(audioTable)
-          .where(
-            includeDrafts
-              ? and(eq(audioTable.type, type), eq(audioTable.slug, slug))
-              : and(
-                  eq(audioTable.type, type),
-                  eq(audioTable.slug, slug),
-                  eq(audioTable.draft, false)
-                )
-          )
-          .limit(1),
+        db.query.audioTable.findFirst({
+          where: includeDrafts
+            ? and(eq(audioTable.type, type), eq(audioTable.slug, slug))
+            : and(
+                eq(audioTable.type, type),
+                eq(audioTable.slug, slug),
+                eq(audioTable.draft, false)
+              ),
+          with: {
+            audioCreators: {
+              with: { creator: true }
+            }
+          }
+        }),
       catch: (error) =>
         new DatabaseError({
           message: `Failed to fetch audio: ${getErrorMessage(error)}`,
@@ -295,7 +256,6 @@ const getBySlugEffect = (type: AudioType, slug: string, mdx: MdxService, include
         })
     })
 
-    const audio = audioRecords[0]
     if (!audio) {
       return yield* new NotFoundError({
         message: 'Audio not found',
@@ -304,34 +264,17 @@ const getBySlugEffect = (type: AudioType, slug: string, mdx: MdxService, include
       })
     }
 
-    const creators = yield* Effect.tryPromise({
-      try: () =>
-        db
-          .select({
-            id: usersTable.id,
-            name: usersTable.name,
-            username: usersTable.username
-          })
-          .from(audioCreators)
-          .innerJoin(usersTable, eq(audioCreators.creatorId, usersTable.id))
-          .where(eq(audioCreators.audioId, audio.id)),
-      catch: (error) =>
-        new DatabaseError({
-          message: `Failed to fetch creators: ${getErrorMessage(error)}`,
-          operation: 'select',
-          table: 'audio_creators'
-        })
-    })
-
     let compiledContent = ''
     if (audio.content) {
       compiledContent = yield* mdx.compile(audio.content).pipe(Effect.orElseSucceed(() => ''))
     }
 
+    const { audioCreators: creators, ...audioFields } = audio
+
     return {
-      ...audio,
+      ...audioFields,
       compiledContent,
-      creators: creators.map((creator) => ({
+      creators: creators.map(({ creator }) => ({
         id: creator.id,
         name: creator.name,
         username: creator.username
@@ -560,17 +503,12 @@ const updateEffect = (
       })
     }
 
-    const creators = yield* Effect.tryPromise({
+    const creatorRows = yield* Effect.tryPromise({
       try: () =>
-        db
-          .select({
-            id: usersTable.id,
-            name: usersTable.name,
-            username: usersTable.username
-          })
-          .from(audioCreators)
-          .innerJoin(usersTable, eq(audioCreators.creatorId, usersTable.id))
-          .where(eq(audioCreators.audioId, updatedAudio.id)),
+        db.query.audioCreators.findMany({
+          where: eq(audioCreators.audioId, updatedAudio.id),
+          with: { creator: true }
+        }),
       catch: (error) =>
         new DatabaseError({
           message: `Failed to fetch creators: ${getErrorMessage(error)}`,
@@ -589,7 +527,7 @@ const updateEffect = (
     return {
       ...updatedAudio,
       compiledContent,
-      creators: creators.map((creator) => ({
+      creators: creatorRows.map(({ creator }) => ({
         id: creator.id,
         name: creator.name,
         username: creator.username

--- a/apps/vps/src/services/show.service.test.ts
+++ b/apps/vps/src/services/show.service.test.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from 'node:crypto'
+import { Effect } from 'effect'
+import { beforeAll, describe, expect, test } from 'vitest'
+import { db } from '@/db'
+import { audioCreators, audioTable } from '@/db/audio.schema'
+import { user } from '@/db/auth.schema'
+import { ShowService, ShowServiceLayer } from './show.service'
+
+const hostId = `show-creators-${randomUUID()}`
+
+const getService = () =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      return yield* ShowService
+    }).pipe(Effect.provide(ShowServiceLayer))
+  )
+
+beforeAll(async () => {
+  await db.insert(user).values({
+    id: hostId,
+    name: 'Show host actor',
+    email: `${hostId}@example.com`
+  })
+})
+
+describe('ShowService creators', () => {
+  test('getAll attaches hosts and getEpisodes attaches episode creators', async () => {
+    const service = await getService()
+    const slug = `show-${randomUUID()}`
+
+    const show = await Effect.runPromise(
+      service.create(
+        {
+          title: `Show ${slug}`,
+          slug,
+          content: ''
+        },
+        [hostId]
+      )
+    )
+
+    const episodeSlug = `episode-${randomUUID()}`
+    const [episode] = await db
+      .insert(audioTable)
+      .values({
+        title: `Episode ${episodeSlug}`,
+        slug: episodeSlug,
+        content: '',
+        type: 'mix',
+        url: 'https://example.com/audio.mp3',
+        showId: show.id
+      })
+      .returning()
+
+    if (!episode) {
+      throw new Error('Failed to insert episode fixture')
+    }
+
+    await db.insert(audioCreators).values({
+      audioId: episode.id,
+      creatorId: hostId
+    })
+
+    const { data: shows } = await Effect.runPromise(service.getAll({ limit: 100, offset: 0 }))
+    const matchedShow = shows.find((s) => s.id === show.id)
+    expect(matchedShow?.hosts).toEqual([expect.objectContaining({ id: hostId })])
+
+    const { data: episodes } = await Effect.runPromise(
+      service.getEpisodes(slug, { limit: 100, offset: 0 })
+    )
+    expect(episodes).toHaveLength(1)
+    expect(episodes[0]?.creators).toEqual([expect.objectContaining({ id: hostId })])
+  })
+})

--- a/apps/vps/src/services/show.service.ts
+++ b/apps/vps/src/services/show.service.ts
@@ -1,8 +1,7 @@
-import { and, asc, count, desc, eq, exists, inArray } from 'drizzle-orm'
+import { and, asc, count, desc, eq, exists } from 'drizzle-orm'
 import { Context, Effect, Layer } from 'effect'
 import { db } from '@/db'
-import { audioCreators, audioTable, type SelectAudio } from '@/db/audio.schema'
-import { user as usersTable } from '@/db/auth.schema'
+import { audioTable, type SelectAudio } from '@/db/audio.schema'
 import {
   type InsertShow,
   type SelectMdxCompiledShow,
@@ -110,13 +109,17 @@ const getAllEffect = (
 
     const shows = yield* Effect.tryPromise({
       try: () =>
-        db
-          .select()
-          .from(showsTable)
-          .where(whereCondition)
-          .limit(limit)
-          .offset(offset)
-          .orderBy(desc(showsTable.createdAt), asc(showsTable.title)),
+        db.query.showsTable.findMany({
+          where: whereCondition,
+          limit,
+          offset,
+          orderBy: [desc(showsTable.createdAt), asc(showsTable.title)],
+          with: {
+            showCreators: {
+              with: { creator: true }
+            }
+          }
+        }),
       catch: (error) =>
         new DatabaseError({
           message: `Failed to fetch shows: ${getErrorMessage(error)}`,
@@ -125,43 +128,9 @@ const getAllEffect = (
         })
     })
 
-    const showIds = shows.map((s) => s.id)
-
-    const hostsData =
-      showIds.length > 0
-        ? yield* Effect.tryPromise({
-            try: () =>
-              db
-                .select({
-                  showId: showCreators.showId,
-                  hostId: usersTable.id,
-                  hostName: usersTable.name
-                })
-                .from(showCreators)
-                .innerJoin(usersTable, eq(showCreators.creatorId, usersTable.id))
-                .where(inArray(showCreators.showId, showIds)),
-            catch: (error) =>
-              new DatabaseError({
-                message: `Failed to fetch hosts: ${getErrorMessage(error)}`,
-                operation: 'select',
-                table: 'show_creators'
-              })
-          })
-        : []
-
-    const hostsByShowId: Record<string, Array<{ id: string; name: string }>> = {}
-    for (const row of hostsData) {
-      const existing = hostsByShowId[row.showId]
-      if (existing) {
-        existing.push({ id: row.hostId, name: row.hostName })
-      } else {
-        hostsByShowId[row.showId] = [{ id: row.hostId, name: row.hostName }]
-      }
-    }
-
-    const data = shows.map((show) => ({
+    const data = shows.map(({ showCreators: hosts, ...show }) => ({
       ...show,
-      hosts: hostsByShowId[show.id] || []
+      hosts: hosts.map(({ creator }) => ({ id: creator.id, name: creator.name }))
     }))
 
     return {
@@ -172,17 +141,18 @@ const getAllEffect = (
 
 const getBySlugEffect = (slug: string, includeDrafts = false) =>
   Effect.gen(function* () {
-    const showRecords = yield* Effect.tryPromise({
+    const show = yield* Effect.tryPromise({
       try: () =>
-        db
-          .select()
-          .from(showsTable)
-          .where(
-            includeDrafts
-              ? eq(showsTable.slug, slug)
-              : and(eq(showsTable.slug, slug), eq(showsTable.draft, false))
-          )
-          .limit(1),
+        db.query.showsTable.findFirst({
+          where: includeDrafts
+            ? eq(showsTable.slug, slug)
+            : and(eq(showsTable.slug, slug), eq(showsTable.draft, false)),
+          with: {
+            showCreators: {
+              with: { creator: true }
+            }
+          }
+        }),
       catch: (error) =>
         new DatabaseError({
           message: `Failed to fetch show: ${getErrorMessage(error)}`,
@@ -191,7 +161,6 @@ const getBySlugEffect = (slug: string, includeDrafts = false) =>
         })
     })
 
-    const show = showRecords[0]
     if (!show) {
       return yield* new NotFoundError({
         message: 'Show not found',
@@ -200,30 +169,14 @@ const getBySlugEffect = (slug: string, includeDrafts = false) =>
       })
     }
 
-    const hosts = yield* Effect.tryPromise({
-      try: () =>
-        db
-          .select({
-            id: usersTable.id,
-            name: usersTable.name
-          })
-          .from(showCreators)
-          .innerJoin(usersTable, eq(showCreators.creatorId, usersTable.id))
-          .where(eq(showCreators.showId, show.id)),
-      catch: (error) =>
-        new DatabaseError({
-          message: `Failed to fetch hosts: ${getErrorMessage(error)}`,
-          operation: 'select',
-          table: 'show_creators'
-        })
-    })
+    const { showCreators: hosts, ...showFields } = show
 
     let processedShow: SelectMdxCompiledShow = {
-      ...show,
+      ...showFields,
       compiledContent: '',
-      hosts: hosts.map((host) => ({
-        id: host.id,
-        name: host.name
+      hosts: hosts.map(({ creator }) => ({
+        id: creator.id,
+        name: creator.name
       }))
     }
 
@@ -370,16 +323,12 @@ const updateEffect = (
       })
     }
 
-    const hosts = yield* Effect.tryPromise({
+    const hostRows = yield* Effect.tryPromise({
       try: () =>
-        db
-          .select({
-            id: usersTable.id,
-            name: usersTable.name
-          })
-          .from(showCreators)
-          .innerJoin(usersTable, eq(showCreators.creatorId, usersTable.id))
-          .where(eq(showCreators.showId, updatedShow.id)),
+        db.query.showCreators.findMany({
+          where: eq(showCreators.showId, updatedShow.id),
+          with: { creator: true }
+        }),
       catch: (error) =>
         new DatabaseError({
           message: `Failed to fetch hosts: ${getErrorMessage(error)}`,
@@ -391,9 +340,9 @@ const updateEffect = (
     const baseProcessedShow: SelectMdxCompiledShow = {
       ...updatedShow,
       compiledContent: '',
-      hosts: hosts.map((host) => ({
-        id: host.id,
-        name: host.name
+      hosts: hostRows.map(({ creator }) => ({
+        id: creator.id,
+        name: creator.name
       }))
     }
 
@@ -497,13 +446,17 @@ const getEpisodesEffect = (showSlug: string, options: { limit: number; offset: n
 
     const episodes = yield* Effect.tryPromise({
       try: () =>
-        db
-          .select()
-          .from(audioTable)
-          .where(whereCondition)
-          .limit(limit)
-          .offset(offset)
-          .orderBy(desc(audioTable.createdAt)),
+        db.query.audioTable.findMany({
+          where: whereCondition,
+          limit,
+          offset,
+          orderBy: desc(audioTable.createdAt),
+          with: {
+            audioCreators: {
+              with: { creator: true }
+            }
+          }
+        }),
       catch: (error) =>
         new DatabaseError({
           message: `Failed to fetch episodes: ${getErrorMessage(error)}`,
@@ -512,58 +465,13 @@ const getEpisodesEffect = (showSlug: string, options: { limit: number; offset: n
         })
     })
 
-    const episodeIds = episodes.map((episode) => episode.id)
-
-    const creatorsData =
-      episodeIds.length > 0
-        ? yield* Effect.tryPromise({
-            try: () =>
-              db
-                .select({
-                  audioId: audioCreators.audioId,
-                  creatorId: usersTable.id,
-                  creatorName: usersTable.name,
-                  creatorUsername: usersTable.username
-                })
-                .from(audioCreators)
-                .innerJoin(usersTable, eq(audioCreators.creatorId, usersTable.id))
-                .where(inArray(audioCreators.audioId, episodeIds)),
-            catch: (error) =>
-              new DatabaseError({
-                message: `Failed to fetch episode creators: ${getErrorMessage(error)}`,
-                operation: 'select',
-                table: 'audio_creators'
-              })
-          })
-        : []
-
-    const creatorsByAudioId: Record<
-      string,
-      Array<{
-        id: string
-        name: string
-        username: string | null
-      }>
-    > = {}
-
-    for (const row of creatorsData) {
-      const existing = creatorsByAudioId[row.audioId]
-      const creatorInfo = {
-        id: row.creatorId,
-        name: row.creatorName,
-        username: row.creatorUsername
-      }
-
-      if (existing) {
-        existing.push(creatorInfo)
-      } else {
-        creatorsByAudioId[row.audioId] = [creatorInfo]
-      }
-    }
-
-    const data = episodes.map((episode) => ({
+    const data = episodes.map(({ audioCreators: creators, ...episode }) => ({
       ...episode,
-      creators: creatorsByAudioId[episode.id] || []
+      creators: creators.map(({ creator }) => ({
+        id: creator.id,
+        name: creator.name,
+        username: creator.username
+      }))
     }))
 
     return {

--- a/apps/vps/src/services/show.service.ts
+++ b/apps/vps/src/services/show.service.ts
@@ -1,7 +1,7 @@
 import { and, asc, count, desc, eq, exists, inArray } from 'drizzle-orm'
 import { Context, Effect, Layer } from 'effect'
 import { db } from '@/db'
-import { audioTable } from '@/db/audio.schema'
+import { audioCreators, audioTable, type SelectAudio } from '@/db/audio.schema'
 import { user as usersTable } from '@/db/auth.schema'
 import {
   type InsertShow,
@@ -65,7 +65,7 @@ export interface ShowService {
     options: { limit: number; offset: number }
   ) => Effect.Effect<
     {
-      data: (typeof audioTable.$inferSelect)[]
+      data: SelectAudio[]
       pagination: PaginationMetadata
     },
     DatabaseError | NotFoundError
@@ -512,8 +512,62 @@ const getEpisodesEffect = (showSlug: string, options: { limit: number; offset: n
         })
     })
 
+    const episodeIds = episodes.map((episode) => episode.id)
+
+    const creatorsData =
+      episodeIds.length > 0
+        ? yield* Effect.tryPromise({
+            try: () =>
+              db
+                .select({
+                  audioId: audioCreators.audioId,
+                  creatorId: usersTable.id,
+                  creatorName: usersTable.name,
+                  creatorUsername: usersTable.username
+                })
+                .from(audioCreators)
+                .innerJoin(usersTable, eq(audioCreators.creatorId, usersTable.id))
+                .where(inArray(audioCreators.audioId, episodeIds)),
+            catch: (error) =>
+              new DatabaseError({
+                message: `Failed to fetch episode creators: ${getErrorMessage(error)}`,
+                operation: 'select',
+                table: 'audio_creators'
+              })
+          })
+        : []
+
+    const creatorsByAudioId: Record<
+      string,
+      Array<{
+        id: string
+        name: string
+        username: string | null
+      }>
+    > = {}
+
+    for (const row of creatorsData) {
+      const existing = creatorsByAudioId[row.audioId]
+      const creatorInfo = {
+        id: row.creatorId,
+        name: row.creatorName,
+        username: row.creatorUsername
+      }
+
+      if (existing) {
+        existing.push(creatorInfo)
+      } else {
+        creatorsByAudioId[row.audioId] = [creatorInfo]
+      }
+    }
+
+    const data = episodes.map((episode) => ({
+      ...episode,
+      creators: creatorsByAudioId[episode.id] || []
+    }))
+
     return {
-      data: episodes,
+      data,
       pagination: createPaginationMetadata(total, limit, offset)
     }
   })


### PR DESCRIPTION
## Why

PR #226 fixed episodes losing their creators by copy-pasting a batch-select-then-group-in-memory pattern that already existed twice in `audio.service.ts`. Reading both files turned up the same pattern 7 times total (3 in `audio.service.ts`, 4 in `show.service.ts`), all doing the identical thing: select parent rows, select junction+user rows filtered by `WHERE id IN (...)`, hand-roll a `Record<string, Creator[]>` grouping loop, map to attach.

The root cause: every schema file already declares real Drizzle `relations()` for these junction tables, and a barrel (`db/exports.ts`) already re-exports all of them, but `db/index.ts` calls `drizzle(pool)` with no schema, so `db.query` (Drizzle's relational query API) has never been available. Every service was hand-rolling what Drizzle already does when wired correctly.

## What changed

- `db/index.ts`: wire the existing barrel into `drizzle(pool, { schema })`. Two lines. No schema/migration changes — `drizzle.config.ts` uses an independent glob for `drizzle-kit`, untouched by this.
- `audio.service.ts`: `getByType`, `getBySlug`, `update` now use `db.query.audioTable.findMany/findFirst` with `with: { audioCreators: { with: { creator: true } } }` instead of the second query + grouping loop.
- `show.service.ts`: `getAll`, `getBySlug`, `getEpisodes` (the PR226 code), `update` get the same treatment for `showCreators`/hosts.
- No API response shape changes: `many()` relations resolve to `[]` (never `null`) for no matches, matching the existing `|| []` fallback exactly. Verified via typecheck that every function's declared return type is still satisfied with zero `as`/type assertions.

## Test plan

- [x] `bun run typecheck` — clean (only 3 pre-existing, unrelated errors remain in `reminder-processor.ts`, confirmed present on `prod` too, untouched by this PR)
- [x] `bun run test` — full suite passes (258/258 on a clean run; a later run had 2 unrelated flaky timeouts under system load, both pass in isolation)
- [x] Added `AudioService creators` case to `audio.service.test.ts` and a new `show.service.test.ts` covering `getAll` hosts + `getEpisodes` creators — this is the regression coverage PR226 itself lacked, the most direct proof this doesn't reintroduce the "Unknown creator" bug.

## Follow-up (not in this PR)

`post.service.ts` has the identical `postCreators` batch+group pattern. Same technique applies directly; flagging so it doesn't get re-discovered and re-copy-pasted a third time.