### PR TITLE
fix(vps): instrument pg at runtime boundary

### DIFF
--- a/apps/vps/src/db/index.ts
+++ b/apps/vps/src/db/index.ts
@@ -2,6 +2,7 @@ import { config } from '@/services/config.service'
 import 'dotenv/config'
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { Pool } from 'pg'
+import { instrumentDatabaseClient } from '@/lib/database-instrumentation'
 import * as schema from './exports'
 
 const stage = config.app.stage
@@ -29,6 +30,7 @@ console.log(
 )
 
 const pool = new Pool(dbConfig)
+pool.on('connect', (client) => instrumentDatabaseClient(client))
 
 export { pool }
 export const db = drizzle(pool, { schema })

--- a/apps/vps/src/instrument.ts
+++ b/apps/vps/src/instrument.ts
@@ -37,7 +37,6 @@ if (enabled) {
     release: process.env.SENTRY_RELEASE,
     tracesSampler: ({ inheritOrSampleWith, name, normalizedRequest }) =>
       inheritOrSampleWith(traceSampleRate({ name, url: normalizedRequest?.url })),
-    integrations: [Sentry.postgresIntegration({ ignoreConnectSpans: true })],
     sendDefaultPii: false,
     enableLogs: true,
     debug: process.env.SENTRY_DEBUG === 'true',

--- a/apps/vps/src/lib/database-instrumentation.test.ts
+++ b/apps/vps/src/lib/database-instrumentation.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test, vi } from 'vitest'
+import { instrumentDatabaseClient } from './database-instrumentation'
+
+describe('instrumentDatabaseClient', () => {
+  test('emits a safe span around query config objects and preserves query behavior', async () => {
+    const secret = 'secret-user-id'
+    const query = vi.fn(async (_queryConfig: unknown) => ({ rows: [{ id: 'audio-1' }] }))
+    const spans: unknown[] = []
+    const runSpan = <A>(options: unknown, evaluate: () => A): A => {
+      spans.push(options)
+      return evaluate()
+    }
+    const client = instrumentDatabaseClient(
+      { query },
+      {
+        hasActiveSpan: () => true,
+        runSpan
+      }
+    )
+    const queryConfig = {
+      text: 'select "audio"."id" from "audio" where "creatorId" = $1',
+      values: [secret]
+    }
+
+    await expect(client.query(queryConfig)).resolves.toEqual({ rows: [{ id: 'audio-1' }] })
+
+    expect(query).toHaveBeenCalledWith(queryConfig)
+    expect(spans).toEqual([
+      {
+        name: 'SELECT audio',
+        op: 'db.query',
+        attributes: {
+          'db.system.name': 'postgresql',
+          'db.operation.name': 'SELECT',
+          'db.collection.name': 'audio',
+          'db.query.summary': 'SELECT audio'
+        }
+      }
+    ])
+    expect(JSON.stringify(spans)).not.toContain(secret)
+  })
+
+  test('takes the direct query path when there is no active request span', async () => {
+    const query = vi.fn(async (_queryConfig: unknown) => 'ok')
+    let spanStarted = false
+    const runSpan = <A>(_options: unknown, evaluate: () => A): A => {
+      spanStarted = true
+      return evaluate()
+    }
+    const client = instrumentDatabaseClient(
+      { query },
+      {
+        hasActiveSpan: () => false,
+        runSpan
+      }
+    )
+
+    await expect(client.query('select 1')).resolves.toBe('ok')
+    expect(spanStarted).toBe(false)
+  })
+
+  test('does not wrap a database client more than once', async () => {
+    const query = vi.fn(async (_queryConfig: unknown) => 'ok')
+    let spanCount = 0
+    const instrumentation = {
+      hasActiveSpan: () => true,
+      runSpan: <A>(_options: unknown, evaluate: () => A): A => {
+        spanCount += 1
+        return evaluate()
+      }
+    }
+    const client = { query }
+
+    instrumentDatabaseClient(client, instrumentation)
+    instrumentDatabaseClient(client, instrumentation)
+
+    await expect(client.query('select 1')).resolves.toBe('ok')
+    expect(spanCount).toBe(1)
+    expect(query).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/vps/src/lib/database-instrumentation.ts
+++ b/apps/vps/src/lib/database-instrumentation.ts
@@ -1,0 +1,78 @@
+import * as Sentry from '@sentry/bun'
+import { extractDatabaseQueryText, summarizeDatabaseQuery } from './database-telemetry'
+
+const INSTRUMENTED_DATABASE_CLIENT = Symbol('instrumented-database-client')
+
+type DatabaseSpanOptions = {
+  readonly name: string
+  readonly op: 'db.query'
+  readonly attributes: Readonly<Record<string, string>>
+}
+
+type DatabaseInstrumentation = {
+  readonly hasActiveSpan: () => boolean
+  readonly runSpan: <A>(options: DatabaseSpanOptions, evaluate: () => A) => A
+}
+
+type QueryableClient = {
+  readonly query: unknown
+  readonly [INSTRUMENTED_DATABASE_CLIENT]?: true
+}
+
+const sentryDatabaseInstrumentation: DatabaseInstrumentation = {
+  hasActiveSpan: () => Sentry.getActiveSpan() !== undefined,
+  runSpan: (options, evaluate) => Sentry.startSpan(options, evaluate)
+}
+
+/**
+ * Instruments the concrete pg query boundary without relying on runtime module hooks.
+ *
+ * Bun does not currently activate Sentry's OpenTelemetry pg patch, so PoolClient
+ * instances are wrapped explicitly. Queries without an active trace take the direct
+ * path without parsing SQL or creating a span.
+ */
+export function instrumentDatabaseClient<T extends QueryableClient>(
+  client: T,
+  instrumentation: DatabaseInstrumentation = sentryDatabaseInstrumentation
+): T {
+  if (client[INSTRUMENTED_DATABASE_CLIENT] || typeof client.query !== 'function') return client
+
+  const originalQuery = client.query
+  const instrumentedQuery = function (
+    this: unknown,
+    queryConfig: unknown,
+    ...arguments_: readonly unknown[]
+  ): unknown {
+    if (!instrumentation.hasActiveSpan()) {
+      return Reflect.apply(originalQuery, this, [queryConfig, ...arguments_])
+    }
+
+    const summary = summarizeDatabaseQuery(extractDatabaseQueryText(queryConfig) ?? '')
+    return instrumentation.runSpan(
+      {
+        name: summary.description,
+        op: 'db.query',
+        attributes: {
+          'db.system.name': 'postgresql',
+          'db.operation.name': summary.operation,
+          'db.collection.name': summary.table,
+          'db.query.summary': summary.description
+        }
+      },
+      () => Reflect.apply(originalQuery, this, [queryConfig, ...arguments_])
+    )
+  }
+
+  Object.defineProperties(client, {
+    query: {
+      configurable: true,
+      value: instrumentedQuery,
+      writable: true
+    },
+    [INSTRUMENTED_DATABASE_CLIENT]: {
+      value: true
+    }
+  })
+
+  return client
+}

--- a/apps/vps/src/lib/database-telemetry.ts
+++ b/apps/vps/src/lib/database-telemetry.ts
@@ -108,7 +108,7 @@ function findTopLevelOperation(
   return undefined
 }
 
-function extractQueryText(value: unknown): string | undefined {
+export function extractDatabaseQueryText(value: unknown): string | undefined {
   if (typeof value === 'string') return value
   if (typeof value !== 'object' || value === null || !('text' in value)) return undefined
   return typeof value.text === 'string' ? value.text : undefined
@@ -141,7 +141,7 @@ export function sanitizeDatabaseSpan<T extends DatabaseSpan>(span: T): T {
   if (typeof dbSystem !== 'string') return span
 
   const rawQuery = DATABASE_QUERY_ATTRIBUTE_KEYS.flatMap((key) => {
-    const query = extractQueryText(span.data[key])
+    const query = extractDatabaseQueryText(span.data[key])
     return query ? [query] : []
   })[0]
   const summary = summarizeDatabaseQuery(rawQuery ?? span.description ?? '')

--- a/apps/vps/src/services/sentry-client.service.ts
+++ b/apps/vps/src/services/sentry-client.service.ts
@@ -42,7 +42,6 @@ export const SentryClientServiceLayer = Layer.effect(
           release: process.env.SENTRY_RELEASE,
           tracesSampler: ({ inheritOrSampleWith, name, normalizedRequest }) =>
             inheritOrSampleWith(traceSampleRate({ name, url: normalizedRequest?.url })),
-          integrations: [Sentry.postgresIntegration({ ignoreConnectSpans: true })],
           sendDefaultPii: false,
           enableLogs: true,
           debug: debugSentry,


### PR DESCRIPTION
## What changed

- instruments concrete `pg` PoolClient instances before their first query instead of relying on OpenTelemetry runtime module patching
- keeps queries with no active trace on the direct path
- emits only low-cardinality summaries and never SQL values or bind parameters
- removes the ineffective Sentry postgres integration to avoid duplicate instrumentation
- covers behavior preservation, privacy, direct-path overhead, and idempotency

## Why

Production verification after v2.76.0 showed sampled HTTP transactions but no `db.query` children. Sentry’s OpenTelemetry postgres integration does not patch `pg` under the deployed Bun runtime, despite the configuration passing type checks and tests. This moves instrumentation to a boundary we own and can exercise deterministically.

Closes #234

## Validation

- `bun test apps/vps/src/lib/database-instrumentation.test.ts apps/vps/src/lib/database-telemetry.test.ts` (13 passed)
- `bun precommit`
- `git diff --check`

## Production gate

After merge and deployment, verify a sampled backend request contains `db.query` child spans in Sentry before treating #234 as complete.