### PR TITLE
feat: harden production observability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_DEFAULT_ACCOUNT_ID }}
           CF_RULESET_IMPORT: ${{ inputs.cf_ruleset_import }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_RELEASE: ${{ steps.deployment-ref.outputs.ref }}
 
         run: |
@@ -87,3 +88,15 @@ jobs:
             bun run sst refresh --stage=prod
           fi
           bun run sst deploy --stage=prod
+
+      - name: Install Sentry CLI
+        run: curl https://cli.sentry.dev/install -fsS | bash
+
+      - name: Publish Sentry release metadata
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_RELEASE: ${{ steps.deployment-ref.outputs.ref }}
+        run: |
+          sentry release set-commits "goosebumps-collective/$SENTRY_RELEASE" --auto
+          sentry release finalize "goosebumps-collective/$SENTRY_RELEASE"
+          sentry release deploy "goosebumps-collective/$SENTRY_RELEASE" production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-24.04
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     permissions:
       id-token: write
       contents: read
@@ -80,7 +82,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_DEFAULT_ACCOUNT_ID }}
           CF_RULESET_IMPORT: ${{ inputs.cf_ruleset_import }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_RELEASE: ${{ steps.deployment-ref.outputs.ref }}
 
         run: |
@@ -89,14 +90,16 @@ jobs:
           fi
           bun run sst deploy --stage=prod
 
-      - name: Install Sentry CLI
-        run: curl https://cli.sentry.dev/install -fsS | bash
-
       - name: Publish Sentry release metadata
+        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
+        # getsentry/action-release v3.7.0
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_RELEASE: ${{ steps.deployment-ref.outputs.ref }}
-        run: |
-          sentry release set-commits "goosebumps-collective/$SENTRY_RELEASE" --auto
-          sentry release finalize "goosebumps-collective/$SENTRY_RELEASE"
-          sentry release deploy "goosebumps-collective/$SENTRY_RELEASE" production
+          SENTRY_ORG: goosebumps-collective
+          SENTRY_PROJECT: gbfm-frontend
+        with:
+          environment: production
+          release: ${{ steps.deployment-ref.outputs.ref }}
+          set_commits: auto
+          finalize: true

--- a/apps/vps/Dockerfile
+++ b/apps/vps/Dockerfile
@@ -67,4 +67,4 @@ COPY --from=deps /usr/src/app/packages/theme ./packages/theme
 COPY --from=deps /usr/src/app/apps/vps ./apps/vps
 COPY --from=deps /usr/src/app/tsconfig.json ./tsconfig.json
 
-CMD ["bun", "run", "apps/vps/scripts/run-backup-task.ts"]
+CMD ["bun", "--preload", "apps/vps/src/instrument.ts", "run", "apps/vps/scripts/run-backup-task.ts"]

--- a/apps/vps/scripts/run-backup-task.ts
+++ b/apps/vps/scripts/run-backup-task.ts
@@ -1,5 +1,6 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { sendBackupNotificationEmail } from '@gbfm/email/index'
+import * as Sentry from '@sentry/bun'
 import { Console, Effect } from 'effect'
 import { config } from '../src/services/config.service'
 import {
@@ -150,14 +151,38 @@ const createBackupEffect = withLogCapture((capture) =>
   })
 )
 
