### PR TITLE
redesign(www): dedupe show identity and artwork on mobile shows page

### DIFF
--- a/apps/www/src/components/EpisodeRow.tsx
+++ b/apps/www/src/components/EpisodeRow.tsx
@@ -1,0 +1,83 @@
+import type { SelectAudio } from '@gbfm/vps/schemas'
+import { Link } from '@tanstack/react-router'
+import { PlayButton } from '@/components/PlayButton'
+import { cn } from '@/lib/utils'
+import { useNowPlayingTrack, usePlayerActions, useTransport } from '@/services/player'
+import { toQueueTrack } from '@/services/player/toQueueTrack'
+
+interface EpisodeRowProps {
+  mix: SelectAudio
+}
+
+export function EpisodeRow({ mix }: EpisodeRowProps) {
+  const current = useNowPlayingTrack()
+  const { isPlaying } = useTransport()
+  const { playTrack, togglePlayPause } = usePlayerActions()
+
+  const isActive = current?.id === mix.id
+  const hasCreators = Boolean(mix.creators && mix.creators.length > 0)
+  const dateLabel = new Date(mix.createdAt).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  })
+
+  const handlePlay = () => {
+    if (isActive) togglePlayPause()
+    else playTrack(toQueueTrack(mix))
+  }
+
+  return (
+    <article
+      data-testid='episode-row'
+      className={cn(
+        'flex items-center justify-between gap-4 border border-border bg-card px-4 py-3 transition-colors duration-200 hover:border-foreground/50',
+        isActive && 'ring-1 ring-highlight bg-secondary'
+      )}>
+      <div className='min-w-0 flex-1'>
+        <Link
+          to='/mixes/$mixId'
+          params={{ mixId: mix.slug }}
+          className='text-base font-bold leading-tight tracking-tight text-foreground line-clamp-1 transition-colors'>
+          {mix.title}
+        </Link>
+        <div className='mt-1 flex flex-wrap items-center gap-x-2 gap-y-1'>
+          <span className='text-[11px] font-mono tracking-widest text-muted-foreground'>
+            {dateLabel}
+          </span>
+          {hasCreators && (
+            <p className='text-xs tracking-widest text-highlight/80'>
+              <span className='opacity-60'>By </span>
+              {mix.creators?.map((creator, index) => (
+                <span key={creator.id}>
+                  {creator.username ? (
+                    <Link
+                      to='/profile/$username'
+                      params={{ username: creator.username }}
+                      className='hover:underline decoration-highlight/50 underline-offset-4'>
+                      {creator.name}
+                    </Link>
+                  ) : (
+                    <span>{creator.name}</span>
+                  )}
+                  {index < (mix.creators?.length || 0) - 1 && (
+                    <span className='mx-1 opacity-50'>&</span>
+                  )}
+                </span>
+              ))}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className='shrink-0'>
+        <PlayButton
+          isActive={isActive}
+          isPlaying={isPlaying}
+          title={mix.title}
+          onClick={handlePlay}
+        />
+      </div>
+    </article>
+  )
+}

--- a/apps/www/src/components/MixListItem.tsx
+++ b/apps/www/src/components/MixListItem.tsx
@@ -2,7 +2,7 @@ import { getMixRecencyLabel } from '@gbfm/core/utils'
 import { Badge } from '@gbfm/ui'
 import type { SelectAudio } from '@gbfm/vps/schemas'
 import { Link } from '@tanstack/react-router'
-import { Pause, Play } from 'lucide-react'
+import { PlayButton } from '@/components/PlayButton'
 import { DEFAULT_IMAGE_URL } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import { useNowPlayingTrack, usePlayerActions, useTransport } from '@/services/player'
@@ -106,11 +106,6 @@ export function MixListItem({ mix, actions }: MixListItemProps) {
               title={mix.title}
               onClick={handlePlay}
             />
-            {hasCreators && (
-              <span className='text-xs text-muted-foreground font-bold tracking-widest'>
-                By {mix.creators?.map((c) => c.name).join(' & ')}
-              </span>
-            )}
           </div>
         </div>
 
@@ -134,38 +129,5 @@ export function MixListItem({ mix, actions }: MixListItemProps) {
         </div>
       </div>
     </article>
-  )
-}
-
-function PlayButton({
-  isActive,
-  isPlaying,
-  title,
-  onClick
-}: {
-  isActive: boolean
-  isPlaying: boolean
-  title: string
-  onClick: () => void
-}) {
-  const playLabel = title.split(' ')[0]
-
-  return (
-    <button
-      type='button'
-      onClick={onClick}
-      className={cn(
-        'flex items-center gap-2 px-5 py-2 text-sm font-bold border-2 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        isActive && isPlaying
-          ? 'bg-highlight text-highlight-foreground border-highlight'
-          : 'border-border text-foreground/80 hover:border-highlight hover:text-highlight'
-      )}>
-      {isActive && isPlaying ? (
-        <Pause size={14} fill='currentColor' />
-      ) : (
-        <Play size={14} fill='currentColor' />
-      )}
-      <span>{isActive && isPlaying ? 'playing' : `play ${playLabel}`}</span>
-    </button>
   )
 }

--- a/apps/www/src/components/PlayButton.tsx
+++ b/apps/www/src/components/PlayButton.tsx
@@ -1,0 +1,32 @@
+import { Pause, Play } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface PlayButtonProps {
+  isActive: boolean
+  isPlaying: boolean
+  title: string
+  onClick: () => void
+}
+
+export function PlayButton({ isActive, isPlaying, title, onClick }: PlayButtonProps) {
+  const playLabel = title.split(' ')[0]
+
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      className={cn(
+        'flex items-center gap-2 px-5 py-2 text-sm font-bold border-2 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        isActive && isPlaying
+          ? 'bg-highlight text-highlight-foreground border-highlight'
+          : 'border-border text-foreground/80 hover:border-highlight hover:text-highlight'
+      )}>
+      {isActive && isPlaying ? (
+        <Pause size={14} fill='currentColor' />
+      ) : (
+        <Play size={14} fill='currentColor' />
+      )}
+      <span>{isActive && isPlaying ? 'playing' : `play ${playLabel}`}</span>
+    </button>
+  )
+}

