### PR TITLE
fix(vps): join database spans to Effect context

### DIFF
--- a/apps/vps/src/lib/database-instrumentation.test.ts
+++ b/apps/vps/src/lib/database-instrumentation.test.ts
@@ -1,3 +1,6 @@
+import { trace } from '@opentelemetry/api'
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { describe, expect, test, vi } from 'vitest'
 import { instrumentDatabaseClient } from './database-instrumentation'
 
@@ -77,5 +80,41 @@ describe('instrumentDatabaseClient', () => {
     await expect(client.query('select 1')).resolves.toBe('ok')
     expect(spanCount).toBe(1)
     expect(query).toHaveBeenCalledOnce()
+  })
+
+  test('emits a child span through the active OpenTelemetry context', async () => {
+    const exporter = new InMemorySpanExporter()
+    const provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)]
+    })
+    provider.register()
+
+    try {
+      const query = vi.fn(async (_queryConfig: unknown) => 'ok')
+      const client = instrumentDatabaseClient({ query })
+      const tracer = provider.getTracer('database-instrumentation-test')
+
+      await tracer.startActiveSpan('request', async (requestSpan) => {
+        await client.query('select "id" from "audio"')
+        requestSpan.end()
+      })
+      await provider.forceFlush()
+
+      const spans = exporter.getFinishedSpans()
+      const databaseSpan = spans.find((span) => span.name === 'SELECT audio')
+      const requestSpan = spans.find((span) => span.name === 'request')
+
+      expect(databaseSpan?.parentSpanContext?.spanId).toBe(requestSpan?.spanContext().spanId)
+      expect(databaseSpan?.attributes).toMatchObject({
+        'sentry.op': 'db.query',
+        'db.system.name': 'postgresql',
+        'db.operation.name': 'SELECT',
+        'db.collection.name': 'audio',
+        'db.query.summary': 'SELECT audio'
+      })
+    } finally {
+      await provider.shutdown()
+      trace.disable()
+    }
   })
 })

--- a/apps/vps/src/lib/database-instrumentation.ts
+++ b/apps/vps/src/lib/database-instrumentation.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/bun'
+import { SpanStatusCode, trace } from '@opentelemetry/api'
 import { extractDatabaseQueryText, summarizeDatabaseQuery } from './database-telemetry'
 
 const INSTRUMENTED_DATABASE_CLIENT = Symbol('instrumented-database-client')
@@ -11,7 +11,7 @@ type DatabaseSpanOptions = {
 
 type DatabaseInstrumentation = {
   readonly hasActiveSpan: () => boolean
-  readonly runSpan: <A>(options: DatabaseSpanOptions, evaluate: () => A) => A
+  readonly runSpan: (options: DatabaseSpanOptions, evaluate: () => unknown) => unknown
 }
 
 type QueryableClient = {
@@ -19,21 +19,68 @@ type QueryableClient = {
   readonly [INSTRUMENTED_DATABASE_CLIENT]?: true
 }
 
-const sentryDatabaseInstrumentation: DatabaseInstrumentation = {
-  hasActiveSpan: () => Sentry.getActiveSpan() !== undefined,
-  runSpan: (options, evaluate) => Sentry.startSpan(options, evaluate)
+const databaseTracer = trace.getTracer('gbfm.database')
+
+function runOpenTelemetrySpan(options: DatabaseSpanOptions, evaluate: () => unknown): unknown {
+  return databaseTracer.startActiveSpan(
+    options.name,
+    {
+      attributes: {
+        ...options.attributes,
+        'sentry.op': options.op
+      }
+    },
+    (span) => {
+      let result: unknown
+      try {
+        result = evaluate()
+      } catch (error) {
+        span.setStatus({ code: SpanStatusCode.ERROR })
+        span.end()
+        throw error
+      }
+
+      if (
+        typeof result === 'object' &&
+        result !== null &&
+        'then' in result &&
+        typeof result.then === 'function'
+      ) {
+        return Promise.resolve(result).then(
+          (value) => {
+            span.end()
+            return value
+          },
+          (error) => {
+            span.setStatus({ code: SpanStatusCode.ERROR })
+            span.end()
+            throw error
+          }
+        )
+      }
+
+      span.end()
+      return result
+    }
+  )
+}
+
+const openTelemetryDatabaseInstrumentation: DatabaseInstrumentation = {
+  hasActiveSpan: () => trace.getActiveSpan()?.isRecording() === true,
+  runSpan: runOpenTelemetrySpan
 }
 
 /**
  * Instruments the concrete pg query boundary without relying on runtime module hooks.
  *
  * Bun does not currently activate Sentry's OpenTelemetry pg patch, so PoolClient
- * instances are wrapped explicitly. Queries without an active trace take the direct
- * path without parsing SQL or creating a span.
+ * instances are wrapped explicitly. The Effect runtime owns the active OpenTelemetry
+ * context, so spans are created through that API and exported by SentrySpanProcessor.
+ * Queries without a recording trace take the direct path without parsing SQL.
  */
 export function instrumentDatabaseClient<T extends QueryableClient>(
   client: T,
-  instrumentation: DatabaseInstrumentation = sentryDatabaseInstrumentation
+  instrumentation: DatabaseInstrumentation = openTelemetryDatabaseInstrumentation
 ): T {
   if (client[INSTRUMENTED_DATABASE_CLIENT] || typeof client.query !== 'function') return client
 


### PR DESCRIPTION
## What changed

- creates database spans through the active OpenTelemetry context owned by Effect
- exports them through the existing `SentrySpanProcessor`
- only instruments recording traces, preserving the direct fast path for unsampled/background queries
- closes spans on synchronous success/failure and asynchronous resolution/rejection
- adds a runtime-style test with a real `NodeTracerProvider` and in-memory exporter, asserting the database span is a child of the active request span

## Production evidence

The v2.76.1 deployment was healthy and emitted sampled HTTP and Effect application spans, but no database children. That proved the PoolClient hook executed outside Sentry SDK scope; Effect owns the actual OpenTelemetry context.

Related to #234. Deliberately does not auto-close it: the issue closes only after a deployed trace contains real `db.query` children.

## Validation

- focused telemetry tests: 14 passed
- `bun precommit`
- `git diff --check`