### PR TITLE
fix(vps): resolve audio thumbnailUrl from show at read time

### DIFF
--- a/apps/vps/src/http/email.handlers.ts
+++ b/apps/vps/src/http/email.handlers.ts
@@ -94,24 +94,26 @@ async function sendMixNotification(
     return { success: true, sentTo: [], emailIds: [], message: 'No opted-in recipients' }
   }
 
-  const [mix] = await db
-    .select()
-    .from(audioTable)
-    .where(
-      and(
-        eq(audioTable.slug, input.mixSlug),
-        eq(audioTable.type, 'mix'),
-        eq(audioTable.draft, false)
-      )
-    )
-    .limit(1)
+  const mix = await db.query.audioTable.findFirst({
+    where: and(
+      eq(audioTable.slug, input.mixSlug),
+      eq(audioTable.type, 'mix'),
+      eq(audioTable.draft, false)
+    ),
+    with: {
+      show: {
+        columns: { thumbnailUrl: true }
+      }
+    }
+  })
 
   if (!mix) {
     throw new MixNotFoundError(`Mix not found: ${input.mixSlug}`)
   }
 
+  const mixThumbnailUrl = mix.thumbnailUrl ?? mix.show?.thumbnailUrl ?? null
   const mixUrl = `https://goosebumps.fm/mixes/${mix.slug}`