-const program = createBackupEffect.pipe(
-  Effect.match({
-    onSuccess: () => process.exit(0),
-    onFailure: (error) => {
-      console.error('Backup failed:', error)
-      process.exit(1)
-    }
-  })
+const monitorSlug = 'database-backup'
+const checkInId = Sentry.captureCheckIn(
+  { monitorSlug, status: 'in_progress' },
+  {
+    schedule: { type: 'crontab', value: '0 2 * * *' },
+    checkinMargin: 10,
+    maxRuntime: 30,
+    timezone: 'UTC',
+    failureIssueThreshold: 1,
+    recoveryThreshold: 1
+  }
 )
 
-Effect.runPromise(program)
+const finish = async (status: 'ok' | 'error') => {
+  Sentry.captureCheckIn({ monitorSlug, checkInId, status })
+  await Sentry.flush(2000)
+}
+
+const program = createBackupEffect.pipe(
+  Effect.match({
+    onSuccess: async () => {
+      await finish('ok')
+      process.exit(0)
+    },
+    onFailure: async (error) => {
+      console.error('Backup failed:', error)
+      Sentry.captureException(error)
+      await finish('error')
+      process.exit(1)
+    }
+  }),
+  Effect.runPromise
+)
+
+await program

--- a/apps/vps/scripts/run-backup-task.ts
+++ b/apps/vps/scripts/run-backup-task.ts
@@ -1,7 +1,7 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { sendBackupNotificationEmail } from '@gbfm/email/index'
 import * as Sentry from '@sentry/bun'
-import { Console, Effect } from 'effect'
+import { Console, Effect, Exit } from 'effect'
 import { config } from '../src/services/config.service'
 import {
   type BackupConfig,
@@ -152,37 +152,38 @@ const createBackupEffect = withLogCapture((capture) =>
 )
 
 const monitorSlug = 'database-backup'
-const checkInId = Sentry.captureCheckIn(
-  { monitorSlug, status: 'in_progress' },
-  {
-    schedule: { type: 'crontab', value: '0 2 * * *' },
-    checkinMargin: 10,
-    maxRuntime: 30,
-    timezone: 'UTC',
-    failureIssueThreshold: 1,
-    recoveryThreshold: 1
-  }
-)
+const monitorConfig = {
+  schedule: { type: 'crontab' as const, value: '0 2 * * *' },
+  checkinMargin: 10,
+  maxRuntime: 30,
+  timezone: 'UTC',
+  failureIssueThreshold: 1,
+  recoveryThreshold: 1
+}
 
-const finish = async (status: 'ok' | 'error') => {
+const finish = async (checkInId: string, status: 'ok' | 'error') => {
   Sentry.captureCheckIn({ monitorSlug, checkInId, status })
   await Sentry.flush(2000)
 }
 
-const program = createBackupEffect.pipe(
-  Effect.match({
-    onSuccess: async () => {
-      await finish('ok')
-      process.exit(0)
-    },
-    onFailure: async (error) => {
-      console.error('Backup failed:', error)
-      Sentry.captureException(error)
-      await finish('error')
-      process.exit(1)
-    }
-  }),
-  Effect.runPromise
-)
+const runBackupTask = async (): Promise<number> => {
+  const sentryEnabled = Sentry.getClient() !== undefined
+  const checkInId = sentryEnabled
+    ? Sentry.captureCheckIn({ monitorSlug, status: 'in_progress' }, monitorConfig)
+    : undefined
+  const exit = await Effect.runPromiseExit(createBackupEffect)
 
-await program
+  if (Exit.isSuccess(exit)) {
+    if (checkInId) await finish(checkInId, 'ok')
+    return 0
+  }
+
+  console.error('Database backup task failed')
+  if (checkInId) {
+    Sentry.captureException(new Error('Database backup task failed'))
+    await finish(checkInId, 'error')
+  }
+  return 1
+}
+
+process.exitCode = await runBackupTask()

--- a/apps/vps/src/app.ts
+++ b/apps/vps/src/app.ts
@@ -19,6 +19,8 @@ const reminderLoopEffect = Effect.gen(function* () {
 
   yield* Effect.race(Effect.sleep(Duration.millis(sleepMs)), awaitSignal)
 
+  // The recovery timer wins at least once every five minutes, including when there
+  // are no reminders due, so this is a loop heartbeat rather than a work-only check-in.
   const checkInId = yield* sentry.startCheckIn('reminder-processing', {
     schedule: { type: 'interval', value: 5, unit: 'minute' },
     checkinMargin: 2,

--- a/apps/vps/src/app.ts
+++ b/apps/vps/src/app.ts
@@ -10,6 +10,7 @@ const RECOVERY_INTERVAL_MS = 5 * 60 * 1000
 
 const reminderLoopEffect = Effect.gen(function* () {
   const { await: awaitSignal } = yield* ReminderSignalService
+  const sentry = yield* SentryService
 
   const nextDate = yield* queryNextDueReminder.pipe(Effect.catch(() => Effect.succeed(null)))
 
@@ -18,7 +19,18 @@ const reminderLoopEffect = Effect.gen(function* () {
 
   yield* Effect.race(Effect.sleep(Duration.millis(sleepMs)), awaitSignal)
 
-  yield* processPendingReminders
+  const checkInId = yield* sentry.startCheckIn('reminder-processing', {
+    schedule: { type: 'interval', value: 5, unit: 'minute' },
+    checkinMargin: 2,
+    maxRuntime: 4,
+    failureIssueThreshold: 2,
+    recoveryThreshold: 1
+  })
+
+  yield* processPendingReminders.pipe(
+    Effect.tap(() => sentry.finishCheckIn('reminder-processing', checkInId, 'ok')),
+    Effect.tapError(() => sentry.finishCheckIn('reminder-processing', checkInId, 'error'))
+  )
 }).pipe(
   Effect.catch((error) =>
     Effect.logError(
@@ -28,7 +40,21 @@ const reminderLoopEffect = Effect.gen(function* () {
   Effect.repeat(Schedule.forever)
 )
 
-const sitemapRegenerationEffect = regenerateSitemap.pipe(
+const sitemapRegenerationEffect = Effect.gen(function* () {
+  const sentry = yield* SentryService
+  const checkInId = yield* sentry.startCheckIn('sitemap-regeneration', {
+    schedule: { type: 'interval', value: 1, unit: 'hour' },
+    checkinMargin: 5,
+    maxRuntime: 10,
+    failureIssueThreshold: 2,
+    recoveryThreshold: 1
+  })
+
+  yield* regenerateSitemap.pipe(
+    Effect.tap(() => sentry.finishCheckIn('sitemap-regeneration', checkInId, 'ok')),
+    Effect.tapError(() => sentry.finishCheckIn('sitemap-regeneration', checkInId, 'error'))
+  )
+}).pipe(
   Effect.catch((error) =>
     Effect.logError(
       `Sitemap regeneration failed: ${error instanceof Error ? error.message : String(error)}`

--- a/apps/vps/src/errors.test.ts
+++ b/apps/vps/src/errors.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest'
+import { getErrorMessage } from './errors'
+
+describe('getErrorMessage', () => {
+  test('replaces Drizzle query text and parameters with a Postgres error code', () => {
+    const cause = Object.assign(new Error('duplicate key value contains private@example.com'), {
+      code: '23505'
+    })
+    const error = new Error(
+      'Failed query: select * from "user" where "email" = $1\nparams: private@example.com',
+      {
+        cause
+      }
+    )
+
+    const message = getErrorMessage(error)
+
+    expect(message).toBe('Database query failed (23505)')
+    expect(message).not.toContain('private@example.com')
+    expect(message).not.toContain('select')
+  })
+
+  test('removes an appended parameter block from generic errors', () => {
+    expect(getErrorMessage(new Error('Request failed\nparams: private-token'))).toBe(
+      'Request failed'
+    )
+  })
+
+  test.each([undefined, null, { code: 23505 }, { code: 'invalid' }])(
+    'uses the safe fallback when the database cause is invalid: %j',
+    (cause) => {
+      const error = new Error('Failed query: select private_data\nparams: private-token', {
+        cause
+      })
+
+      const message = getErrorMessage(error)
+
+      expect(message).toBe('Database query failed')
+      expect(message).not.toContain('private')
+    }
+  )
+
+  test('accepts a valid code without exposing other cause properties', () => {
+    const error = new Error('Failed query: select private_data', {
+      cause: { code: '23505', detail: 'private-token' }
+    })
+
+    expect(getErrorMessage(error)).toBe('Database query failed (23505)')
+  })
+})

--- a/apps/vps/src/errors.ts
+++ b/apps/vps/src/errors.ts
@@ -1,7 +1,20 @@
-import { Data } from 'effect'
+import { Data, Option, Schema } from 'effect'
+
+const DRIZZLE_QUERY_FAILURE = /^Failed query:/i
+const PostgresFailureCause = Schema.Struct({
+  code: Schema.String.pipe(Schema.check(Schema.isPattern(/^[A-Z0-9]{5}$/)))
+})
+const decodePostgresFailureCause = Schema.decodeUnknownOption(PostgresFailureCause)
+
+function databaseFailureSummary(error: Error): string {
+  const cause = Option.getOrUndefined(decodePostgresFailureCause(error.cause))
+  if (cause) return `Database query failed (${cause.code})`
+
+  return 'Database query failed'
+}
 
 /**
- * Extracts a human-readable message from any error type.
+ * Extracts a human-readable, telemetry-safe message from any error type.
  *
  * @param error - The error to extract a message from
  * @returns The error message string
@@ -19,7 +32,11 @@ import { Data } from 'effect'
  * // => 'Unknown error'
  */
 export function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message
+  if (error instanceof Error) {
+    return DRIZZLE_QUERY_FAILURE.test(error.message)
+      ? databaseFailureSummary(error)
+      : error.message.replace(/\nparams:[\s\S]*$/i, '')
+  }
   if (typeof error === 'string') return error
   return 'Unknown error'
 }
@@ -34,6 +51,7 @@ export class DatabaseError extends Data.TaggedError('DatabaseError')<{
   readonly message: string
   readonly operation: string
   readonly table?: string
+  readonly cause?: unknown
 }> {}
 
 export class ReminderProcessingError extends Data.TaggedError('ReminderProcessingError')<{

--- a/apps/vps/src/errors.ts
+++ b/apps/vps/src/errors.ts
@@ -51,7 +51,6 @@ export class DatabaseError extends Data.TaggedError('DatabaseError')<{
   readonly message: string
   readonly operation: string
   readonly table?: string
-  readonly cause?: unknown
 }> {}
 
 export class ReminderProcessingError extends Data.TaggedError('ReminderProcessingError')<{

--- a/apps/vps/src/http/site-routes.ts
+++ b/apps/vps/src/http/site-routes.ts
@@ -9,7 +9,7 @@ import { musicLabelCreatorsTable, musicLabelsTable } from '@/db/music-entity.sch
 import { postCreators, postsTable } from '@/db/post.schema'
 import { releasesTable } from '@/db/release.schema'
 import { showCreators, showsTable } from '@/db/show.schema'
-import { DatabaseError, NotFoundError } from '@/errors'
+import { DatabaseError, getErrorMessage, NotFoundError } from '@/errors'
 import { buildErrorHtml, buildOGHtml } from '@/routes/redirect/redirect.template'
 import { getCachedSitemap } from '@/routes/redirect/seo/sitemap.service'
 import { ResolveService } from '@/services/resolve.service'
@@ -76,7 +76,13 @@ const errorResponse =
 const fetchDb = <A>(query: () => Promise<A>, table: string) =>
   Effect.tryPromise({
     try: query,
-    catch: (error) => new DatabaseError({ message: String(error), operation: 'select', table })
+    catch: (cause) =>
+      new DatabaseError({
+        message: getErrorMessage(cause),
+        operation: 'select',
+        table,
+        cause
+      })
   })
 
 const shareMix = HttpRouter.params.pipe(

--- a/apps/vps/src/http/site-routes.ts
+++ b/apps/vps/src/http/site-routes.ts
@@ -80,8 +80,7 @@ const fetchDb = <A>(query: () => Promise<A>, table: string) =>
       new DatabaseError({
         message: getErrorMessage(cause),
         operation: 'select',
-        table,
-        cause
+        table
       })
   })
 

--- a/apps/vps/src/instrument.ts
+++ b/apps/vps/src/instrument.ts
@@ -1,5 +1,7 @@
 import { isRecord } from '@gbfm/core/utils'
+import { traceSampleRate } from '@gbfm/core/observability/trace-sampling'
 import * as Sentry from '@sentry/bun'
+import { sanitizeDatabaseSpan } from '@/lib/database-telemetry'
 import { hasLocalSentryContext, shouldEnableSentry } from '@/lib/sentry'
 
 let resource: Record<string, unknown> | undefined
@@ -33,10 +35,13 @@ if (enabled) {
     dsn,
     environment,
     release: process.env.SENTRY_RELEASE,
-    tracesSampleRate: 1.0,
+    tracesSampler: ({ inheritOrSampleWith, name, normalizedRequest }) =>
+      inheritOrSampleWith(traceSampleRate({ name, url: normalizedRequest?.url })),
+    integrations: [Sentry.postgresIntegration({ ignoreConnectSpans: true })],
     sendDefaultPii: false,
     enableLogs: true,
     debug: process.env.SENTRY_DEBUG === 'true',
+    beforeSendSpan: sanitizeDatabaseSpan,
     beforeSend: (event) => {
       return hasLocalSentryContext(event) ? null : event
     },

--- a/apps/vps/src/lib/database-telemetry.test.ts
+++ b/apps/vps/src/lib/database-telemetry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest'
+import { sanitizeDatabaseSpan, summarizeDatabaseQuery } from './database-telemetry'
+
+describe('summarizeDatabaseQuery', () => {
+  test.each([
+    ['select "audio"."id" from "audio" where "creatorId" = $1', 'SELECT audio'],
+    ['insert into "music_reminder" ("id") values ($1)', 'INSERT music_reminder'],
+    ['update public."shows" set "title" = $1', 'UPDATE shows'],
+    ['delete from "post_creators" where "postId" = $1', 'DELETE post_creators']
+  ])('summarizes %s without values', (query, description) => {
+    expect(summarizeDatabaseQuery(query).description).toBe(description)
+  })
+})
+
+describe('sanitizeDatabaseSpan', () => {
+  test('replaces SQL and parameter attributes with safe low-cardinality fields', () => {
+    const span = sanitizeDatabaseSpan({
+      op: 'default',
+      description: 'select "audio"."id" from "audio" where "creatorId" = $1',
+      data: {
+        'db.system': 'postgresql',
+        'db.statement': 'select "audio"."id" from "audio" where "creatorId" = $1',
+        'db.query.text': 'select "audio"."id" from "audio" where "creatorId" = $1',
+        'db.query.parameters': 'secret-user-id',
+        'server.address': 'database.internal'
+      }
+    })
+
+    expect(span).toEqual({
+      op: 'db.query',
+      description: 'SELECT audio',
+      data: {
+        'db.system': 'postgresql',
+        'server.address': 'database.internal',
+        'sentry.op': 'db.query',
+        'db.system.name': 'postgresql',
+        'db.operation.name': 'SELECT',
+        'db.collection.name': 'audio',
+        'db.query.summary': 'SELECT audio'
+      }
+    })
+    expect(JSON.stringify(span)).not.toContain('secret-user-id')
+    expect(JSON.stringify(span)).not.toContain('creatorId')
+  })
+
+  test('leaves non-database spans unchanged', () => {
+    const span = { op: 'http.server', description: 'GET /health', data: {} }
+    expect(sanitizeDatabaseSpan(span)).toBe(span)
+  })
+})

--- a/apps/vps/src/lib/database-telemetry.test.ts
+++ b/apps/vps/src/lib/database-telemetry.test.ts
@@ -6,7 +6,12 @@ describe('summarizeDatabaseQuery', () => {
     ['select "audio"."id" from "audio" where "creatorId" = $1', 'SELECT audio'],
     ['insert into "music_reminder" ("id") values ($1)', 'INSERT music_reminder'],
     ['update public."shows" set "title" = $1', 'UPDATE shows'],
-    ['delete from "post_creators" where "postId" = $1', 'DELETE post_creators']
+    ['delete from "post_creators" where "postId" = $1', 'DELETE post_creators'],
+    ['with matching as (select "id" from "audio") update "shows" set "title" = $1', 'UPDATE shows'],
+    [
+      'with recursive tree as (select "id" from "shows") delete from "shows" where "id" = $1',
+      'DELETE shows'
+    ]
   ])('summarizes %s without values', (query, description) => {
     expect(summarizeDatabaseQuery(query).description).toBe(description)
   })
@@ -22,6 +27,8 @@ describe('sanitizeDatabaseSpan', () => {
         'db.statement': 'select "audio"."id" from "audio" where "creatorId" = $1',
         'db.query.text': 'select "audio"."id" from "audio" where "creatorId" = $1',
         'db.query.parameters': 'secret-user-id',
+        'db.operation.parameters': 'another-secret',
+        'db.query.parameter.0': 'one-more-secret',
         'server.address': 'database.internal'
       }
     })
@@ -40,7 +47,41 @@ describe('sanitizeDatabaseSpan', () => {
       }
     })
     expect(JSON.stringify(span)).not.toContain('secret-user-id')
+    expect(JSON.stringify(span)).not.toContain('another-secret')
+    expect(JSON.stringify(span)).not.toContain('one-more-secret')
     expect(JSON.stringify(span)).not.toContain('creatorId')
+  })
+
+  test('extracts SQL text from query config objects without retaining values', () => {
+    const span = sanitizeDatabaseSpan({
+      data: {
+        'db.system.name': 'postgresql',
+        'db.query': {
+          text: 'insert into "music_reminder" ("id") values ($1)',
+          values: ['secret-reminder-id']
+        }
+      }
+    })
+
+    expect(span).toMatchObject({
+      description: 'INSERT music_reminder',
+      data: { 'db.collection.name': 'music_reminder' }
+    })
+    expect(JSON.stringify(span)).not.toContain('secret-reminder-id')
+  })
+
+  test('preserves the instrumented database system instead of relabelling it', () => {
+    const span = sanitizeDatabaseSpan({
+      description: 'select value from cache',
+      data: { 'db.system': 'redis' }
+    })
+
+    expect(span).toMatchObject({
+      data: {
+        'db.system': 'redis',
+        'db.system.name': 'redis'
+      }
+    })
   })
 
   test('leaves non-database spans unchanged', () => {

--- a/apps/vps/src/lib/database-telemetry.ts
+++ b/apps/vps/src/lib/database-telemetry.ts
@@ -1,12 +1,12 @@
-const DATABASE_TEXT_ATTRIBUTE_KEYS = [
-  'db.statement',
-  'db.query',
-  'db.query.text',
-  'db.query.parameters'
-] as const
-const DATABASE_TEXT_ATTRIBUTES = new Set<string>(DATABASE_TEXT_ATTRIBUTE_KEYS)
-
-const SQL_OPERATION_PATTERN = /\b(select|insert|update|delete)\b/i
+const DATABASE_QUERY_ATTRIBUTE_KEYS = ['db.statement', 'db.query', 'db.query.text'] as const
+const SAFE_DATABASE_ATTRIBUTE_KEYS = new Set([
+  'db.system',
+  'db.system.name',
+  'db.namespace',
+  'db.name',
+  'server.address',
+  'server.port'
+])
 const TABLE_PATTERNS: Readonly<Record<string, RegExp>> = {
   SELECT: /\bfrom\s+((?:"[^"]+"|[\w$]+)(?:\s*\.\s*(?:"[^"]+"|[\w$]+))?)/i,
   INSERT: /\binsert\s+into\s+((?:"[^"]+"|[\w$]+)(?:\s*\.\s*(?:"[^"]+"|[\w$]+))?)/i,
@@ -26,9 +26,92 @@ export type DatabaseQuerySummary = {
   readonly description: string
 }
 
+type SqlOperation = 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE'
+
 function unquoteIdentifier(identifier: string): string {
   const part = identifier.split('.').at(-1)?.trim() ?? ''
   return part.startsWith('"') && part.endsWith('"') ? part.slice(1, -1) : part
+}
+
+function findTopLevelOperation(
+  query: string
+): { operation: SqlOperation; index: number } | undefined {
+  let depth = 0
+
+  for (let index = 0; index < query.length; index += 1) {
+    const character = query[index]
+    const nextCharacter = query[index + 1]
+
+    if (character === '-' && nextCharacter === '-') {
+      const lineEnd = query.indexOf('\n', index + 2)
+      if (lineEnd === -1) return undefined
+      index = lineEnd
+      continue
+    }
+
+    if (character === '/' && nextCharacter === '*') {
+      const commentEnd = query.indexOf('*/', index + 2)
+      if (commentEnd === -1) return undefined
+      index = commentEnd + 1
+      continue
+    }
+
+    if (character === "'" || character === '"') {
+      const quote = character
+      for (index += 1; index < query.length; index += 1) {
+        if (query[index] !== quote) continue
+        if (query[index + 1] === quote) {
+          index += 1
+          continue
+        }
+        break
+      }
+      continue
+    }
+
+    if (character === '$') {
+      const delimiter = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/.exec(query.slice(index))?.[0]
+      if (delimiter) {
+        const valueEnd = query.indexOf(delimiter, index + delimiter.length)
+        if (valueEnd === -1) return undefined
+        index = valueEnd + delimiter.length - 1
+        continue
+      }
+    }
+
+    if (character === '(') {
+      depth += 1
+      continue
+    }
+    if (character === ')') {
+      depth = Math.max(0, depth - 1)
+      continue
+    }
+
+    if (depth !== 0 || character === undefined || !/[A-Za-z]/.test(character)) continue
+
+    const token = /^[A-Za-z]+/.exec(query.slice(index))?.[0]
+    if (!token) continue
+
+    const operation = token.toUpperCase()
+    if (
+      operation === 'SELECT' ||
+      operation === 'INSERT' ||
+      operation === 'UPDATE' ||
+      operation === 'DELETE'
+    ) {
+      return { operation, index }
+    }
+    index += token.length - 1
+  }
+
+  return undefined
+}
+
+function extractQueryText(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  if (typeof value !== 'object' || value === null || !('text' in value)) return undefined
+  return typeof value.text === 'string' ? value.text : undefined
 }
 
 /**
@@ -37,8 +120,10 @@ function unquoteIdentifier(identifier: string): string {
  * Bind parameters, predicates, selected columns, and literal values are deliberately discarded.
  */
 export function summarizeDatabaseQuery(query: string): DatabaseQuerySummary {
-  const operation = query.match(SQL_OPERATION_PATTERN)?.[1]?.toUpperCase() ?? 'QUERY'
-  const tableMatch = TABLE_PATTERNS[operation]?.exec(query)
+  const match = findTopLevelOperation(query)
+  const operation = match?.operation ?? 'QUERY'
+  const operationQuery = match ? query.slice(match.index) : query
+  const tableMatch = TABLE_PATTERNS[operation]?.exec(operationQuery)
   const table = tableMatch?.[1] ? unquoteIdentifier(tableMatch[1]) : 'unknown'
 
   return {
@@ -53,23 +138,23 @@ export function summarizeDatabaseQuery(query: string): DatabaseQuerySummary {
  */
 export function sanitizeDatabaseSpan<T extends DatabaseSpan>(span: T): T {
   const dbSystem = span.data['db.system.name'] ?? span.data['db.system']
-  if (dbSystem === undefined) return span
+  if (typeof dbSystem !== 'string') return span
 
-  const rawQuery = DATABASE_TEXT_ATTRIBUTE_KEYS.flatMap((key) => {
-    const value = span.data[key]
-    return typeof value === 'string' ? [value] : []
+  const rawQuery = DATABASE_QUERY_ATTRIBUTE_KEYS.flatMap((key) => {
+    const query = extractQueryText(span.data[key])
+    return query ? [query] : []
   })[0]
   const summary = summarizeDatabaseQuery(rawQuery ?? span.description ?? '')
   const data: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(span.data)) {
-    if (!DATABASE_TEXT_ATTRIBUTES.has(key)) {
+    if (SAFE_DATABASE_ATTRIBUTE_KEYS.has(key)) {
       data[key] = value
     }
   }
 
   data['sentry.op'] = 'db.query'
-  data['db.system.name'] = 'postgresql'
+  data['db.system.name'] = dbSystem
   data['db.operation.name'] = summary.operation
   data['db.collection.name'] = summary.table
   data['db.query.summary'] = summary.description

--- a/apps/vps/src/lib/database-telemetry.ts
+++ b/apps/vps/src/lib/database-telemetry.ts
@@ -1,0 +1,83 @@
+const DATABASE_TEXT_ATTRIBUTE_KEYS = [
+  'db.statement',
+  'db.query',
+  'db.query.text',
+  'db.query.parameters'
+] as const
+const DATABASE_TEXT_ATTRIBUTES = new Set<string>(DATABASE_TEXT_ATTRIBUTE_KEYS)
+
+const SQL_OPERATION_PATTERN = /\b(select|insert|update|delete)\b/i
+const TABLE_PATTERNS: Readonly<Record<string, RegExp>> = {
+  SELECT: /\bfrom\s+((?:"[^"]+"|[\w$]+)(?:\s*\.\s*(?:"[^"]+"|[\w$]+))?)/i,
+  INSERT: /\binsert\s+into\s+((?:"[^"]+"|[\w$]+)(?:\s*\.\s*(?:"[^"]+"|[\w$]+))?)/i,
+  UPDATE: /\bupdate\s+((?:"[^"]+"|[\w$]+)(?:\s*\.\s*(?:"[^"]+"|[\w$]+))?)/i,
+  DELETE: /\bdelete\s+from\s+((?:"[^"]+"|[\w$]+)(?:\s*\.\s*(?:"[^"]+"|[\w$]+))?)/i
+}
+
+type DatabaseSpan = {
+  readonly data: Readonly<Record<string, unknown>>
+  readonly description?: string
+  readonly op?: string
+}
+
+export type DatabaseQuerySummary = {
+  readonly operation: string
+  readonly table: string
+  readonly description: string
+}
+
+function unquoteIdentifier(identifier: string): string {
+  const part = identifier.split('.').at(-1)?.trim() ?? ''
+  return part.startsWith('"') && part.endsWith('"') ? part.slice(1, -1) : part
+}
+
+/**
+ * Reduces SQL to low-cardinality fields that are safe to send to telemetry.
+ *
+ * Bind parameters, predicates, selected columns, and literal values are deliberately discarded.
+ */
+export function summarizeDatabaseQuery(query: string): DatabaseQuerySummary {
+  const operation = query.match(SQL_OPERATION_PATTERN)?.[1]?.toUpperCase() ?? 'QUERY'
+  const tableMatch = TABLE_PATTERNS[operation]?.exec(query)
+  const table = tableMatch?.[1] ? unquoteIdentifier(tableMatch[1]) : 'unknown'
+
+  return {
+    operation,
+    table,
+    description: table === 'unknown' ? operation : `${operation} ${table}`
+  }
+}
+
+/**
+ * Removes raw SQL and parameters from a Sentry database span while preserving useful DB semantics.
+ */
+export function sanitizeDatabaseSpan<T extends DatabaseSpan>(span: T): T {
+  const dbSystem = span.data['db.system.name'] ?? span.data['db.system']
+  if (dbSystem === undefined) return span
+
+  const rawQuery = DATABASE_TEXT_ATTRIBUTE_KEYS.flatMap((key) => {
+    const value = span.data[key]
+    return typeof value === 'string' ? [value] : []
+  })[0]
+  const summary = summarizeDatabaseQuery(rawQuery ?? span.description ?? '')
+  const data: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(span.data)) {
+    if (!DATABASE_TEXT_ATTRIBUTES.has(key)) {
+      data[key] = value
+    }
+  }
+
+  data['sentry.op'] = 'db.query'
+  data['db.system.name'] = 'postgresql'
+  data['db.operation.name'] = summary.operation
+  data['db.collection.name'] = summary.table
+  data['db.query.summary'] = summary.description
+
+  return {
+    ...span,
+    op: 'db.query',
+    description: summary.description,
+    data
+  }
+}

--- a/apps/vps/src/services/sentry-client.service.ts
+++ b/apps/vps/src/services/sentry-client.service.ts
@@ -1,8 +1,10 @@
+import { traceSampleRate } from '@gbfm/core/observability/trace-sampling'
 import * as Sentry from '@sentry/bun'
 
 type Client = NonNullable<ReturnType<typeof Sentry.getClient>>
 
 import { Context, Effect, Layer } from 'effect'
+import { sanitizeDatabaseSpan } from '@/lib/database-telemetry'
 import { hasLocalSentryContext, shouldEnableSentry } from '@/lib/sentry'
 import { ConfigService } from './config.service'
 
@@ -38,10 +40,13 @@ export const SentryClientServiceLayer = Layer.effect(
           dsn: sentry.dsn,
           environment: sentry.environment,
           release: process.env.SENTRY_RELEASE,
-          tracesSampleRate: 1.0,
+          tracesSampler: ({ inheritOrSampleWith, name, normalizedRequest }) =>
+            inheritOrSampleWith(traceSampleRate({ name, url: normalizedRequest?.url })),
+          integrations: [Sentry.postgresIntegration({ ignoreConnectSpans: true })],
           sendDefaultPii: false,
           enableLogs: true,
           debug: debugSentry,
+          beforeSendSpan: sanitizeDatabaseSpan,
           beforeSend: (event) => {
             return hasLocalSentryContext(event) ? null : event
           },

--- a/apps/vps/src/services/sentry.service.ts
+++ b/apps/vps/src/services/sentry.service.ts
@@ -2,12 +2,23 @@ import * as Sentry from '@sentry/bun'
 import { Context, Effect, Layer } from 'effect'
 import { SentryClientService } from './sentry-client.service'
 
+type MonitorConfig = NonNullable<Parameters<typeof Sentry.captureCheckIn>[1]>
+
 export interface SentryService {
   readonly captureException: (
     error: unknown,
     context?: Record<string, unknown>
   ) => Effect.Effect<void>
   readonly captureMessage: (message: string, level?: Sentry.SeverityLevel) => Effect.Effect<void>
+  readonly startCheckIn: (
+    monitorSlug: string,
+    monitorConfig: MonitorConfig
+  ) => Effect.Effect<string | undefined>
+  readonly finishCheckIn: (
+    monitorSlug: string,
+    checkInId: string | undefined,
+    status: 'ok' | 'error'
+  ) => Effect.Effect<void>
 }
 
 export const SentryService = Context.Service<SentryService>('SentryService')
@@ -27,6 +38,16 @@ export const SentryServiceLayer = Layer.effect(
         Effect.sync(() => {
           if (!enabled) return
           Sentry.captureMessage(message, level)
+        }),
+      startCheckIn: (monitorSlug, monitorConfig) =>
+        Effect.sync(() => {
+          if (!enabled) return undefined
+          return Sentry.captureCheckIn({ monitorSlug, status: 'in_progress' }, monitorConfig)
+        }),
+      finishCheckIn: (monitorSlug, checkInId, status) =>
+        Effect.sync(() => {
+          if (!enabled || !checkInId) return
+          Sentry.captureCheckIn({ monitorSlug, checkInId, status })
         })
     }
   })

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@overengineering/fps-meter": "0.2.4",
     "@playwright/test": "1.59.1",
+    "@sentry/vite-plugin": "5.4.0",
     "@tailwindcss/typography": "0.5.19",
     "@tailwindcss/vite": "4.2.4",
     "@tanstack/router-devtools": "1.166.13",

--- a/apps/www/src/main.tsx
+++ b/apps/www/src/main.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react'
+import { traceSampleRate } from '@gbfm/core/observability/trace-sampling'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { Loader2 } from 'lucide-react'
@@ -60,8 +61,20 @@ if (env.sentryDsn && (!env.isDev || env.sentryEnableLocal)) {
     release: env.sentryRelease,
     debug: env.isDev,
     enableLogs: true,
-    integrations: [Sentry.browserTracingIntegration()],
-    tracesSampleRate: 1.0,
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.replayIntegration({
+        maskAllText: true,
+        blockAllMedia: true
+      })
+    ],
+    tracesSampler: ({ inheritOrSampleWith, location, name }) =>
+      inheritOrSampleWith(
+        traceSampleRate({
+          name,
+          url: location ? `${location.pathname}${location.search}` : undefined
+        })
+      ),
     tracePropagationTargets,
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: env.isDev ? 0 : 1.0,
@@ -69,25 +82,6 @@ if (env.sentryDsn && (!env.isDev || env.sentryEnableLocal)) {
     beforeSend: (event) => (hasLocalUrl(event) ? null : event),
     beforeSendTransaction: (event) => (hasLocalUrl(event) ? null : event)
   })
-
-  // Replay only ever fires on error (replaysSessionSampleRate is 0), so its ~300KB
-  // client is loaded on first error instead of shipping in the initial bundle.
-  if (!env.isDev) {
-    let replayLoading = false
-    const client = Sentry.getClient()
-    client?.on('beforeSendEvent', (event) => {
-      if (replayLoading || event.exception === undefined) return
-      replayLoading = true
-      import('@sentry/react').then(({ replayIntegration }) => {
-        client.addIntegration(
-          replayIntegration({
-            maskAllText: false,
-            blockAllMedia: false
-          })
-        )
-      })
-    })
-  }
 }
 
 function App() {

--- a/apps/www/src/main.tsx
+++ b/apps/www/src/main.tsx
@@ -61,13 +61,7 @@ if (env.sentryDsn && (!env.isDev || env.sentryEnableLocal)) {
     release: env.sentryRelease,
     debug: env.isDev,
     enableLogs: true,
-    integrations: [
-      Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration({
-        maskAllText: true,
-        blockAllMedia: true
-      })
-    ],
+    integrations: [Sentry.browserTracingIntegration()],
     tracesSampler: ({ inheritOrSampleWith, location, name }) =>
       inheritOrSampleWith(
         traceSampleRate({
@@ -82,6 +76,23 @@ if (env.sentryDsn && (!env.isDev || env.sentryEnableLocal)) {
     beforeSend: (event) => (hasLocalUrl(event) ? null : event),
     beforeSendTransaction: (event) => (hasLocalUrl(event) ? null : event)
   })
+
+  if (!env.isDev) {
+    const client = Sentry.getClient()
+    Sentry.lazyLoadIntegration('replayIntegration').then(
+      (replayIntegration) => {
+        client?.addIntegration(
+          replayIntegration({
+            maskAllText: true,
+            blockAllMedia: true
+          })
+        )
+      },
+      () => {
+        Sentry.captureMessage('Failed to load browser replay integration', 'warning')
+      }
+    )
+  }
 }
 
 function App() {

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage } from 'node:http'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'node:path'
@@ -10,6 +11,8 @@ import { repoChangelogPlugin } from './plugins/repo-changelog'
 import { themeColorsPlugin } from './plugins/theme-colors'
 
 const VPS_PROXY_TARGET = process.env.VITE_VPS_BASE_URL || 'http://127.0.0.1:3003'
+const sentryRelease = process.env.SENTRY_RELEASE
+const shouldUploadSourceMaps = Boolean(process.env.SENTRY_AUTH_TOKEN && sentryRelease)
 
 const vpsProxy = {
   target: VPS_PROXY_TARGET,
@@ -37,8 +40,31 @@ export default defineConfig({
       })
     },
     tanstackRouter({ autoCodeSplitting: true }),
-    react({ include: /\.(jsx|js|mdx|md|tsx|ts)$/ })
+    react({ include: /\.(jsx|js|mdx|md|tsx|ts)$/ }),
+    ...(shouldUploadSourceMaps
+      ? [
+          sentryVitePlugin({
+            org: 'goosebumps-collective',
+            project: 'gbfm-frontend',
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+            telemetry: false,
+            sourcemaps: {
+              filesToDeleteAfterUpload: ['./dist/**/*.map']
+            },
+            release: {
+              name: sentryRelease,
+              create: true,
+              finalize: false,
+              setCommits: false,
+              deploy: false
+            }
+          })
+        ]
+      : [])
   ],
+  build: {
+    sourcemap: shouldUploadSourceMaps ? 'hidden' : false
+  },
   resolve: {
     alias: {
       '@': resolve(fileURLToPath(new URL('.', import.meta.url)), 'src')

--- a/bun.lock
+++ b/bun.lock
@@ -185,6 +185,7 @@
       "devDependencies": {
         "@overengineering/fps-meter": "0.2.4",
         "@playwright/test": "1.59.1",
+        "@sentry/vite-plugin": "5.4.0",
         "@tailwindcss/typography": "0.5.19",
         "@tailwindcss/vite": "4.2.4",
         "@tanstack/router-devtools": "1.166.13",
@@ -1445,6 +1446,28 @@
 
     "@sentry/bun": ["@sentry/bun@10.52.0", "", { "dependencies": { "@sentry/core": "10.52.0", "@sentry/node": "10.52.0" } }, "sha512-dLcfS0OyNcKN13uUJ0w11JGOtRVV3+3BN+/QbnssJdciX1BCglWTLOjxfFE8URMk9uskI9fyIH2IsJb2XR/xtg=="],
 
+    "@sentry/bundler-plugins": ["@sentry/bundler-plugins@10.69.0", "", { "dependencies": { "@babel/core": "^7.18.5", "@sentry/cli": "^2.58.6", "@sentry/core": "10.69.0", "dotenv": "^17.4.2", "find-up": "^5.0.0", "glob": "^13.0.6", "magic-string": "~0.30.8" }, "peerDependencies": { "rollup": ">=3.2.0", "webpack": ">=5.0.0" }, "optionalPeers": ["rollup", "webpack"] }, "sha512-I1otnSJIH4IOugLp+kcBbT0Kcex+J8xnHuUyzMAwCYSpZ0FMVvA723uNmkMdW0PxRRw0oEhe0qDB+t+ZjHxUiA=="],
+
+    "@sentry/cli": ["@sentry/cli@2.58.6", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.58.6", "@sentry/cli-linux-arm": "2.58.6", "@sentry/cli-linux-arm64": "2.58.6", "@sentry/cli-linux-i686": "2.58.6", "@sentry/cli-linux-x64": "2.58.6", "@sentry/cli-win32-arm64": "2.58.6", "@sentry/cli-win32-i686": "2.58.6", "@sentry/cli-win32-x64": "2.58.6" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg=="],
+
+    "@sentry/cli-darwin": ["@sentry/cli-darwin@2.58.6", "", { "os": "darwin" }, "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA=="],
+
+    "@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw=="],
+
+    "@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g=="],
+
+    "@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg=="],
+
+    "@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q=="],
+
+    "@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.58.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A=="],
+
+    "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg=="],
+
+    "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.6", "", { "os": "win32", "cpu": "x64" }, "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA=="],
+
+    "@sentry/conventions": ["@sentry/conventions@0.16.0", "", {}, "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ=="],
+
     "@sentry/core": ["@sentry/core@10.52.0", "", {}, "sha512-VA/kAqLhkMnRWY2RXdBLyTemR9D4m7MVRy/gyapoq9yvllVPx9WXbvKgnMP2LQp7mFgT/oLFvw58aQKaYTGn3A=="],
 
     "@sentry/node": ["@sentry/node@10.52.0", "", { "dependencies": { "@fastify/otel": "0.18.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/instrumentation-amqplib": "0.61.0", "@opentelemetry/instrumentation-connect": "0.57.0", "@opentelemetry/instrumentation-dataloader": "0.31.0", "@opentelemetry/instrumentation-fs": "0.33.0", "@opentelemetry/instrumentation-generic-pool": "0.57.0", "@opentelemetry/instrumentation-graphql": "0.62.0", "@opentelemetry/instrumentation-hapi": "0.60.0", "@opentelemetry/instrumentation-http": "0.214.0", "@opentelemetry/instrumentation-kafkajs": "0.23.0", "@opentelemetry/instrumentation-knex": "0.58.0", "@opentelemetry/instrumentation-koa": "0.62.0", "@opentelemetry/instrumentation-lru-memoizer": "0.58.0", "@opentelemetry/instrumentation-mongodb": "0.67.0", "@opentelemetry/instrumentation-mongoose": "0.60.0", "@opentelemetry/instrumentation-mysql": "0.60.0", "@opentelemetry/instrumentation-mysql2": "0.60.0", "@opentelemetry/instrumentation-pg": "0.66.0", "@opentelemetry/instrumentation-tedious": "0.33.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@prisma/instrumentation": "7.6.0", "@sentry/core": "10.52.0", "@sentry/node-core": "10.52.0", "@sentry/opentelemetry": "10.52.0", "import-in-the-middle": "^3.0.0" } }, "sha512-9+p3KJUk3rHO1HOEZuSknP2RgKCJZONDm4HWgkVDtVBtocb66KLtVlMjc59d2/bWP7tM3wc877tpG30quFfU9g=="],
@@ -1454,6 +1477,8 @@
     "@sentry/opentelemetry": ["@sentry/opentelemetry@10.52.0", "", { "dependencies": { "@sentry/core": "10.52.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-Sc7StsvC0bwhMcgDfTRWUIexO5cNzzKUurvUwtpgQUnxO7AzexU3lkY3yHYDsCbWYAEQMXAgQYQtbcqoh+Ie7g=="],
 
     "@sentry/react": ["@sentry/react@10.52.0", "", { "dependencies": { "@sentry/browser": "10.52.0", "@sentry/core": "10.52.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-2m72QCsja2cJJHD0ALxRnVt0qMEC2FV4LSi6AAiEdEG4lTb6mgcxavx5pJrW90jE+6dMGPbUz4q8c9vi4jh1qQ=="],
+
+    "@sentry/vite-plugin": ["@sentry/vite-plugin@5.4.0", "", { "dependencies": { "@sentry/bundler-plugins": "^10.64.0" } }, "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
 
@@ -3385,6 +3410,8 @@
 
     "protobufjs": ["protobufjs@8.0.3", "", { "dependencies": { "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ=="],
 
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
     "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
 
     "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
@@ -4033,6 +4060,8 @@
 
     "ylru": ["ylru@1.4.0", "", {}, "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA=="],
 
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
@@ -4322,6 +4351,12 @@
     "@semantic-release/release-notes-generator/get-stream": ["get-stream@7.0.1", "", {}, "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ=="],
 
     "@semantic-release/release-notes-generator/read-package-up": ["read-package-up@11.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0", "read-pkg": "^9.0.0", "type-fest": "^4.6.0" } }, "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ=="],
+
+    "@sentry/bundler-plugins/@sentry/core": ["@sentry/core@10.69.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0" } }, "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg=="],
+
+    "@sentry/bundler-plugins/find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "@sentry/cli/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "@tailwindcss/node/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
@@ -5625,6 +5660,10 @@
 
     "@semantic-release/release-notes-generator/read-package-up/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
+    "@sentry/bundler-plugins/find-up/locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/vite/@tailwindcss/node/enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
@@ -6271,6 +6310,8 @@
 
     "@semantic-release/release-notes-generator/read-package-up/read-pkg/unicorn-magic": ["unicorn-magic@0.1.0", "", {}, "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="],
 
+    "@sentry/bundler-plugins/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
     "@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
@@ -6814,6 +6855,8 @@
     "@grpc/grpc-js/@grpc/proto-loader/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
+
+    "@sentry/bundler-plugins/find-up/locate-path/p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/infra/vps.ts
+++ b/infra/vps.ts
@@ -95,6 +95,7 @@ export const dbBackupTask = new sst.aws.Task('DatabaseBackupTask', {
     dockerfile: 'apps/vps/Dockerfile'
   },
   environment: {
+    SENTRY_RELEASE: process.env.SENTRY_RELEASE ?? '',
     DATABASE_BACKUP_BUCKET: dbBackupBucket.name,
     DatabaseHost: secret.DatabaseHost.value,
     DatabaseUser: secret.DatabaseUser.value,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
     "./utils/slug": "./src/utils/slug.ts",
     "./api": "./src/api/index.ts",
     "./feature-flags": "./src/feature-flags/index.ts",
+    "./observability/trace-sampling": "./src/observability/trace-sampling.ts",
     "./status": "./src/status/index.ts"
   },
   "scripts": {

--- a/packages/core/src/observability/trace-sampling.test.ts
+++ b/packages/core/src/observability/trace-sampling.test.ts
@@ -19,4 +19,8 @@ describe('traceSampleRate', () => {
   test('samples other traffic at the baseline rate', () => {
     expect(traceSampleRate({ name: 'pageload', url: '/about' })).toBe(0.2)
   })
+
+  test('uses the URL as the source of truth when a transaction name is misleading', () => {
+    expect(traceSampleRate({ name: 'GET /health', url: '/api/music/track/123' })).toBe(0.5)
+  })
 })

--- a/packages/core/src/observability/trace-sampling.test.ts
+++ b/packages/core/src/observability/trace-sampling.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest'
+import { traceSampleRate } from './trace-sampling'
+
+describe('traceSampleRate', () => {
+  test.each(['/health', '/robots.txt', '/sitemap.xml'])(
+    'samples noisy route %s at one percent',
+    (url) => {
+      expect(traceSampleRate({ name: `GET ${url}`, url })).toBe(0.01)
+    }
+  )
+
+  test.each(['/api/profile/guidefari', '/api/music/track/123', '/auth/get-session'])(
+    'keeps representative business traffic for %s',
+    (url) => {
+      expect(traceSampleRate({ name: `GET ${url}`, url })).toBe(0.5)
+    }
+  )
+
+  test('samples other traffic at the baseline rate', () => {
+    expect(traceSampleRate({ name: 'pageload', url: '/about' })).toBe(0.2)
+  })
+})

--- a/packages/core/src/observability/trace-sampling.ts
+++ b/packages/core/src/observability/trace-sampling.ts
@@ -1,0 +1,20 @@
+const NOISE_PATH_PATTERN = /(?:^|\/)(?:health|robots\.txt|sitemap\.xml)(?:$|[/?#])/i
+const BUSINESS_PATH_PATTERN = /\/(?:api\/(?:profile|music|audio|shows?|content)|auth)(?:\/|$|[?#])/i
+
+export type TraceSamplingInput = {
+  readonly name: string
+  readonly url?: string
+}
+
+/**
+ * Returns the head-sampling rate for a trace without depending on a telemetry SDK.
+ *
+ * Errors remain independently captured by Sentry. This policy preserves more business-route
+ * traces while sharply reducing synthetic liveness and crawler noise.
+ */
+export function traceSampleRate({ name, url }: TraceSamplingInput): number {
+  const target = `${name} ${url ?? ''}`
+  if (NOISE_PATH_PATTERN.test(target)) return 0.01
+  if (BUSINESS_PATH_PATTERN.test(target)) return 0.5
+  return 0.2
+}

--- a/packages/core/src/observability/trace-sampling.ts
+++ b/packages/core/src/observability/trace-sampling.ts
@@ -13,7 +13,7 @@ export type TraceSamplingInput = {
  * traces while sharply reducing synthetic liveness and crawler noise.
  */
 export function traceSampleRate({ name, url }: TraceSamplingInput): number {
-  const target = `${name} ${url ?? ''}`
+  const target = url ?? name
   if (NOISE_PATH_PATTERN.test(target)) return 0.01
   if (BUSINESS_PATH_PATTERN.test(target)) return 0.5
   return 0.2


### PR DESCRIPTION
## What changed

- add privacy-safe Postgres spans with stable operation/table summaries and strip SQL text/parameters
- sanitize persistence error messages while preserving safe PostgreSQL error codes
- adopt route-aware trace sampling and privacy-first frontend replay
- publish frontend source maps and Sentry release commit/deploy metadata from the production workflow
- add Sentry Cron check-ins for reminder processing, sitemap regeneration, and database backups
- preload Sentry in the backup task and flush terminal check-ins before exit

## Why

The production relational-query incident passed TypeScript because the invalid table alias only existed in generated SQL. PR #232 adds the real-Postgres prevention layer for that bug class; this PR makes the remaining runtime failures diagnosable without leaking SQL parameters, and makes silent background-job failures observable.

## Operational work already applied

- enabled IP scrubbing for both Sentry projects
- created the `GBFM Service Health` dashboard
- assigned the existing high-priority alert to `#goosebumps-collective` with a five-minute throttle

Sentry currently rejects detector and metric-alert writes for this account, so the two existing functional uptime checks remain disabled and are tracked in #238. CI also still needs a non-personal `SENTRY_AUTH_TOKEN` before release publication can run (#236).

## Verification

- `bun precommit`
- focused VPS database telemetry/error tests: 8 passing
- trace sampling tests: 7 passing
- frontend production build

Refs #234
Refs #235
Refs #236
Refs #237
Refs #238