--- a/apps/www/src/components/shows/EpisodeGrid.tsx
+++ b/apps/www/src/components/shows/EpisodeGrid.tsx
@@ -1,5 +1,5 @@
+import { EpisodeRow } from '@/components/EpisodeRow'
 import { LoadMoreTrigger } from '@/components/LoadMoreTrigger'
-import { MixListItem } from '@/components/MixListItem'
 import { useShowEpisodes } from '@/lib/http'
 
 interface EpisodeGridProps {
@@ -18,17 +18,17 @@ export function EpisodeGrid({ showSlug }: EpisodeGridProps) {
 
   if (isPending) {
     return (
-      <div className='grid gap-2'>
+      <div className='space-y-3'>
         {Array.from({ length: 5 }).map((_, i) => (
           <div
             // oxlint-disable-next-line react/no-array-index-key
             key={i}
-            className='flex gap-3 items-start p-2'>
-            <div className='w-14 h-14 rounded-sm bg-muted/50 animate-pulse shrink-0' />
+            className='flex items-center justify-between gap-4 border border-border p-4'>
             <div className='flex-1 space-y-2'>
               <div className='h-4 w-3/4 rounded bg-muted/50 animate-pulse' />
               <div className='h-3 w-1/2 rounded bg-muted/50 animate-pulse' />
             </div>
+            <div className='h-8 w-24 rounded bg-muted/50 animate-pulse shrink-0' />
           </div>
         ))}
       </div>
@@ -52,7 +52,7 @@ export function EpisodeGrid({ showSlug }: EpisodeGridProps) {
       <h2 className='text-xl font-bold'>Episodes</h2>
       <div className='space-y-3'>
         {episodes.map((episode) => (
-          <MixListItem key={episode.id} mix={episode} />
+          <EpisodeRow key={episode.id} mix={episode} />
         ))}
         <LoadMoreTrigger
           onLoadMore={fetchNextPage}

--- a/apps/www/src/components/shows/SelectedShowBar.tsx
+++ b/apps/www/src/components/shows/SelectedShowBar.tsx
@@ -3,19 +3,19 @@ import { DEFAULT_IMAGE_URL } from '@/lib/constants'
 import type { ShowWithHosts } from '@/lib/http'
 import { SubscribeButton } from './SubscribeButton'
 
-interface ShowHeroPanelProps {
+interface SelectedShowBarProps {
   show: ShowWithHosts
 }
 
-export function ShowHeroPanel({ show }: ShowHeroPanelProps) {
+export function SelectedShowBar({ show }: SelectedShowBarProps) {
   const hostNames = show.hosts?.map((h) => h.name).join(', ')
 
   return (
-    <div className='flex flex-col sm:flex-row gap-4 sm:gap-6 items-start pt-2 mb-6 pb-6 border-b border-border/40'>
+    <div className='flex flex-col lg:flex-row gap-4 lg:gap-6 items-start pt-2 mb-6 pb-6 border-b border-border/40'>
       <img
         src={show.thumbnailUrl || DEFAULT_IMAGE_URL}
         alt={show.title}
-        className='w-20 h-20 sm:w-40 sm:h-40 object-cover border rounded-sm border-border bg-background shrink-0'
+        className='hidden lg:block w-40 h-40 object-cover border rounded-sm border-border bg-background shrink-0'
       />
       <div className='flex-1 min-w-0 space-y-2 sm:space-y-3'>
         <h2 className='text-xl sm:text-3xl font-black tracking-tight mt-0'>{show.title}</h2>
@@ -37,8 +37,8 @@ export function ShowHeroPanel({ show }: ShowHeroPanelProps) {
             <SubscribeButton showId={show.id} showTitle={show.title} />
           </div>
           <Link
-            to='/$slug'
-            params={{ slug: show.slug }}
+            to='/shows/$showSlug'
+            params={{ showSlug: show.slug }}
             className='text-sm font-medium text-primary hover:opacity-80'>
             View show page
           </Link>

--- a/apps/www/src/routes/shows/index.tsx
+++ b/apps/www/src/routes/shows/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo } from 'react'
 import { z } from 'zod'
 import { LoadMoreTrigger } from '@/components/LoadMoreTrigger'
 import { EpisodeGrid } from '@/components/shows/EpisodeGrid'
-import { ShowHeroPanel } from '@/components/shows/ShowHeroPanel'
+import { SelectedShowBar } from '@/components/shows/SelectedShowBar'
 import { ShowListItem } from '@/components/shows/ShowListItem'
 import { ShowSwitcherRail } from '@/components/shows/ShowSwitcherRail'
 import { useAllShows, type ShowWithHosts } from '@/lib/http'
@@ -117,7 +117,7 @@ function ShowsListPage() {
 function SelectedShowPanel({ show }: { show: ShowWithHosts }) {
   return (
     <section>
-      <ShowHeroPanel show={show} />
+      <SelectedShowBar show={show} />
       <EpisodeGrid showSlug={show.slug} />
     </section>
   )


### PR DESCRIPTION
## Summary

On mobile, `/shows` was showing the same show artwork three times (switcher rail card, hero panel, and every episode card), the title twice, and the host name up to four times. This was because the inline `ShowHeroPanel` duplicated identity information already shown by the switcher rail, and the episode list reused the full `MixListItem` card (built for a mixed feed, not a single show's episode list).

This PR:

- Deletes `ShowHeroPanel.tsx`, replaced by `SelectedShowBar.tsx`, which renders the selected show's title, host line, and actions (Subscribe + Open) exactly once.
- Keeps the show image out of the bar on mobile (the switcher rail's selected card already shows it there); shows it at `lg+` since the desktop sidebar only has small thumbnails.
- Preserves the existing `hidden sm:block` behavior for the show description (unchanged from `ShowHeroPanel`).
- Adds `EpisodeRow.tsx`, a compact, text-forward row for a show's episode list: title, date, play control, creators exactly once. No artwork, no description, no tags, no recency badge.
- Extracts `PlayButton` out of `MixListItem.tsx` into its own component (`PlayButton.tsx`), reused unchanged by both `MixListItem` and `EpisodeRow`.
- `EpisodeGrid.tsx` now renders `EpisodeRow` instead of `MixListItem`, so both `/shows` and `/shows/$showSlug` get the denser episode list.
- `/mixes` keeps `MixListItem` with its artwork untouched, since artwork carries real distinguishing information on that feed.
- Fixes `MixListItem` rendering `mix.creators` twice (kept the byline near the date row, removed the duplicate next to the play button).
- Fixes the "Open"/"view show page" link: `ShowHeroPanel` linked to the nonexistent `/$slug` route; the new bar links to `/shows/$showSlug`, matching the actual route file (`apps/www/src/routes/shows/$showSlug.tsx`) and verified by clicking it in a real browser.

Frontend-only change. Nothing under `apps/vps` or any DB schema/migration touched.

## Follow-up (not in this PR)

`apps/vps/src/services/audio.service.ts`'s `createEffect` persists a copy of the show's `thumbnailUrl` into `audioTable.thumbnailUrl` at insert time, so episodes carry baked-in stale copies of show art. The real fix is to stop persisting it and resolve the fallback at read time instead, which needs its own change because existing rows already have it baked in.


## Test evidence

Verified with a real dev server (proxied to the read-only production API) using `agent-browser`, at both a mobile viewport (375x812) and desktop (1280x900).

**`/shows` at 375x812** — one show image (in the switcher rail's selected card), title once, host once, actions row, episodes as text rows with no artwork.

![/shows mobile viewport showing one show image, single title and host, and text-only episode rows](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/231/01-shows-375x812.png)

**`/shows` at 1280x900** — desktop sidebar list unchanged, selected show bar now shows the show image (`hidden lg:block`), title/host once, episode rows.

![/shows desktop viewport showing the sidebar list and the show image next to the title](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/231/02-shows-1280x900.png)

**`/shows/farendradio` (canonical show detail route) at 375x812** — its own existing hero layout, with the shared `EpisodeGrid` now rendering the same compact text rows.

![show detail route mobile viewport with compact episode row](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/231/03-showslug-375x812.png)

**`/shows/farendradio` at 1280x900** — confirms the `$showSlug` route (untouched header) also benefits from the shared `EpisodeGrid` change.

![show detail route desktop viewport with compact episode row](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/231/06-showslug-1280x900.png)

**`/mixes` at 375x812** — unregressed: full artwork, tags, description, and creators rendered exactly once (fix from this PR, previously duplicated).

![/mixes mobile viewport showing full mix card with artwork and a single creators byline](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/231/04-mixes-375x812.png)

**`/mixes` at 1280x900** — unregressed at desktop too.

![/mixes desktop viewport showing multiple mix cards with artwork intact](https://d20tmfka7s58bt.cloudfront.net/pr-evidence/gbfm/231/05-mixes-1280x900.png)

Also verified by clicking "View show page" from `/shows` in the live browser: it navigates to `/shows/farendradio`, confirming the route fix (previously `to='/$slug'`, a route that does not exist).

```
$ agent-browser find text "View show page" click
$ agent-browser wait --url "**/shows/farendradio"
$ agent-browser get url
http://localhost:5174/shows/farendradio
```

Checks run locally, all exit 0:
- `bun run format:check`
- `bun run lint`
- `apps/www`: `bun run typecheck` — pre-existing, unrelated errors remain in `@gbfm/player`/`@gbfm/spotify`/effect-version-skew files not touched by this PR; every file changed in this PR has zero typecheck errors
- `apps/www`: `bun run build` — succeeds