-  const coverImageUrl = input.metadata?.coverImageUrl || mix.thumbnailUrl || undefined
+  const coverImageUrl = input.metadata?.coverImageUrl || mixThumbnailUrl || undefined
   const releaseDate =
     input.metadata?.releaseDate ||
     (mix.createdAt

--- a/apps/vps/src/http/site-routes.ts
+++ b/apps/vps/src/http/site-routes.ts
@@ -85,19 +85,20 @@ const shareMix = HttpRouter.params.pipe(
     if (!slug) return missingParamResponse('mix slug')
 
     const program = Effect.gen(function* () {
-      const [audio] = yield* fetchDb(
+      const audio = yield* fetchDb(
         () =>
-          db
-            .select()
-            .from(audioTable)
-            .where(
-              and(
-                eq(audioTable.type, 'mix'),
-                eq(audioTable.slug, slug),
-                eq(audioTable.draft, false)
-              )
-            )
-            .limit(1),
+          db.query.audioTable.findFirst({
+            where: and(
+              eq(audioTable.type, 'mix'),
+              eq(audioTable.slug, slug),
+              eq(audioTable.draft, false)
+            ),
+            with: {
+              show: {
+                columns: { thumbnailUrl: true }
+              }
+            }
+          }),
         'audio'
       )
       if (!audio)
@@ -118,7 +119,7 @@ const shareMix = HttpRouter.params.pipe(
           type: 'music.song',
           title: audio.title || slug,
           description: audio.description || `Listen to ${audio.title || slug} on goosebumps.fm`,
-          image: audio.thumbnailUrl,
+          image: audio.thumbnailUrl ?? audio.show?.thumbnailUrl ?? null,
           canonicalPath: `/mixes/${slug}`,
           audio: audio.url,
           creators: creators.map((c) => c.name),
@@ -141,19 +142,20 @@ const shareTrack = HttpRouter.params.pipe(
     if (!slug) return missingParamResponse('track slug')
 
     const program = Effect.gen(function* () {
-      const [audio] = yield* fetchDb(
+      const audio = yield* fetchDb(
         () =>
-          db
-            .select()
-            .from(audioTable)
-            .where(
-              and(
-                eq(audioTable.type, 'track'),
-                eq(audioTable.slug, slug),
-                eq(audioTable.draft, false)
-              )
-            )
-            .limit(1),
+          db.query.audioTable.findFirst({
+            where: and(
+              eq(audioTable.type, 'track'),
+              eq(audioTable.slug, slug),
+              eq(audioTable.draft, false)
+            ),
+            with: {
+              show: {
+                columns: { thumbnailUrl: true }
+              }
+            }
+          }),
         'audio'
       )
       if (!audio)
@@ -174,7 +176,7 @@ const shareTrack = HttpRouter.params.pipe(
           type: 'music.song',
           title: audio.title || slug,
           description: audio.description || `Listen to ${audio.title || slug} on goosebumps.fm`,
-          image: audio.thumbnailUrl,
+          image: audio.thumbnailUrl ?? audio.show?.thumbnailUrl ?? null,
           canonicalPath: `/tracks/${slug}`,
           audio: audio.url,
           creators: creators.map((c) => c.name),

--- a/apps/vps/src/services/audio.service.test.ts
+++ b/apps/vps/src/services/audio.service.test.ts
@@ -5,6 +5,7 @@ import { beforeAll, describe, expect, test } from 'vitest'
 import { db } from '@/db'
 import { audioTable } from '@/db/audio.schema'
 import { user } from '@/db/auth.schema'
+import { showsTable } from '@/db/show.schema'
 import { CryptoLive } from '@/lib/crypto'
 import { MdxServiceLayer } from '@/lib/mdx'
 import { ConfigServiceLayer } from '@/services/config.service'
@@ -156,5 +157,108 @@ describe('AudioService creators', () => {
     expect(match?.creators).toEqual([
       expect.objectContaining({ id: actorId, name: 'Audio idempotency actor' })
     ])
+  })
+})
+
+const makeShow = async (thumbnailUrl: string | null) => {
+  const slug = `show-${randomUUID()}`
+  const [show] = await db
+    .insert(showsTable)
+    .values({
+      title: `Show ${slug}`,
+      slug,
+      content: '',
+      thumbnailUrl
+    })
+    .returning()
+
+  if (!show) {
+    throw new Error('Failed to insert show fixture')
+  }
+  return show
+}
+
+describe('AudioService show thumbnailUrl fallback', () => {
+  test('persists NULL when created with a showId and no thumbnailUrl of its own', async () => {
+    const service = await getService()
+    const show = await makeShow('https://example.com/show-art.png')
+    const slug = `no-thumbnail-${randomUUID()}`
+
+    const created = await Effect.runPromise(
+      service.create({ ...makeAudio(slug), showId: show.id }, [actorId], {
+        actorId,
+        idempotencyKey: randomUUID()
+      })
+    )
+
+    const [row] = await db.select().from(audioTable).where(eq(audioTable.id, created.id))
+    expect(row?.thumbnailUrl).toBeNull()
+  })
+
+  test('getByType and getBySlug fall back to the show current thumbnailUrl', async () => {
+    const service = await getService()
+    const show = await makeShow('https://example.com/show-art.png')
+    const slug = `fallback-${randomUUID()}`
+
+    const created = await Effect.runPromise(
+      service.create({ ...makeAudio(slug), showId: show.id }, [actorId], {
+        actorId,
+        idempotencyKey: randomUUID()
+      })
+    )
+
+    const bySlug = await Effect.runPromise(service.getBySlug('mix', slug))
+    expect(bySlug.thumbnailUrl).toBe('https://example.com/show-art.png')
+
+    const { data: byType } = await Effect.runPromise(
+      service.getByType('mix', { limit: 100, offset: 0 })
+    )
+    const match = byType.find((audio) => audio.id === created.id)
+    expect(match?.thumbnailUrl).toBe('https://example.com/show-art.png')
+  })
+
+  test('reflects the show new thumbnailUrl after the show art changes, not a stale copy', async () => {
+    const service = await getService()
+    const show = await makeShow('https://example.com/old-show-art.png')
+    const slug = `stale-check-${randomUUID()}`
+
+    await Effect.runPromise(
+      service.create({ ...makeAudio(slug), showId: show.id }, [actorId], {
+        actorId,
+        idempotencyKey: randomUUID()
+      })
+    )
+
+    await db
+      .update(showsTable)
+      .set({ thumbnailUrl: 'https://example.com/new-show-art.png' })
+      .where(eq(showsTable.id, show.id))
+
+    const bySlug = await Effect.runPromise(service.getBySlug('mix', slug))
+    expect(bySlug.thumbnailUrl).toBe('https://example.com/new-show-art.png')
+  })
+
+  test('keeps its own explicit thumbnailUrl instead of the show artwork', async () => {
+    const service = await getService()
+    const show = await makeShow('https://example.com/show-art.png')
+    const slug = `own-thumbnail-${randomUUID()}`
+
+    const created = await Effect.runPromise(
+      service.create(
+        {
+          ...makeAudio(slug),
+          showId: show.id,
+          thumbnailUrl: 'https://example.com/own-art.png'
+        },
+        [actorId],
+        { actorId, idempotencyKey: randomUUID() }
+      )
+    )
+
+    const [row] = await db.select().from(audioTable).where(eq(audioTable.id, created.id))
+    expect(row?.thumbnailUrl).toBe('https://example.com/own-art.png')
+
+    const bySlug = await Effect.runPromise(service.getBySlug('mix', slug))
+    expect(bySlug.thumbnailUrl).toBe('https://example.com/own-art.png')
   })
 })

--- a/apps/vps/src/services/audio.service.ts
+++ b/apps/vps/src/services/audio.service.ts
@@ -178,6 +178,9 @@ const getByTypeEffect = (
               with: {
                 audioCreators: {
                   with: { creator: true }
+                },
+                show: {
+                  columns: { thumbnailUrl: true }
                 }
               }
             }),
@@ -191,8 +194,9 @@ const getByTypeEffect = (
         })
     })
 
-    const data = audioItems.map(({ audioCreators: creators, ...audio }) => ({
+    const data = audioItems.map(({ audioCreators: creators, show, ...audio }) => ({
       ...audio,
+      thumbnailUrl: audio.thumbnailUrl ?? show?.thumbnailUrl ?? null,
       creators: creators.map(({ creator }) => ({
         id: creator.id,
         name: creator.name,
@@ -245,6 +249,9 @@ const getBySlugEffect = (type: AudioType, slug: string, mdx: MdxService, include
           with: {
             audioCreators: {
               with: { creator: true }
+            },
+            show: {
+              columns: { thumbnailUrl: true }
             }
           }
         }),
@@ -269,10 +276,11 @@ const getBySlugEffect = (type: AudioType, slug: string, mdx: MdxService, include
       compiledContent = yield* mdx.compile(audio.content).pipe(Effect.orElseSucceed(() => ''))
     }
 
-    const { audioCreators: creators, ...audioFields } = audio
+    const { audioCreators: creators, show, ...audioFields } = audio
 
     return {
       ...audioFields,
+      thumbnailUrl: audioFields.thumbnailUrl ?? show?.thumbnailUrl ?? null,
       compiledContent,
       creators: creators.map(({ creator }) => ({
         id: creator.id,
@@ -289,29 +297,10 @@ const createEffect = (
 ) =>
   Effect.gen(function* () {
     const idempotencyFingerprint = yield* createAudioFingerprint(data, creatorIds)
-    let audioData = { ...data }
-
-    if (data.showId && !data.thumbnailUrl) {
-      const showId = data.showId
-      const showResult = yield* Effect.tryPromise({
-        try: () =>
-          db
-            .select({ thumbnailUrl: showsTable.thumbnailUrl })
-            .from(showsTable)
-            .where(eq(showsTable.id, showId))
-            .limit(1),
-        catch: (error) =>
-          new DatabaseError({
-            message: `Failed to fetch show: ${getErrorMessage(error)}`,
-            operation: 'select',
-            table: 'shows'
-          })
-      })
-
-      if (showResult[0]?.thumbnailUrl) {
-        audioData = { ...audioData, thumbnailUrl: showResult[0].thumbnailUrl }
-      }
-    }
+    // thumbnailUrl is intentionally left as-is (NULL when not provided): the
+    // show's artwork is resolved at read time instead of copied here, so
+    // episodes stay in sync when a show's art changes later.
+    const audioData = { ...data }
 
     const result = yield* Effect.tryPromise({
       try: () =>
@@ -524,8 +513,28 @@ const updateEffect = (
         .pipe(Effect.orElseSucceed(() => ''))
     }
 
+    let showThumbnailUrl: string | null = null
+    const showId = updatedAudio.showId
+    if (!updatedAudio.thumbnailUrl && showId) {
+      const show = yield* Effect.tryPromise({
+        try: () =>
+          db.query.showsTable.findFirst({
+            where: eq(showsTable.id, showId),
+            columns: { thumbnailUrl: true }
+          }),
+        catch: (error) =>
+          new DatabaseError({
+            message: `Failed to fetch show: ${getErrorMessage(error)}`,
+            operation: 'select',
+            table: 'shows'
+          })
+      })
+      showThumbnailUrl = show?.thumbnailUrl ?? null
+    }
+
     return {
       ...updatedAudio,
+      thumbnailUrl: updatedAudio.thumbnailUrl ?? showThumbnailUrl,
       compiledContent,
       creators: creatorRows.map(({ creator }) => ({
         id: creator.id,

--- a/apps/vps/src/services/favorite.service.ts
+++ b/apps/vps/src/services/favorite.service.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, isNotNull, or } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
 import { Context, Effect, Layer } from 'effect'
 import { db } from '@/db'
 import { audioTable } from '@/db/audio.schema'
@@ -6,6 +7,8 @@ import { favoritesTable, type SelectFavorite } from '@/db/favorites.schema'
 import { showSubscriptionsTable, showsTable } from '@/db/show.schema'
 import { ConflictError, DatabaseError, getErrorMessage, NotFoundError } from '@/errors'
 import { recordFavoriteAdd, recordFavoriteRemove } from '@/lib/performance-monitoring'
+
+const audioShowsTable = alias(showsTable, 'audio_shows')
 
 type FavoriteWithContent = {
   id: string
@@ -433,6 +436,7 @@ const getFavoritesEffect = (
                 type: audioTable.type,
                 url: audioTable.url
               },
+              audioShowThumbnailUrl: audioShowsTable.thumbnailUrl,
               show: {
                 id: showsTable.id,
                 title: showsTable.title,
@@ -443,6 +447,7 @@ const getFavoritesEffect = (
             .from(favoritesTable)
             .leftJoin(audioTable, eq(favoritesTable.audioId, audioTable.id))
             .leftJoin(showsTable, eq(favoritesTable.showId, showsTable.id))
+            .leftJoin(audioShowsTable, eq(audioTable.showId, audioShowsTable.id))
             .where(
               and(
                 eq(favoritesTable.userId, userId),
@@ -470,9 +475,14 @@ const getFavoritesEffect = (
         offset
       })
 
-      return favorites.map((favorite) => ({
+      return favorites.map(({ audioShowThumbnailUrl, ...favorite }) => ({
         ...favorite,
-        audio: favorite.audio?.id ? favorite.audio : null,
+        audio: favorite.audio?.id
+          ? {
+              ...favorite.audio,
+              thumbnailUrl: favorite.audio.thumbnailUrl ?? audioShowThumbnailUrl ?? null
+            }
+          : null,
         show: favorite.show?.id ? favorite.show : null
       }))
     })

--- a/apps/vps/src/services/profile.service.ts
+++ b/apps/vps/src/services/profile.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from 'drizzle-orm'
+import { and, asc, eq, exists } from 'drizzle-orm'
 import { Context, Effect, Layer } from 'effect'
 import { db } from '@/db'
 import { audioCreators, audioTable } from '@/db/audio.schema'
@@ -125,26 +125,51 @@ export const getPublicProfileEffect = (username: string) =>
 
     const userMixes = yield* Effect.tryPromise({
       try: () =>
-        db
-          .select({
-            id: audioTable.id,
-            title: audioTable.title,
-            slug: audioTable.slug,
-            thumbnailUrl: audioTable.thumbnailUrl,
-            type: audioTable.type,
-            showId: audioTable.showId
-          })
-          .from(audioTable)
-          .innerJoin(audioCreators, eq(audioTable.id, audioCreators.audioId))
-          .where(and(eq(audioCreators.creatorId, foundUser.id), eq(audioTable.draft, false)))
-          .orderBy(audioTable.createdAt),
+        db.query.audioTable.findMany({
+          columns: {
+            id: true,
+            title: true,
+            slug: true,
+            thumbnailUrl: true,
+            type: true,
+            showId: true
+          },
+          with: {
+            show: {
+              columns: { thumbnailUrl: true }
+            }
+          },
+          where: and(
+            exists(
+              db
+                .select({ id: audioCreators.audioId })
+                .from(audioCreators)
+                .where(
+                  and(
+                    eq(audioCreators.audioId, audioTable.id),
+                    eq(audioCreators.creatorId, foundUser.id)
+                  )
+                )
+            ),
+            eq(audioTable.draft, false)
+          ),
+          orderBy: asc(audioTable.createdAt)
+        }),
       catch: (error) =>
         new DatabaseError({
           message: `Failed to get user mixes: ${getErrorMessage(error)}`,
           operation: 'select',
           table: 'audio'
         })
-    }).pipe(Effect.withSpan('profile.getPublic.mixes', { attributes: { userId: foundUser.id } }))
+    }).pipe(
+      Effect.map((rows) =>
+        rows.map(({ show, ...row }) => ({
+          ...row,
+          thumbnailUrl: row.thumbnailUrl ?? show?.thumbnailUrl ?? null
+        }))
+      ),
+      Effect.withSpan('profile.getPublic.mixes', { attributes: { userId: foundUser.id } })
+    )
 
     const userShows = yield* Effect.tryPromise({
       try: () =>

--- a/apps/vps/src/services/search.service.ts
+++ b/apps/vps/src/services/search.service.ts
@@ -67,35 +67,45 @@ const searchEffect = (query: string, limit: number) =>
 
     const audio = Effect.tryPromise({
       try: () =>
-        db
-          .select({
-            id: audioTable.id,
-            title: audioTable.title,
-            slug: audioTable.slug,
-            type: audioTable.type,
-            thumbnailUrl: audioTable.thumbnailUrl,
-            description: audioTable.description
-          })
-          .from(audioTable)
-          .where(
-            and(
-              eq(audioTable.draft, false),
-              or(
-                ilike(audioTable.title, pattern),
-                ilike(audioTable.description, pattern),
-                ilike(audioTable.content, pattern),
-                tagMatches(audioTable.tags, pattern)
-              )
+        db.query.audioTable.findMany({
+          columns: {
+            id: true,
+            title: true,
+            slug: true,
+            type: true,
+            thumbnailUrl: true,
+            description: true
+          },
+          with: {
+            show: {
+              columns: { thumbnailUrl: true }
+            }
+          },
+          where: and(
+            eq(audioTable.draft, false),
+            or(
+              ilike(audioTable.title, pattern),
+              ilike(audioTable.description, pattern),
+              ilike(audioTable.content, pattern),
+              tagMatches(audioTable.tags, pattern)
             )
-          )
-          .limit(limit),
+          ),
+          limit
+        }),
       catch: (error) =>
         new DatabaseError({
           message: `Failed to search audio: ${getErrorMessage(error)}`,
           operation: 'select',
           table: 'audio'
         })
-    })
+    }).pipe(
+      Effect.map((rows) =>
+        rows.map(({ show, ...row }) => ({
+          ...row,
+          thumbnailUrl: row.thumbnailUrl ?? show?.thumbnailUrl ?? null
+        }))
+      )
+    )
 
     const posts = Effect.tryPromise({
       try: () =>

--- a/apps/vps/src/services/show.service.test.ts
+++ b/apps/vps/src/services/show.service.test.ts
@@ -71,4 +71,63 @@ describe('ShowService creators', () => {
     expect(episodes).toHaveLength(1)
     expect(episodes[0]?.creators).toEqual([expect.objectContaining({ id: hostId })])
   })
+
+  test('getEpisodes falls back to the show current thumbnailUrl when an episode has none', async () => {
+    const service = await getService()
+    const slug = `show-thumb-${randomUUID()}`
+
+    const show = await Effect.runPromise(
+      service.create(
+        {
+          title: `Show ${slug}`,
+          slug,
+          content: '',
+          thumbnailUrl: 'https://example.com/show-art.png'
+        },
+        [hostId]
+      )
+    )
+
+    const episodeSlug = `episode-${randomUUID()}`
+    const [episode] = await db
+      .insert(audioTable)
+      .values({
+        title: `Episode ${episodeSlug}`,
+        slug: episodeSlug,
+        content: '',
+        type: 'mix',
+        url: 'https://example.com/audio.mp3',
+        showId: show.id
+      })
+      .returning()
+
+    if (!episode) {
+      throw new Error('Failed to insert episode fixture')
+    }
+
+    await db.insert(audioCreators).values({
+      audioId: episode.id,
+      creatorId: hostId
+    })
+
+    const { data: episodesBefore } = await Effect.runPromise(
+      service.getEpisodes(slug, { limit: 100, offset: 0 })
+    )
+    expect(episodesBefore.find((e) => e.id === episode.id)?.thumbnailUrl).toBe(
+      'https://example.com/show-art.png'
+    )
+
+    await Effect.runPromise(
+      service.update(slug, hostId, 'admin', {
+        thumbnailUrl: 'https://example.com/new-show-art.png'
+      })
+    )
+
+    const { data: episodesAfter } = await Effect.runPromise(
+      service.getEpisodes(slug, { limit: 100, offset: 0 })
+    )
+    expect(episodesAfter.find((e) => e.id === episode.id)?.thumbnailUrl).toBe(
+      'https://example.com/new-show-art.png'
+    )
+  })
 })

--- a/apps/vps/src/services/show.service.ts
+++ b/apps/vps/src/services/show.service.ts
@@ -454,6 +454,9 @@ const getEpisodesEffect = (showSlug: string, options: { limit: number; offset: n
           with: {
             audioCreators: {
               with: { creator: true }
+            },
+            show: {
+              columns: { thumbnailUrl: true }
             }
           }
         }),
@@ -465,8 +468,9 @@ const getEpisodesEffect = (showSlug: string, options: { limit: number; offset: n
         })
     })
 
-    const data = episodes.map(({ audioCreators: creators, ...episode }) => ({
+    const data = episodes.map(({ audioCreators: creators, show: episodeShow, ...episode }) => ({
       ...episode,
+      thumbnailUrl: episode.thumbnailUrl ?? episodeShow?.thumbnailUrl ?? null,
       creators: creators.map(({ creator }) => ({
         id: creator.id,
         name: creator.name,


### PR DESCRIPTION
## The leak

`createEffect` in `audio.service.ts` copied the show's `thumbnailUrl` into `audioTable.thumbnailUrl` at create time whenever an episode had a `showId` and no artwork of its own. That copy was a frozen duplicate: once persisted, it never updated again, so changing a show's artwork after the fact left every existing episode showing stale art forever. The show/episode relationship was expressed as copied data instead of a reference.

## Base branch note

This PR targets `prod` directly. PR #228 (`fix/creators-join-refactor`, the Drizzle relational-queries refactor this depends on) is already merged into `prod` as of this branch's base commit, so there is no stacking/ordering concern: `db.query.audioTable.findMany`/`findFirst` and the `audioRelations` -> `show` relation this PR relies on are already live on `prod`. Verified before branching:
- `apps/vps/src/db/index.ts` calls `drizzle(pool, { schema })`
- `apps/vps/src/services/audio.service.ts` already used `db.query.audioTable.findMany`
- `git merge-base --is-ancestor <PR228 commit> origin/prod` confirmed the merge

## The fix (both sides)

1. Stop persisting the copy. Removed the write-time show-artwork lookup and copy from `createEffect`. A newly created audio row with a `showId` and no `thumbnailUrl` of its own now persists `thumbnailUrl` as `NULL`.

2. Resolve at read time. Every read path that returns an audio row's `thumbnailUrl` now falls back to the show's current artwork when the audio row has none, via `audio.thumbnailUrl ?? audio.show?.thumbnailUrl ?? null`, using the existing `with: { show: { columns: { thumbnailUrl: true } } }` relational query (no hand-rolled joins for this relation, consistent with #228's direction). The internal `show` object is always destructured out before the response is built, so no API response gains an unexpected nested `show` field, and the wire shape stays `thumbnailUrl: string | null`.

Read paths covered:
- `audio.service.ts`: `getByTypeEffect`, `getBySlugEffect`, `updateEffect`
- `show.service.ts`: `getEpisodesEffect`
- `site-routes.ts`: `shareMix`, `shareTrack` (Open Graph share cards), converted from raw `db.select()` to the relational query with the show relation

I also grepped `apps/vps/src` for every other place an audio row's `thumbnailUrl` is read and found three more real, user-facing consumers with the same latent gap, so I fixed them too:
- `favorite.service.ts` (`getFavoritesEffect`): favorited mixes/tracks. Uses a second aliased join of `showsTable` (`alias(showsTable, 'audio_shows')`) since the existing query already joins `showsTable` once for a different purpose (the favorited show itself, when the favorite is a show-favorite, not the audio's parent show).
- `search.service.ts` (`searchEffect`): search results grid.
- `profile.service.ts` (`getPublicProfileEffect`): public profile page's list of a creator's mixes.
- `email.handlers.ts` (`sendMixNotification`): mix-release notification email cover image.

Consumers checked and deliberately left alone:
- `audio.service.ts` `markAttachedAssets(...)` calls in `createEffect`/`updateEffect`: these track the raw persisted `thumbnailUrl` for asset-lifecycle bookkeeping, not a display value. Resolving the fallback there would incorrectly mark the show's shared asset as "attached" to every episode.
- `qrcode.service.ts`, `shows.handlers.ts`, `resolve.service.ts`, `post.service.ts`: read `show.thumbnailUrl` or `post.thumbnailUrl` directly, not derived from an audio row.
- `spotify.service.ts`, `music-link-scraper.service.ts`, `music-entity/*`: `thumbnailUrl` there is scraped external metadata, unrelated to `audioTable`/`showsTable`.
- `rssXml` in `site-routes.ts`: reads `audioTable` raw but `rss.template.ts` never renders `thumbnailUrl`.
- `shareShow` in `site-routes.ts`: reads `showsTable` directly, not an audio row.

## Explicitly not in scope

No migration, no backfill. Existing rows keep their already-baked copies (accepted, per explicit instruction): their `thumbnailUrl` is non-null from the old write-time copy, so the read-time fallback never fires for them and they keep showing their frozen show-art snapshot. Only newly created episodes follow the show's art live going forward. No schema changes, no new columns/views.

## Test plan

Extended `audio.service.test.ts` and `show.service.test.ts` (real Postgres via testcontainers, existing `getService()` / `randomUUID()` conventions):
- Creating audio with a `showId` and no `thumbnailUrl` persists `NULL` in the row (checked by querying `audioTable` directly).
- `getByType` and `getBySlug` return the show's current `thumbnailUrl` as a fallback.
- Updating the show's `thumbnailUrl` after the episode was created and re-reading returns the new artwork, not a stale copy (the regression this whole change exists to prevent).
- An audio row created with its own explicit `thumbnailUrl` keeps it, unaffected by the show's artwork.
- `show.service.test.ts`: `getEpisodes` falls back to the show's art, and reflects the show's new art after an update.

Results:
- `cd apps/vps && bun run typecheck` (`tsgo --noEmit`): clean, exit 0, zero errors (including the previously-flagged `reminder-processor.ts` errors, which are not present on this base either).
- `cd apps/vps && bun run test`: full suite green, 17 files / 265 tests passed, no timeouts.
