### PR TITLE
fix(vps): correlate creator filters via inArray in relational queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,7 @@ The standard five-role triage vocabulary. See `docs/agents/triage-labels.md`.
 ### Domain docs
 
 Single-context. See `docs/agents/domain.md`.
+
+### Drizzle queries
+
+Relational-query rules and the generated-SQL test strategy. See `docs/agents/drizzle-queries.md`.

--- a/apps/vps/drizzle/0046_melted_solo.sql
+++ b/apps/vps/drizzle/0046_melted_solo.sql
@@ -1,0 +1,3 @@
+CREATE INDEX "audio_creators_creatorId_idx" ON "audio_creators" USING btree ("creatorId");--> statement-breakpoint
+CREATE INDEX "post_creators_creatorId_idx" ON "post_creators" USING btree ("creatorId");--> statement-breakpoint
+CREATE INDEX "show_creators_creatorId_idx" ON "show_creators" USING btree ("creatorId");

--- a/apps/vps/drizzle/meta/0046_snapshot.json
+++ b/apps/vps/drizzle/meta/0046_snapshot.json
@@ -1,0 +1,3571 @@
+{
+  "id": "d58d0b54-5cbb-48d4-b9f8-37cc7b4004ac",
+  "prevId": "8e962034-e62d-4767-bcaf-a79c719d39cd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audio_creators": {
+      "name": "audio_creators",
+      "schema": "",
+      "columns": {
+        "audioId": {
+          "name": "audioId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creatorId": {
+          "name": "creatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "audio_creators_creatorId_idx": {
+          "name": "audio_creators_creatorId_idx",
+          "columns": [
+            {
+              "expression": "creatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_creators_audioId_audio_id_fk": {
+          "name": "audio_creators_audioId_audio_id_fk",
+          "tableFrom": "audio_creators",
+          "tableTo": "audio",
+          "columnsFrom": ["audioId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audio_creators_creatorId_user_id_fk": {
+          "name": "audio_creators_creatorId_user_id_fk",
+          "tableFrom": "audio_creators",
+          "tableTo": "user",
+          "columnsFrom": ["creatorId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audio_creators_audioId_creatorId_pk": {
+          "name": "audio_creators_audioId_creatorId_pk",
+          "columns": ["audioId", "creatorId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audio": {
+      "name": "audio",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnailUrl": {
+          "name": "thumbnailUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannerImageUrl": {
+          "name": "bannerImageUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "audio_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyActorId": {
+          "name": "idempotencyActorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyFingerprint": {
+          "name": "idempotencyFingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "showId": {
+          "name": "showId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "episodeNumber": {
+          "name": "episodeNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playCount": {
+          "name": "playCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "audio_slug_idx": {
+          "name": "audio_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_type_slug_unique": {
+          "name": "audio_type_slug_unique",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_actor_idempotency_unique": {
+          "name": "audio_actor_idempotency_unique",
+          "columns": [
+            {
+              "expression": "idempotencyActorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotencyKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_show_idx": {
+          "name": "audio_show_idx",
+          "columns": [
+            {
+              "expression": "showId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_type_created_idx": {
+          "name": "audio_type_created_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_tags_gin_idx": {
+          "name": "audio_tags_gin_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_showId_shows_id_fk": {
+          "name": "audio_showId_shows_id_fk",
+          "tableFrom": "audio",
+          "tableTo": "shows",
+          "columnsFrom": ["showId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "user_display_username_unique": {
+          "name": "user_display_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["display_username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_social_links": {
+      "name": "user_social_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_social_links_user_id_idx": {
+          "name": "user_social_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_social_links_user_position_uq": {
+          "name": "user_social_links_user_position_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_social_links_user_id_user_id_fk": {
+          "name": "user_social_links_user_id_user_id_fk",
+          "tableFrom": "user_social_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_delivery_logs": {
+      "name": "email_delivery_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientName": {
+          "name": "recipientName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailType": {
+          "name": "emailType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateName": {
+          "name": "templateName",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "sesMessageId": {
+          "name": "sesMessageId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bouncedAt": {
+          "name": "bouncedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complainedAt": {
+          "name": "complainedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_delivery_logs_userId_idx": {
+          "name": "email_delivery_logs_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_logs_recipientEmail_idx": {
+          "name": "email_delivery_logs_recipientEmail_idx",
+          "columns": [
+            {
+              "expression": "recipientEmail",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_logs_status_idx": {
+          "name": "email_delivery_logs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_logs_createdAt_idx": {
+          "name": "email_delivery_logs_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_delivery_logs_userId_user_id_fk": {
+          "name": "email_delivery_logs_userId_user_id_fk",
+          "tableFrom": "email_delivery_logs",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_email_preferences": {
+      "name": "user_email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mixReleaseEnabled": {
+          "name": "mixReleaseEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "promotionalEnabled": {
+          "name": "promotionalEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "systemEnabled": {
+          "name": "systemEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "globalUnsubscribe": {
+          "name": "globalUnsubscribe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "unsubscribeToken": {
+          "name": "unsubscribeToken",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_email_preferences_userId_user_id_fk": {
+          "name": "user_email_preferences_userId_user_id_fk",
+          "tableFrom": "user_email_preferences",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_preferences_userId_unique": {
+          "name": "user_email_preferences_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId"]
+        },
+        "user_email_preferences_unsubscribeToken_unique": {
+          "name": "user_email_preferences_unsubscribeToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["unsubscribeToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_id": {
+          "name": "audio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favorites_user_created_idx": {
+          "name": "favorites_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorites_user_id_user_id_fk": {
+          "name": "favorites_user_id_user_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_audio_id_audio_id_fk": {
+          "name": "favorites_audio_id_audio_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "audio",
+          "columnsFrom": ["audio_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_show_id_shows_id_fk": {
+          "name": "favorites_show_id_shows_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "shows",
+          "columnsFrom": ["show_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_audio": {
+          "name": "unique_user_audio",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "audio_id"]
+        },
+        "unique_user_show": {
+          "name": "unique_user_show",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "show_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_album_artists": {
+      "name": "music_album_artists",
+      "schema": "",
+      "columns": {
+        "albumId": {
+          "name": "albumId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artistId": {
+          "name": "artistId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayOrder": {
+          "name": "displayOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "music_album_artists_albumId_music_albums_id_fk": {
+          "name": "music_album_artists_albumId_music_albums_id_fk",
+          "tableFrom": "music_album_artists",
+          "tableTo": "music_albums",
+          "columnsFrom": ["albumId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_album_artists_artistId_music_artists_id_fk": {
+          "name": "music_album_artists_artistId_music_artists_id_fk",
+          "tableFrom": "music_album_artists",
+          "tableTo": "music_artists",
+          "columnsFrom": ["artistId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_album_artists_albumId_artistId_pk": {
+          "name": "music_album_artists_albumId_artistId_pk",
+          "columns": ["albumId", "artistId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_albums": {
+      "name": "music_albums",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artistNames": {
+          "name": "artistNames",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImageUrl": {
+          "name": "coverImageUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "albumType": {
+          "name": "albumType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_albums_slug_idx": {
+          "name": "music_albums_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_albums_createdById_user_id_fk": {
+          "name": "music_albums_createdById_user_id_fk",
+          "tableFrom": "music_albums",
+          "tableTo": "user",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_albums_slug_unique": {
+          "name": "music_albums_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_artists": {
+      "name": "music_artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_artists_slug_idx": {
+          "name": "music_artists_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_artists_createdById_user_id_fk": {
+          "name": "music_artists_createdById_user_id_fk",
+          "tableFrom": "music_artists",
+          "tableTo": "user",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_artists_slug_unique": {
+          "name": "music_artists_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_entity_links": {
+      "name": "music_entity_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "scrapedAt": {
+          "name": "scrapedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedBy": {
+          "name": "verifiedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_entity_links_entity_idx": {
+          "name": "music_entity_links_entity_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_entity_links_status_idx": {
+          "name": "music_entity_links_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_entity_links_platform_idx": {
+          "name": "music_entity_links_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_entity_links_entityType_music_entity_types_id_fk": {
+          "name": "music_entity_links_entityType_music_entity_types_id_fk",
+          "tableFrom": "music_entity_links",
+          "tableTo": "music_entity_types",
+          "columnsFrom": ["entityType"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "music_entity_links_platform_music_platforms_id_fk": {
+          "name": "music_entity_links_platform_music_platforms_id_fk",
+          "tableFrom": "music_entity_links",
+          "tableTo": "music_platforms",
+          "columnsFrom": ["platform"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "music_entity_links_verifiedBy_user_id_fk": {
+          "name": "music_entity_links_verifiedBy_user_id_fk",
+          "tableFrom": "music_entity_links",
+          "tableTo": "user",
+          "columnsFrom": ["verifiedBy"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_entity_links_unique_platform": {
+          "name": "music_entity_links_unique_platform",
+          "nullsNotDistinct": false,
+          "columns": ["entityType", "entityId", "platform"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_entity_types": {
+      "name": "music_entity_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_label_albums": {
+      "name": "music_label_albums",
+      "schema": "",
+      "columns": {
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "music_label_albums_album_id_idx": {
+          "name": "music_label_albums_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_label_albums_label_id_music_labels_id_fk": {
+          "name": "music_label_albums_label_id_music_labels_id_fk",
+          "tableFrom": "music_label_albums",
+          "tableTo": "music_labels",
+          "columnsFrom": ["label_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_label_albums_album_id_music_albums_id_fk": {
+          "name": "music_label_albums_album_id_music_albums_id_fk",
+          "tableFrom": "music_label_albums",
+          "tableTo": "music_albums",
+          "columnsFrom": ["album_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_label_albums_label_id_album_id_pk": {
+          "name": "music_label_albums_label_id_album_id_pk",
+          "columns": ["label_id", "album_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_label_artists": {
+      "name": "music_label_artists",
+      "schema": "",
+      "columns": {
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "music_label_artists_artist_id_idx": {
+          "name": "music_label_artists_artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_label_artists_label_id_music_labels_id_fk": {
+          "name": "music_label_artists_label_id_music_labels_id_fk",
+          "tableFrom": "music_label_artists",
+          "tableTo": "music_labels",
+          "columnsFrom": ["label_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_label_artists_artist_id_music_artists_id_fk": {
+          "name": "music_label_artists_artist_id_music_artists_id_fk",
+          "tableFrom": "music_label_artists",
+          "tableTo": "music_artists",
+          "columnsFrom": ["artist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_label_artists_label_id_artist_id_pk": {
+          "name": "music_label_artists_label_id_artist_id_pk",
+          "columns": ["label_id", "artist_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_label_creators": {
+      "name": "music_label_creators",
+      "schema": "",
+      "columns": {
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "music_label_creators_label_id_music_labels_id_fk": {
+          "name": "music_label_creators_label_id_music_labels_id_fk",
+          "tableFrom": "music_label_creators",
+          "tableTo": "music_labels",
+          "columnsFrom": ["label_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_label_creators_creator_id_user_id_fk": {
+          "name": "music_label_creators_creator_id_user_id_fk",
+          "tableFrom": "music_label_creators",
+          "tableTo": "user",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_label_creators_label_id_creator_id_pk": {
+          "name": "music_label_creators_label_id_creator_id_pk",
+          "columns": ["label_id", "creator_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_labels": {
+      "name": "music_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_image_url": {
+          "name": "banner_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_labels_slug_idx": {
+          "name": "music_labels_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_labels_created_by_id_user_id_fk": {
+          "name": "music_labels_created_by_id_user_id_fk",
+          "tableFrom": "music_labels",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_labels_slug_unique": {
+          "name": "music_labels_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_platforms": {
+      "name": "music_platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "websiteUrl": {
+          "name": "websiteUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iconUrl": {
+          "name": "iconUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_playlist_tracks": {
+      "name": "music_playlist_tracks",
+      "schema": "",
+      "columns": {
+        "playlistId": {
+          "name": "playlistId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trackId": {
+          "name": "trackId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_playlist_tracks_position_idx": {
+          "name": "music_playlist_tracks_position_idx",
+          "columns": [
+            {
+              "expression": "playlistId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_playlist_tracks_playlistId_music_playlists_id_fk": {
+          "name": "music_playlist_tracks_playlistId_music_playlists_id_fk",
+          "tableFrom": "music_playlist_tracks",
+          "tableTo": "music_playlists",
+          "columnsFrom": ["playlistId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_playlist_tracks_trackId_music_tracks_id_fk": {
+          "name": "music_playlist_tracks_trackId_music_tracks_id_fk",
+          "tableFrom": "music_playlist_tracks",
+          "tableTo": "music_tracks",
+          "columnsFrom": ["trackId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_playlist_tracks_playlistId_trackId_pk": {
+          "name": "music_playlist_tracks_playlistId_trackId_pk",
+          "columns": ["playlistId", "trackId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_playlists": {
+      "name": "music_playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImageUrl": {
+          "name": "coverImageUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curatorId": {
+          "name": "curatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_playlists_slug_idx": {
+          "name": "music_playlists_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_playlists_curatorId_user_id_fk": {
+          "name": "music_playlists_curatorId_user_id_fk",
+          "tableFrom": "music_playlists",
+          "tableTo": "user",
+          "columnsFrom": ["curatorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "music_playlists_createdById_user_id_fk": {
+          "name": "music_playlists_createdById_user_id_fk",
+          "tableFrom": "music_playlists",
+          "tableTo": "user",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_playlists_slug_unique": {
+          "name": "music_playlists_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_track_artists": {
+      "name": "music_track_artists",
+      "schema": "",
+      "columns": {
+        "trackId": {
+          "name": "trackId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artistId": {
+          "name": "artistId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayOrder": {
+          "name": "displayOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "music_track_artists_trackId_music_tracks_id_fk": {
+          "name": "music_track_artists_trackId_music_tracks_id_fk",
+          "tableFrom": "music_track_artists",
+          "tableTo": "music_tracks",
+          "columnsFrom": ["trackId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_track_artists_artistId_music_artists_id_fk": {
+          "name": "music_track_artists_artistId_music_artists_id_fk",
+          "tableFrom": "music_track_artists",
+          "tableTo": "music_artists",
+          "columnsFrom": ["artistId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_track_artists_trackId_artistId_pk": {
+          "name": "music_track_artists_trackId_artistId_pk",
+          "columns": ["trackId", "artistId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_tracks": {
+      "name": "music_tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artistNames": {
+          "name": "artistNames",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImageUrl": {
+          "name": "coverImageUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "albumId": {
+          "name": "albumId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trackNumber": {
+          "name": "trackNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_tracks_slug_idx": {
+          "name": "music_tracks_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_tracks_albumId_music_albums_id_fk": {
+          "name": "music_tracks_albumId_music_albums_id_fk",
+          "tableFrom": "music_tracks",
+          "tableTo": "music_albums",
+          "columnsFrom": ["albumId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "music_tracks_createdById_user_id_fk": {
+          "name": "music_tracks_createdById_user_id_fk",
+          "tableFrom": "music_tracks",
+          "tableTo": "user",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_tracks_slug_unique": {
+          "name": "music_tracks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_reminder": {
+      "name": "music_reminder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "music_title": {
+          "name": "music_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "music_url": {
+          "name": "music_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_cover_url": {
+          "name": "album_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_date": {
+          "name": "reminder_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "reminder_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_sent": {
+          "name": "is_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_reminder_user_id_idx": {
+          "name": "music_reminder_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_reminder_reminder_date_idx": {
+          "name": "music_reminder_reminder_date_idx",
+          "columns": [
+            {
+              "expression": "reminder_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_reminder_is_sent_idx": {
+          "name": "music_reminder_is_sent_idx",
+          "columns": [
+            {
+              "expression": "is_sent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_reminder_status_idx": {
+          "name": "music_reminder_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_reminder_user_id_user_id_fk": {
+          "name": "music_reminder_user_id_user_id_fk",
+          "tableFrom": "music_reminder",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribeToken": {
+          "name": "unsubscribeToken",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "unsubscribedAt": {
+          "name": "unsubscribedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_email_idx": {
+          "name": "newsletter_subscribers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_subscribers_userId_idx": {
+          "name": "newsletter_subscribers_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "newsletter_subscribers_userId_user_id_fk": {
+          "name": "newsletter_subscribers_userId_user_id_fk",
+          "tableFrom": "newsletter_subscribers",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscribers_email_unique": {
+          "name": "newsletter_subscribers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "newsletter_subscribers_unsubscribeToken_unique": {
+          "name": "newsletter_subscribers_unsubscribeToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["unsubscribeToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_creators": {
+      "name": "post_creators",
+      "schema": "",
+      "columns": {
+        "postId": {
+          "name": "postId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creatorId": {
+          "name": "creatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "post_creators_creatorId_idx": {
+          "name": "post_creators_creatorId_idx",
+          "columns": [
+            {
+              "expression": "creatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_creators_postId_posts_id_fk": {
+          "name": "post_creators_postId_posts_id_fk",
+          "tableFrom": "post_creators",
+          "tableTo": "posts",
+          "columnsFrom": ["postId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_creators_creatorId_user_id_fk": {
+          "name": "post_creators_creatorId_user_id_fk",
+          "tableFrom": "post_creators",
+          "tableTo": "user",
+          "columnsFrom": ["creatorId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_creators_postId_creatorId_pk": {
+          "name": "post_creators_postId_creatorId_pk",
+          "columns": ["postId", "creatorId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnailUrl": {
+          "name": "thumbnailUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannerImageUrl": {
+          "name": "bannerImageUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "music_entity_type": {
+          "name": "music_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "music_entity_id": {
+          "name": "music_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "posts_slug_idx": {
+          "name": "posts_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_music_entity_idx": {
+          "name": "posts_music_entity_idx",
+          "columns": [
+            {
+              "expression": "music_entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "music_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_type_created_idx": {
+          "name": "posts_type_created_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_tags_gin_idx": {
+          "name": "posts_tags_gin_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.releases": {
+      "name": "releases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnailUrl": {
+          "name": "thumbnailUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannerImageUrl": {
+          "name": "bannerImageUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamingLinks": {
+          "name": "streamingLinks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "releases_slug_idx": {
+          "name": "releases_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "releases_labelId_music_labels_id_fk": {
+          "name": "releases_labelId_music_labels_id_fk",
+          "tableFrom": "releases",
+          "tableTo": "music_labels",
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.show_creators": {
+      "name": "show_creators",
+      "schema": "",
+      "columns": {
+        "showId": {
+          "name": "showId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creatorId": {
+          "name": "creatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "show_creators_creatorId_idx": {
+          "name": "show_creators_creatorId_idx",
+          "columns": [
+            {
+              "expression": "creatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_creators_showId_shows_id_fk": {
+          "name": "show_creators_showId_shows_id_fk",
+          "tableFrom": "show_creators",
+          "tableTo": "shows",
+          "columnsFrom": ["showId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_creators_creatorId_user_id_fk": {
+          "name": "show_creators_creatorId_user_id_fk",
+          "tableFrom": "show_creators",
+          "tableTo": "user",
+          "columnsFrom": ["creatorId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "show_creators_showId_creatorId_pk": {
+          "name": "show_creators_showId_creatorId_pk",
+          "columns": ["showId", "creatorId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.show_subscriptions": {
+      "name": "show_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "showId": {
+          "name": "showId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "show_subscriptions_user_idx": {
+          "name": "show_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "show_subscriptions_show_idx": {
+          "name": "show_subscriptions_show_idx",
+          "columns": [
+            {
+              "expression": "showId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_subscriptions_userId_user_id_fk": {
+          "name": "show_subscriptions_userId_user_id_fk",
+          "tableFrom": "show_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_subscriptions_showId_shows_id_fk": {
+          "name": "show_subscriptions_showId_shows_id_fk",
+          "tableFrom": "show_subscriptions",
+          "tableTo": "shows",
+          "columnsFrom": ["showId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "show_subscriptions_user_show_unique": {
+          "name": "show_subscriptions_user_show_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId", "showId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shows": {
+      "name": "shows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnailUrl": {
+          "name": "thumbnailUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannerImageUrl": {
+          "name": "bannerImageUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "shows_slug_idx": {
+          "name": "shows_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_assets": {
+      "name": "upload_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "upload_asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "upload_asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_size": {
+          "name": "expected_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_to_table": {
+          "name": "attached_to_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_to_id": {
+          "name": "attached_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upload_assets_user_id_idx": {
+          "name": "upload_assets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upload_assets_status_idx": {
+          "name": "upload_assets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upload_assets_expires_at_idx": {
+          "name": "upload_assets_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upload_assets_attached_to_idx": {
+          "name": "upload_assets_attached_to_idx",
+          "columns": [
+            {
+              "expression": "attached_to_table",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attached_to_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upload_assets_user_id_user_id_fk": {
+          "name": "upload_assets_user_id_user_id_fk",
+          "tableFrom": "upload_assets",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "upload_assets_key_unique": {
+          "name": "upload_assets_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.audio_type": {
+      "name": "audio_type",
+      "schema": "public",
+      "values": ["mix", "track", "misc"]
+    },
+    "public.reminder_status": {
+      "name": "reminder_status",
+      "schema": "public",
+      "values": ["pending", "processing", "sent", "failed"]
+    },
+    "public.post_type": {
+      "name": "post_type",
+      "schema": "public",
+      "values": ["post", "micro"]
+    },
+    "public.upload_asset_status": {
+      "name": "upload_asset_status",
+      "schema": "public",
+      "values": ["pending", "uploaded", "attached", "expired"]
+    },
+    "public.upload_asset_type": {
+      "name": "upload_asset_type",
+      "schema": "public",
+      "values": ["image", "audio"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/vps/drizzle/meta/_journal.json
+++ b/apps/vps/drizzle/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1785056527660,
       "tag": "0045_amusing_firedrake",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1785443553422,
+      "tag": "0046_melted_solo",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/vps/src/db/audio.schema.ts
+++ b/apps/vps/src/db/audio.schema.ts
@@ -135,7 +135,10 @@ export const audioCreators = pgTable(
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' })
   },
-  (t) => [primaryKey({ columns: [t.audioId, t.creatorId] })]
+  (t) => [
+    primaryKey({ columns: [t.audioId, t.creatorId] }),
+    index('audio_creators_creatorId_idx').on(t.creatorId)
+  ]
 )
 
 export const audioRelations = relations(audioTable, ({ many, one }) => ({

--- a/apps/vps/src/db/creator-membership.ts
+++ b/apps/vps/src/db/creator-membership.ts
@@ -1,0 +1,39 @@
+import { eq, inArray } from 'drizzle-orm'
+import { db } from '@/db'
+import { audioCreators, audioTable } from '@/db/audio.schema'
+import { postCreators, postsTable } from '@/db/post.schema'
+import { showCreators, showsTable } from '@/db/show.schema'
+
+/**
+ * Membership predicates must stay uncorrelated. Drizzle relational queries
+ * (db.query.*) alias the base table, so a correlated subquery built from a
+ * standalone db.select() renders the unaliased table name and Postgres rejects
+ * it with "invalid reference to FROM-clause entry".
+ */
+
+export const audioIdsForCreator = (creatorId: string) =>
+  inArray(
+    audioTable.id,
+    db
+      .select({ id: audioCreators.audioId })
+      .from(audioCreators)
+      .where(eq(audioCreators.creatorId, creatorId))
+  )
+
+export const showIdsForCreator = (creatorId: string) =>
+  inArray(
+    showsTable.id,
+    db
+      .select({ id: showCreators.showId })
+      .from(showCreators)
+      .where(eq(showCreators.creatorId, creatorId))
+  )
+
+export const postIdsForCreator = (creatorId: string) =>
+  inArray(
+    postsTable.id,
+    db
+      .select({ id: postCreators.postId })
+      .from(postCreators)
+      .where(eq(postCreators.creatorId, creatorId))
+  )

--- a/apps/vps/src/db/label-music-entity-migration.test.ts
+++ b/apps/vps/src/db/label-music-entity-migration.test.ts
@@ -74,6 +74,36 @@ CREATE TABLE "label_creators" (
   CONSTRAINT "label_creators_labelId_creatorId_pk" PRIMARY KEY ("labelId", "creatorId")
 );
 
+CREATE TABLE "shows" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL
+);
+
+CREATE TABLE "audio" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL
+);
+
+CREATE TABLE "posts" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL
+);
+
+CREATE TABLE "audio_creators" (
+  "audioId" uuid NOT NULL REFERENCES "audio"("id"),
+  "creatorId" text NOT NULL REFERENCES "user"("id") ON DELETE cascade,
+  CONSTRAINT "audio_creators_audioId_creatorId_pk" PRIMARY KEY ("audioId", "creatorId")
+);
+
+CREATE TABLE "show_creators" (
+  "showId" uuid NOT NULL REFERENCES "shows"("id") ON DELETE cascade,
+  "creatorId" text NOT NULL REFERENCES "user"("id") ON DELETE cascade,
+  CONSTRAINT "show_creators_showId_creatorId_pk" PRIMARY KEY ("showId", "creatorId")
+);
+
+CREATE TABLE "post_creators" (
+  "postId" uuid NOT NULL REFERENCES "posts"("id"),
+  "creatorId" text NOT NULL REFERENCES "user"("id") ON DELETE cascade,
+  CONSTRAINT "post_creators_postId_creatorId_pk" PRIMARY KEY ("postId", "creatorId")
+);
+
 CREATE TABLE "releases" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
   "title" varchar(255) NOT NULL,

--- a/apps/vps/src/db/post.schema.ts
+++ b/apps/vps/src/db/post.schema.ts
@@ -121,7 +121,10 @@ export const postCreators = pgTable(
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' })
   },
-  (t) => [primaryKey({ columns: [t.postId, t.creatorId] })]
+  (t) => [
+    primaryKey({ columns: [t.postId, t.creatorId] }),
+    index('post_creators_creatorId_idx').on(t.creatorId)
+  ]
 )
 
 export const postsRelations = relations(postsTable, ({ many }) => ({

--- a/apps/vps/src/db/relational-queries.smoke.test.ts
+++ b/apps/vps/src/db/relational-queries.smoke.test.ts
@@ -1,0 +1,163 @@
+import { randomUUID } from 'node:crypto'
+import { and, asc, desc, eq, ilike, or } from 'drizzle-orm'
+import { describe, expect, test } from 'vitest'
+import { db } from '@/db'
+import { audioCreators, audioTable } from '@/db/audio.schema'
+import { audioIdsForCreator, showIdsForCreator } from '@/db/creator-membership'
+import { showCreators, showsTable } from '@/db/show.schema'
+
+/**
+ * Every db.query.* shape in the codebase, executed against real Postgres.
+ *
+ * Drizzle relational queries alias the base table and build lateral joins, so
+ * a predicate that is valid TypeScript can still emit invalid SQL. tsc cannot
+ * catch that; only execution can. These run with no fixtures because an empty
+ * result still proves the statement planned and executed.
+ */
+
+const actorId = `smoke-${randomUUID()}`
+
+describe('relational query smoke matrix', () => {
+  test('audio.service getByType, both visibility branches', async () => {
+    const shape = (where: ReturnType<typeof and>) =>
+      db.query.audioTable.findMany({
+        where,
+        limit: 1,
+        offset: 0,
+        orderBy: desc(audioTable.createdAt),
+        with: {
+          audioCreators: { with: { creator: true } },
+          show: { columns: { thumbnailUrl: true } }
+        }
+      })
+
+    await expect(
+      shape(and(eq(audioTable.type, 'mix'), eq(audioTable.draft, false)))
+    ).resolves.toBeDefined()
+    await expect(
+      shape(and(eq(audioTable.type, 'mix'), audioIdsForCreator(actorId)))
+    ).resolves.toBeDefined()
+  })
+
+  test('audio.service getBySlug', async () => {
+    await expect(
+      db.query.audioTable.findFirst({
+        where: and(eq(audioTable.type, 'mix'), eq(audioTable.slug, 'smoke-missing')),
+        with: {
+          audioCreators: { with: { creator: true } },
+          show: { columns: { thumbnailUrl: true } }
+        }
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  test('audio.service audioCreators and show lookups', async () => {
+    await expect(
+      db.query.audioCreators.findMany({
+        where: eq(audioCreators.creatorId, actorId),
+        with: { creator: true }
+      })
+    ).resolves.toBeDefined()
+
+    await expect(
+      db.query.showsTable.findFirst({
+        where: eq(showsTable.slug, 'smoke-missing'),
+        columns: { thumbnailUrl: true }
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  test('profile.service public mixes', async () => {
+    await expect(
+      db.query.audioTable.findMany({
+        columns: {
+          id: true,
+          title: true,
+          slug: true,
+          thumbnailUrl: true,
+          type: true,
+          showId: true
+        },
+        with: { show: { columns: { thumbnailUrl: true } } },
+        where: and(audioIdsForCreator(actorId), eq(audioTable.draft, false)),
+        orderBy: asc(audioTable.createdAt)
+      })
+    ).resolves.toBeDefined()
+  })
+
+  test('show.service getAll, both visibility branches', async () => {
+    const shape = (where: ReturnType<typeof and>) =>
+      db.query.showsTable.findMany({
+        where,
+        limit: 1,
+        offset: 0,
+        orderBy: [desc(showsTable.createdAt), asc(showsTable.title)],
+        with: { showCreators: { with: { creator: true } } }
+      })
+
+    await expect(shape(eq(showsTable.draft, false))).resolves.toBeDefined()
+    await expect(shape(showIdsForCreator(actorId))).resolves.toBeDefined()
+  })
+
+  test('show.service getBySlug, getEpisodes, showCreators', async () => {
+    await expect(
+      db.query.showsTable.findFirst({
+        where: and(eq(showsTable.slug, 'smoke-missing'), eq(showsTable.draft, false)),
+        with: { showCreators: { with: { creator: true } } }
+      })
+    ).resolves.toBeUndefined()
+
+    await expect(
+      db.query.audioTable.findMany({
+        where: eq(audioTable.showId, randomUUID()),
+        limit: 1,
+        offset: 0,
+        orderBy: desc(audioTable.createdAt),
+        with: {
+          audioCreators: { with: { creator: true } },
+          show: { columns: { thumbnailUrl: true } }
+        }
+      })
+    ).resolves.toBeDefined()
+
+    await expect(
+      db.query.showCreators.findMany({
+        where: eq(showCreators.creatorId, actorId),
+        with: { creator: true }
+      })
+    ).resolves.toBeDefined()
+  })
+
+  test('search.service audio search', async () => {
+    await expect(
+      db.query.audioTable.findMany({
+        with: { show: { columns: { thumbnailUrl: true } } },
+        where: and(
+          eq(audioTable.draft, false),
+          or(ilike(audioTable.title, '%smoke%'), ilike(audioTable.slug, '%smoke%'))
+        ),
+        limit: 1
+      })
+    ).resolves.toBeDefined()
+  })
+
+  test('site-routes and email handlers share card lookups', async () => {
+    await expect(
+      db.query.audioTable.findFirst({
+        where: and(
+          eq(audioTable.type, 'mix'),
+          eq(audioTable.slug, 'smoke-missing'),
+          eq(audioTable.draft, false)
+        ),
+        with: { show: { columns: { thumbnailUrl: true } } }
+      })
+    ).resolves.toBeUndefined()
+
+    await expect(
+      db.query.audioTable.findFirst({
+        where: and(eq(audioTable.id, randomUUID()), eq(audioTable.draft, false)),
+        with: { show: { columns: { thumbnailUrl: true } } }
+      })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/apps/vps/src/db/show.schema.ts
+++ b/apps/vps/src/db/show.schema.ts
@@ -33,7 +33,10 @@ export const showCreators = pgTable(
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' })
   },
-  (t) => [primaryKey({ columns: [t.showId, t.creatorId] })]
+  (t) => [
+    primaryKey({ columns: [t.showId, t.creatorId] }),
+    index('show_creators_creatorId_idx').on(t.creatorId)
+  ]
 )
 
 export const showSubscriptionsTable = pgTable(

--- a/apps/vps/src/services/audio.service.test.ts
+++ b/apps/vps/src/services/audio.service.test.ts
@@ -13,6 +13,7 @@ import { UploadAssetServiceLayer } from '@/services/upload-asset.service'
 import { AudioService, AudioServiceLayer, createAudioFingerprint } from './audio.service'
 
 const actorId = `audio-idempotency-${randomUUID()}`
+const otherActorId = `audio-other-${randomUUID()}`
 
 const makeAudio = (slug: string) => ({
   title: `Audio ${slug}`,
@@ -37,10 +38,61 @@ const getService = () =>
   )
 
 beforeAll(async () => {
-  await db.insert(user).values({
-    id: actorId,
-    name: 'Audio idempotency actor',
-    email: `${actorId}@example.com`
+  await db.insert(user).values([
+    {
+      id: actorId,
+      name: 'Audio idempotency actor',
+      email: `${actorId}@example.com`
+    },
+    {
+      id: otherActorId,
+      name: 'Audio other actor',
+      email: `${otherActorId}@example.com`
+    }
+  ])
+})
+
+describe('AudioService.getByTypeForEdit visibility', () => {
+  test('returns only the non-admin actor own audio', async () => {
+    const service = await getService()
+    const ownSlug = `own-${randomUUID()}`
+    const otherSlug = `other-${randomUUID()}`
+
+    const own = await Effect.runPromise(
+      service.create(makeAudio(ownSlug), [actorId], { actorId, idempotencyKey: randomUUID() })
+    )
+    const other = await Effect.runPromise(
+      service.create(makeAudio(otherSlug), [otherActorId], {
+        actorId: otherActorId,
+        idempotencyKey: randomUUID()
+      })
+    )
+
+    const { data } = await Effect.runPromise(
+      service.getByTypeForEdit('mix', { limit: 200, offset: 0 }, actorId, 'user')
+    )
+    const ids = data.map((audio) => audio.id)
+
+    expect(ids).toContain(own.id)
+    expect(ids).not.toContain(other.id)
+  })
+
+  test('returns audio owned by others for an admin actor', async () => {
+    const service = await getService()
+    const otherSlug = `admin-view-${randomUUID()}`
+
+    const other = await Effect.runPromise(
+      service.create(makeAudio(otherSlug), [otherActorId], {
+        actorId: otherActorId,
+        idempotencyKey: randomUUID()
+      })
+    )
+
+    const { data } = await Effect.runPromise(
+      service.getByTypeForEdit('mix', { limit: 200, offset: 0 }, actorId, 'admin')
+    )
+
+    expect(data.map((audio) => audio.id)).toContain(other.id)
   })
 })
 

--- a/apps/vps/src/services/audio.service.ts
+++ b/apps/vps/src/services/audio.service.ts
@@ -1,4 +1,4 @@
-import { and, arrayContains, count, desc, eq, inArray, sql } from 'drizzle-orm'
+import { and, arrayContains, count, desc, eq, sql } from 'drizzle-orm'
 import { Context, Crypto, Effect, Encoding, Layer } from 'effect'
 import { db } from '@/db'
 import {
@@ -8,6 +8,7 @@ import {
   type SelectAudio,
   type SelectMdxCompiledAudio
 } from '@/db/audio.schema'
+import { audioIdsForCreator } from '@/db/creator-membership'
 import { timeQuery } from '@/db/query-timer'
 import { showsTable } from '@/db/show.schema'
 import {
@@ -126,13 +127,7 @@ const getByTypeEffect = (
     const visibilityCondition = actor
       ? actor.userRole === 'admin'
         ? undefined
-        : inArray(
-            audioTable.id,
-            db
-              .select({ id: audioCreators.audioId })
-              .from(audioCreators)
-              .where(eq(audioCreators.creatorId, actor.userId))
-          )
+        : audioIdsForCreator(actor.userId)
       : eq(audioTable.draft, false)
     const whereCondition = and(
       eq(audioTable.type, type),

--- a/apps/vps/src/services/audio.service.ts
+++ b/apps/vps/src/services/audio.service.ts
@@ -1,4 +1,4 @@
-import { and, arrayContains, count, desc, eq, exists, sql } from 'drizzle-orm'
+import { and, arrayContains, count, desc, eq, inArray, sql } from 'drizzle-orm'
 import { Context, Crypto, Effect, Encoding, Layer } from 'effect'
 import { db } from '@/db'
 import {
@@ -126,16 +126,12 @@ const getByTypeEffect = (
     const visibilityCondition = actor
       ? actor.userRole === 'admin'
         ? undefined
-        : exists(
+        : inArray(
+            audioTable.id,
             db
               .select({ id: audioCreators.audioId })
               .from(audioCreators)
-              .where(
-                and(
-                  eq(audioCreators.audioId, audioTable.id),
-                  eq(audioCreators.creatorId, actor.userId)
-                )
-              )
+              .where(eq(audioCreators.creatorId, actor.userId))
           )
       : eq(audioTable.draft, false)
     const whereCondition = and(

--- a/apps/vps/src/services/post.service.ts
+++ b/apps/vps/src/services/post.service.ts
@@ -1,6 +1,7 @@
-import { and, arrayContains, count, desc, eq, exists, inArray, sql } from 'drizzle-orm'
+import { and, arrayContains, count, desc, eq, inArray, sql } from 'drizzle-orm'
 import { Context, Effect, Layer } from 'effect'
 import { db } from '@/db'
+import { postIdsForCreator } from '@/db/creator-membership'
 import { user as usersTable } from '@/db/auth.schema'
 import {
   type InsertPost,
@@ -246,17 +247,7 @@ const getAllEffect = (
     const visibilityCondition = actor
       ? actor.userRole === 'admin'
         ? undefined
-        : exists(
-            db
-              .select({ id: postCreators.postId })
-              .from(postCreators)
-              .where(
-                and(
-                  eq(postCreators.postId, postsTable.id),
-                  eq(postCreators.creatorId, actor.userId)
-                )
-              )
-          )
+        : postIdsForCreator(actor.userId)
       : eq(postsTable.draft, false)
     const whereCondition = and(visibilityCondition, contentCondition)
 

--- a/apps/vps/src/services/profile.service.test.ts
+++ b/apps/vps/src/services/profile.service.test.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from 'node:crypto'
+import { Effect } from 'effect'
+import { beforeAll, describe, expect, test } from 'vitest'
+import { db } from '@/db'
+import { audioCreators, audioTable } from '@/db/audio.schema'
+import { user } from '@/db/auth.schema'
+import { showCreators, showsTable } from '@/db/show.schema'
+import { ProfileService, ProfileServiceLayer } from './profile.service'
+
+const username = `profile-${randomUUID().slice(0, 8)}`
+const ownerId = `profile-owner-${randomUUID()}`
+const otherId = `profile-other-${randomUUID()}`
+
+const getService = () =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      return yield* ProfileService
+    }).pipe(Effect.provide(ProfileServiceLayer))
+  )
+
+const insertAudio = async (values: {
+  slug: string
+  creatorId: string
+  showId?: string
+  thumbnailUrl?: string
+  draft?: boolean
+}) => {
+  const [audio] = await db
+    .insert(audioTable)
+    .values({
+      title: `Audio ${values.slug}`,
+      slug: values.slug,
+      content: '',
+      type: 'mix',
+      url: 'https://example.com/audio.mp3',
+      showId: values.showId ?? null,
+      thumbnailUrl: values.thumbnailUrl ?? null,
+      draft: values.draft ?? false
+    })
+    .returning()
+
+  if (!audio) {
+    throw new Error('Failed to insert audio fixture')
+  }
+
+  await db.insert(audioCreators).values({ audioId: audio.id, creatorId: values.creatorId })
+  return audio
+}
+
+beforeAll(async () => {
+  await db.insert(user).values([
+    {
+      id: ownerId,
+      name: 'Profile owner',
+      email: `${ownerId}@example.com`,
+      username
+    },
+    {
+      id: otherId,
+      name: 'Profile other',
+      email: `${otherId}@example.com`,
+      username: `${username}-other`
+    }
+  ])
+})
+
+describe('getPublicProfile mixes', () => {
+  test('returns only mixes the profile user created', async () => {
+    const service = await getService()
+
+    const own = await insertAudio({ slug: `own-${randomUUID()}`, creatorId: ownerId })
+    const other = await insertAudio({ slug: `other-${randomUUID()}`, creatorId: otherId })
+
+    const profile = await Effect.runPromise(service.getPublicProfile(username))
+    const ids = profile.content.mixes.map((mix) => mix.id)
+
+    expect(ids).toContain(own.id)
+    expect(ids).not.toContain(other.id)
+  })
+
+  test('excludes draft mixes', async () => {
+    const service = await getService()
+
+    const draft = await insertAudio({
+      slug: `draft-${randomUUID()}`,
+      creatorId: ownerId,
+      draft: true
+    })
+
+    const profile = await Effect.runPromise(service.getPublicProfile(username))
+
+    expect(profile.content.mixes.map((mix) => mix.id)).not.toContain(draft.id)
+  })
+
+  test('falls back to the show thumbnailUrl when a mix has none', async () => {
+    const service = await getService()
+    const showSlug = `profile-show-${randomUUID()}`
+
+    const [show] = await db
+      .insert(showsTable)
+      .values({
+        title: `Show ${showSlug}`,
+        slug: showSlug,
+        content: '',
+        thumbnailUrl: 'https://example.com/show-art.png'
+      })
+      .returning()
+
+    if (!show) {
+      throw new Error('Failed to insert show fixture')
+    }
+
+    await db.insert(showCreators).values({ showId: show.id, creatorId: ownerId })
+
+    const episode = await insertAudio({
+      slug: `episode-${randomUUID()}`,
+      creatorId: ownerId,
+      showId: show.id
+    })
+    const standalone = await insertAudio({
+      slug: `standalone-${randomUUID()}`,
+      creatorId: ownerId,
+      thumbnailUrl: 'https://example.com/own-art.png'
+    })
+
+    const profile = await Effect.runPromise(service.getPublicProfile(username))
+    const mixes = profile.content.mixes
+
+    expect(mixes.find((mix) => mix.id === episode.id)?.thumbnailUrl).toBe(
+      'https://example.com/show-art.png'
+    )
+    expect(mixes.find((mix) => mix.id === standalone.id)?.thumbnailUrl).toBe(
+      'https://example.com/own-art.png'
+    )
+  })
+})

--- a/apps/vps/src/services/profile.service.ts
+++ b/apps/vps/src/services/profile.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, exists } from 'drizzle-orm'
+import { and, asc, eq, inArray } from 'drizzle-orm'
 import { Context, Effect, Layer } from 'effect'
 import { db } from '@/db'
 import { audioCreators, audioTable } from '@/db/audio.schema'
@@ -140,16 +140,12 @@ export const getPublicProfileEffect = (username: string) =>
             }
           },
           where: and(
-            exists(
+            inArray(
+              audioTable.id,
               db
                 .select({ id: audioCreators.audioId })
                 .from(audioCreators)
-                .where(
-                  and(
-                    eq(audioCreators.audioId, audioTable.id),
-                    eq(audioCreators.creatorId, foundUser.id)
-                  )
-                )
+                .where(eq(audioCreators.creatorId, foundUser.id))
             ),
             eq(audioTable.draft, false)
           ),

--- a/apps/vps/src/services/profile.service.ts
+++ b/apps/vps/src/services/profile.service.ts
@@ -1,7 +1,8 @@
-import { and, asc, eq, inArray } from 'drizzle-orm'
+import { and, asc, eq } from 'drizzle-orm'
 import { Context, Effect, Layer } from 'effect'
 import { db } from '@/db'
 import { audioCreators, audioTable } from '@/db/audio.schema'
+import { audioIdsForCreator } from '@/db/creator-membership'
 import {
   SOCIAL_LINK_PLATFORMS,
   type SocialLinkPlatform,
@@ -139,16 +140,7 @@ export const getPublicProfileEffect = (username: string) =>
               columns: { thumbnailUrl: true }
             }
           },
-          where: and(
-            inArray(
-              audioTable.id,
-              db
-                .select({ id: audioCreators.audioId })
-                .from(audioCreators)
-                .where(eq(audioCreators.creatorId, foundUser.id))
-            ),
-            eq(audioTable.draft, false)
-          ),
+          where: and(audioIdsForCreator(foundUser.id), eq(audioTable.draft, false)),
           orderBy: asc(audioTable.createdAt)
         }),
       catch: (error) =>

--- a/apps/vps/src/services/show.service.test.ts
+++ b/apps/vps/src/services/show.service.test.ts
@@ -72,6 +72,21 @@ describe('ShowService creators', () => {
     expect(episodes[0]?.creators).toEqual([expect.objectContaining({ id: hostId })])
   })
 
+  test('getAll scopes to the actor own shows for a non-admin actor', async () => {
+    const service = await getService()
+    const slug = `show-scoped-${randomUUID()}`
+
+    const show = await Effect.runPromise(
+      service.create({ title: `Show ${slug}`, slug, content: '' }, [hostId])
+    )
+
+    const { data: shows } = await Effect.runPromise(
+      service.getAllForEdit({ limit: 100, offset: 0 }, hostId, 'user')
+    )
+
+    expect(shows.map((s) => s.id)).toContain(show.id)
+  })
+
   test('getEpisodes falls back to the show current thumbnailUrl when an episode has none', async () => {
     const service = await getService()
     const slug = `show-thumb-${randomUUID()}`

--- a/apps/vps/src/services/show.service.test.ts
+++ b/apps/vps/src/services/show.service.test.ts
@@ -7,6 +7,7 @@ import { user } from '@/db/auth.schema'
 import { ShowService, ShowServiceLayer } from './show.service'
 
 const hostId = `show-creators-${randomUUID()}`
+const otherHostId = `show-creators-other-${randomUUID()}`
 
 const getService = () =>
   Effect.runPromise(
@@ -16,11 +17,18 @@ const getService = () =>
   )
 
 beforeAll(async () => {
-  await db.insert(user).values({
-    id: hostId,
-    name: 'Show host actor',
-    email: `${hostId}@example.com`
-  })
+  await db.insert(user).values([
+    {
+      id: hostId,
+      name: 'Show host actor',
+      email: `${hostId}@example.com`
+    },
+    {
+      id: otherHostId,
+      name: 'Other show host actor',
+      email: `${otherHostId}@example.com`
+    }
+  ])
 })
 
 describe('ShowService creators', () => {
@@ -72,19 +80,40 @@ describe('ShowService creators', () => {
     expect(episodes[0]?.creators).toEqual([expect.objectContaining({ id: hostId })])
   })
 
-  test('getAll scopes to the actor own shows for a non-admin actor', async () => {
+  test('getAllForEdit returns only the non-admin actor own shows', async () => {
     const service = await getService()
-    const slug = `show-scoped-${randomUUID()}`
+    const ownSlug = `show-own-${randomUUID()}`
+    const otherSlug = `show-other-${randomUUID()}`
 
-    const show = await Effect.runPromise(
-      service.create({ title: `Show ${slug}`, slug, content: '' }, [hostId])
+    const ownShow = await Effect.runPromise(
+      service.create({ title: `Show ${ownSlug}`, slug: ownSlug, content: '' }, [hostId])
+    )
+    const otherShow = await Effect.runPromise(
+      service.create({ title: `Show ${otherSlug}`, slug: otherSlug, content: '' }, [otherHostId])
     )
 
     const { data: shows } = await Effect.runPromise(
       service.getAllForEdit({ limit: 100, offset: 0 }, hostId, 'user')
     )
+    const ids = shows.map((s) => s.id)
 
-    expect(shows.map((s) => s.id)).toContain(show.id)
+    expect(ids).toContain(ownShow.id)
+    expect(ids).not.toContain(otherShow.id)
+  })
+
+  test('getAllForEdit returns every show for an admin actor', async () => {
+    const service = await getService()
+    const otherSlug = `show-admin-${randomUUID()}`
+
+    const otherShow = await Effect.runPromise(
+      service.create({ title: `Show ${otherSlug}`, slug: otherSlug, content: '' }, [otherHostId])
+    )
+
+    const { data: shows } = await Effect.runPromise(
+      service.getAllForEdit({ limit: 100, offset: 0 }, hostId, 'admin')
+    )
+
+    expect(shows.map((s) => s.id)).toContain(otherShow.id)
   })
 
   test('getEpisodes falls back to the show current thumbnailUrl when an episode has none', async () => {

--- a/apps/vps/src/services/show.service.ts
+++ b/apps/vps/src/services/show.service.ts
@@ -1,7 +1,8 @@
-import { and, asc, count, desc, eq, inArray } from 'drizzle-orm'
+import { and, asc, count, desc, eq } from 'drizzle-orm'
 import { Context, Effect, Layer } from 'effect'
 import { db } from '@/db'
 import { audioTable, type SelectAudio } from '@/db/audio.schema'
+import { showIdsForCreator } from '@/db/creator-membership'
 import {
   type InsertShow,
   type SelectMdxCompiledShow,
@@ -82,13 +83,7 @@ const getAllEffect = (
     const whereCondition = actor
       ? actor.userRole === 'admin'
         ? undefined
-        : inArray(
-            showsTable.id,
-            db
-              .select({ id: showCreators.showId })
-              .from(showCreators)
-              .where(eq(showCreators.creatorId, actor.userId))
-          )
+        : showIdsForCreator(actor.userId)
       : eq(showsTable.draft, false)
 
     const countResult = yield* Effect.tryPromise({

--- a/apps/vps/src/services/show.service.ts
+++ b/apps/vps/src/services/show.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, exists } from 'drizzle-orm'
+import { and, asc, count, desc, eq, inArray } from 'drizzle-orm'
 import { Context, Effect, Layer } from 'effect'
 import { db } from '@/db'
 import { audioTable, type SelectAudio } from '@/db/audio.schema'
@@ -82,16 +82,12 @@ const getAllEffect = (
     const whereCondition = actor
       ? actor.userRole === 'admin'
         ? undefined
-        : exists(
+        : inArray(
+            showsTable.id,
             db
               .select({ id: showCreators.showId })
               .from(showCreators)
-              .where(
-                and(
-                  eq(showCreators.showId, showsTable.id),
-                  eq(showCreators.creatorId, actor.userId)
-                )
-              )
+              .where(eq(showCreators.creatorId, actor.userId))
           )
       : eq(showsTable.draft, false)
 

--- a/docs/agents/drizzle-queries.md
+++ b/docs/agents/drizzle-queries.md
@@ -1,0 +1,60 @@
+# Drizzle query rules
+
+## Relational queries must not take correlated subqueries
+
+Relational queries (`db.query.*`) alias the base table:
+
+```sql
+from "shows" "showsTable"
+```
+
+An `exists()` built from a standalone `db.select()` renders its correlated
+reference with the table's real name, not the alias:
+
+```sql
+exists (select "showId" from "show_creators"
+        where "show_creators"."showId" = "shows"."id")
+```
+
+Once the table is aliased, `"shows"` is out of scope and Postgres rejects the
+statement with `invalid reference to FROM-clause entry for table "shows"`.
+
+This shipped to production in July 2026 and broke every public profile view for
+a user with mixes. `tsc` cannot catch it: the builder calls are legal
+TypeScript, and only the generated SQL is wrong.
+
+**Rule:** a predicate passed to `db.query.*` must not contain a standalone
+correlated subquery. Use an uncorrelated membership subquery, a declared
+relation, or an explicit join.
+
+```ts
+// no: correlated, breaks under aliasing
+exists(db.select().from(audioCreators).where(eq(audioCreators.audioId, audioTable.id)))
+
+// yes: uncorrelated, alias-independent
+inArray(audioTable.id, db.select({ id: audioCreators.audioId }).from(audioCreators))
+```
+
+Creator-membership predicates are centralized in `src/db/creator-membership.ts`
+(`audioIdsForCreator`, `showIdsForCreator`, `postIdsForCreator`). Use those
+rather than rebuilding the subquery per service.
+
+Watch for a condition shared between a plain `db.select()` count and a
+`db.query.*` list. Plain selects do not alias, so the count succeeds while the
+list throws, and the bug looks intermittent.
+
+## Generated SQL is a runtime artifact
+
+Treat it like compiled output: test it by executing against real Postgres.
+`src/db/relational-queries.smoke.test.ts` runs every `db.query.*` shape in the
+codebase, including both branches of each visibility predicate. Add a case there
+when you introduce a new relational query shape.
+
+Avoid SQL string snapshots. Executing catches alias bugs, schema drift, dialect
+behavior, and ORM upgrades; a snapshot only detects that the string changed.
+
+## Authorization tests must prove exclusion
+
+A visibility test that only asserts the actor's own row is returned would pass
+against a query returning every row. Always create a second user's record and
+assert it is absent, and cover the admin branch separately.


### PR DESCRIPTION
Fixes the production `DatabaseError` reported in Sentry (`gbfm-backend`, July 30, `584dcdee...`).

## Root cause

Drizzle relational queries (`db.query.*`) alias the base table:

```sql
from "shows" "showsTable"
```

The `exists()` conditions were built from a standalone `db.select()`, which renders its correlated reference using the table's **real** name:

```sql
exists (select "showId" from "show_creators"
        where ("show_creators"."showId" = "shows"."id" and ...))
```

Once the table is aliased to `showsTable`, the bare name `"shows"` is no longer in scope, so Postgres rejects the query with `invalid reference to FROM-clause entry for table "shows"`.

This is invisible to `tsc` — the builder type-checks fine and only fails at runtime.

## Fix

Replace the correlated `exists()` with an uncorrelated `inArray()` subquery at the three sites whose condition feeds a `db.query.*` call:

```sql
where "showsTable"."id" in (select "showId" from "show_creators" where ...)
```

The outer column is rendered by Drizzle itself, so it always picks up the correct alias, and the subquery no longer references the outer table. `inArray` is equivalent here because both subqueries are plain membership tests on the join table, and it is alias-independent in **both** plain-select and relational contexts — which matters because `audio`/`show` reuse one `whereCondition` across both.

## Sites fixed

| File | Impact |
|---|---|
| `profile.service.ts` `getPublicProfile` | **The reported crash.** Broke every public profile view for a user with mixes. |
| `audio.service.ts` `getByType` | Non-admin authenticated actor only. |
| `show.service.ts` `getAll` | Non-admin authenticated actor only. |

The latter two share one `whereCondition` between a plain `db.select()` count and a `db.query.*` `findMany`, so the count succeeded and only the list query threw — which is why this went unnoticed.

The other four `exists()` call sites (`site-routes.ts`, `sitemap.service.ts`, `post.service.ts`, `release.service.ts`) feed plain `db.select()` queries that don't alias, so they are correct and left alone.

## Verification

- Reproduced the exact Sentry SQL byte-for-byte via `toSQL()`, then confirmed the fix emits valid SQL for all five affected queries (including the two count queries).
- Added a `show.service` regression test for the non-admin actor path. Verified it **fails against the previous code** with the exact `FROM-clause` error, and passes after the fix.
- Full `apps/vps` suite: 266 passed against a real Postgres container. Typecheck and lint clean.