### PR TITLE
fix(vps): trace queries at the pool boundary

### DIFF
--- a/apps/vps/src/db/index.ts
+++ b/apps/vps/src/db/index.ts
@@ -29,7 +29,7 @@ console.log(
   `[DB] Connecting stage=${config.app.dbStage || 'prod'} host=${dbConfig.host} db=${dbConfig.database}`
 )
 
-const pool = new Pool(dbConfig)
+const pool = instrumentDatabaseClient(new Pool(dbConfig))
 pool.on('connect', (client) => instrumentDatabaseClient(client))
 
 export { pool }

--- a/apps/vps/src/lib/database-instrumentation.test.ts
+++ b/apps/vps/src/lib/database-instrumentation.test.ts
@@ -82,7 +82,7 @@ describe('instrumentDatabaseClient', () => {
     expect(query).toHaveBeenCalledOnce()
   })
 
-  test('emits a child span through the active OpenTelemetry context', async () => {
+  test('emits one child span when a pool delegates asynchronously to a client', async () => {
     const exporter = new InMemorySpanExporter()
     const provider = new NodeTracerProvider({
       spanProcessors: [new SimpleSpanProcessor(exporter)]
@@ -90,12 +90,17 @@ describe('instrumentDatabaseClient', () => {
     provider.register()
 
     try {
-      const query = vi.fn(async (_queryConfig: unknown) => 'ok')
-      const client = instrumentDatabaseClient({ query })
+      const clientQuery = vi.fn(async (_queryConfig: unknown) => 'ok')
+      const client = instrumentDatabaseClient({ query: clientQuery })
+      const poolQuery = vi.fn(async (queryConfig: unknown) => {
+        await Promise.resolve()
+        return client.query(queryConfig)
+      })
+      const pool = instrumentDatabaseClient({ query: poolQuery })
       const tracer = provider.getTracer('database-instrumentation-test')
 
       await tracer.startActiveSpan('request', async (requestSpan) => {
-        await client.query('select "id" from "audio"')
+        await pool.query('select "id" from "audio"')
         requestSpan.end()
       })
       await provider.forceFlush()
@@ -112,6 +117,9 @@ describe('instrumentDatabaseClient', () => {
         'db.collection.name': 'audio',
         'db.query.summary': 'SELECT audio'
       })
+      expect(spans.filter((span) => span.name === 'SELECT audio')).toHaveLength(1)
+      expect(poolQuery).toHaveBeenCalledOnce()
+      expect(clientQuery).toHaveBeenCalledOnce()
     } finally {
       await provider.shutdown()
       trace.disable()

--- a/apps/vps/src/lib/database-instrumentation.ts
+++ b/apps/vps/src/lib/database-instrumentation.ts
@@ -1,7 +1,9 @@
 import { SpanStatusCode, trace } from '@opentelemetry/api'
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { extractDatabaseQueryText, summarizeDatabaseQuery } from './database-telemetry'
 
 const INSTRUMENTED_DATABASE_CLIENT = Symbol('instrumented-database-client')
+const activeDatabaseQuery = new AsyncLocalStorage<boolean>()
 
 type DatabaseSpanOptions = {
   readonly name: string
@@ -73,10 +75,11 @@ const openTelemetryDatabaseInstrumentation: DatabaseInstrumentation = {
 /**
  * Instruments the concrete pg query boundary without relying on runtime module hooks.
  *
- * Bun does not currently activate Sentry's OpenTelemetry pg patch, so PoolClient
- * instances are wrapped explicitly. The Effect runtime owns the active OpenTelemetry
- * context, so spans are created through that API and exported by SentrySpanProcessor.
- * Queries without a recording trace take the direct path without parsing SQL.
+ * Bun does not currently activate Sentry's OpenTelemetry pg patch, so Pool and
+ * PoolClient instances are wrapped explicitly. The Pool boundary preserves Effect's
+ * active context before pg switches to its callback internals. Async-local re-entry
+ * protection prevents the PoolClient call delegated by Pool.query from creating a
+ * duplicate span. Queries without a recording trace take the direct path.
  */
 export function instrumentDatabaseClient<T extends QueryableClient>(
   client: T,
@@ -90,7 +93,7 @@ export function instrumentDatabaseClient<T extends QueryableClient>(
     queryConfig: unknown,
     ...arguments_: readonly unknown[]
   ): unknown {
-    if (!instrumentation.hasActiveSpan()) {
+    if (activeDatabaseQuery.getStore() || !instrumentation.hasActiveSpan()) {
       return Reflect.apply(originalQuery, this, [queryConfig, ...arguments_])
     }
 
@@ -106,7 +109,10 @@ export function instrumentDatabaseClient<T extends QueryableClient>(
           'db.query.summary': summary.description
         }
       },
-      () => Reflect.apply(originalQuery, this, [queryConfig, ...arguments_])
+      () =>
+        activeDatabaseQuery.run(true, () =>
+          Reflect.apply(originalQuery, this, [queryConfig, ...arguments_])
+        )
     )
   }
 


### PR DESCRIPTION
## What changed

- instruments `Pool.query` at the immediate Effect callback boundary, before pg switches to its internal callback chain
- retains PoolClient instrumentation for transactions
- uses `AsyncLocalStorage` re-entry protection so Pool→PoolClient delegation emits exactly one span
- keeps unsampled/background queries on the direct path
- expands the real OpenTelemetry provider test to model asynchronous Pool→PoolClient delegation and assert one exported child span

## Production evidence

`v2.76.2` reached ECS steady state and Sentry indexed 36 HTTP spans plus 34 Effect spans, but zero `db.query` spans. Source inspection showed pg performs the concrete client call later inside its callback chain. The Pool boundary still has Effect’s active OpenTelemetry context, so this moves span creation there.

Related to #234. This PR deliberately does not auto-close the issue; production verification remains the gate.

## Validation

- focused telemetry tests: 14 passed
- `bun precommit`
- `git diff --check`