### PR TITLE
fix(vps): register database tracing provider

### DIFF
--- a/apps/vps/src/lib/database-instrumentation.test.ts
+++ b/apps/vps/src/lib/database-instrumentation.test.ts
@@ -1,4 +1,4 @@
-import { trace } from '@opentelemetry/api'
+import { context, trace } from '@opentelemetry/api'
 import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { describe, expect, test, vi } from 'vitest'
@@ -83,11 +83,15 @@ describe('instrumentDatabaseClient', () => {
   })
 
   test('emits one child span when a pool delegates asynchronously to a client', async () => {
-    const exporter = new InMemorySpanExporter()
-    const provider = new NodeTracerProvider({
-      spanProcessors: [new SimpleSpanProcessor(exporter)]
+    const databaseExporter = new InMemorySpanExporter()
+    const databaseProvider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(databaseExporter)]
     })
-    provider.register()
+    databaseProvider.register()
+    const effectExporter = new InMemorySpanExporter()
+    const effectProvider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(effectExporter)]
+    })
 
     try {
       const clientQuery = vi.fn(async (_queryConfig: unknown) => 'ok')
@@ -97,19 +101,25 @@ describe('instrumentDatabaseClient', () => {
         return client.query(queryConfig)
       })
       const pool = instrumentDatabaseClient({ query: poolQuery })
-      const tracer = provider.getTracer('database-instrumentation-test')
+      const requestSpan = effectProvider
+        .getTracer('database-instrumentation-test')
+        .startSpan('request')
 
-      await tracer.startActiveSpan('request', async (requestSpan) => {
+      await context.with(trace.setSpan(context.active(), requestSpan), async () => {
         await pool.query('select "id" from "audio"')
-        requestSpan.end()
       })
-      await provider.forceFlush()
+      requestSpan.end()
+      await Promise.all([databaseProvider.forceFlush(), effectProvider.forceFlush()])
 
-      const spans = exporter.getFinishedSpans()
-      const databaseSpan = spans.find((span) => span.name === 'SELECT audio')
-      const requestSpan = spans.find((span) => span.name === 'request')
+      const databaseSpans = databaseExporter.getFinishedSpans()
+      const databaseSpan = databaseSpans.find((span) => span.name === 'SELECT audio')
+      const finishedRequestSpan = effectExporter
+        .getFinishedSpans()
+        .find((span) => span.name === 'request')
 
-      expect(databaseSpan?.parentSpanContext?.spanId).toBe(requestSpan?.spanContext().spanId)
+      expect(databaseSpan?.parentSpanContext?.spanId).toBe(
+        finishedRequestSpan?.spanContext().spanId
+      )
       expect(databaseSpan?.attributes).toMatchObject({
         'sentry.op': 'db.query',
         'db.system.name': 'postgresql',
@@ -117,11 +127,11 @@ describe('instrumentDatabaseClient', () => {
         'db.collection.name': 'audio',
         'db.query.summary': 'SELECT audio'
       })
-      expect(spans.filter((span) => span.name === 'SELECT audio')).toHaveLength(1)
+      expect(databaseSpans.filter((span) => span.name === 'SELECT audio')).toHaveLength(1)
       expect(poolQuery).toHaveBeenCalledOnce()
       expect(clientQuery).toHaveBeenCalledOnce()
     } finally {
-      await provider.shutdown()
+      await Promise.all([databaseProvider.shutdown(), effectProvider.shutdown()])
       trace.disable()
     }
   })

--- a/apps/vps/src/lib/otel.ts
+++ b/apps/vps/src/lib/otel.ts
@@ -1,7 +1,8 @@
 import { NodeSdk } from '@effect/opentelemetry'
-import { propagation } from '@opentelemetry/api'
+import { propagation, trace } from '@opentelemetry/api'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { SentryPropagator, SentrySampler, SentrySpanProcessor } from '@sentry/opentelemetry'
 import { Effect, Layer } from 'effect'
 import { ConfigService } from '@/services/config.service'
@@ -32,33 +33,52 @@ export const OtlpLive = Effect.gen(function* () {
   const otlpEndpoint = (config.otel.endpoint || '').replace(/\/$/, '')
   const otelHeaders = parseOtelHeaders(config.otel.headers)
 
-  const otlpProcessors = otlpEndpoint
-    ? [
-        new SimpleSpanProcessor(
-          new OTLPTraceExporter({
-            url: otlpEndpoint.endsWith('/v1/traces') ? otlpEndpoint : `${otlpEndpoint}/v1/traces`,
-            ...(otelHeaders ? { headers: otelHeaders } : {})
-          })
-        )
-      ]
-    : []
-
-  // Dual export in dev: Jaeger (above) for the trace-waterfall UI, motel
-  // (github.com/kitlangton/motel) for terminal/agent-queryable local
-  // telemetry. Span export failures are caught by OTel's own SDK and never
-  // throw into the request path, so this is safe to leave unconditional
-  // within the dev/local gate even when the motel server isn't running.
-  const motelProcessors = ['dev', 'local'].includes(config.app.stage)
-    ? [new SimpleSpanProcessor(new OTLPTraceExporter({ url: MOTEL_TRACES_URL }))]
-    : []
-
-  const sentryProcessors = sentry.enabled ? [new SentrySpanProcessor()] : []
+  const makeSpanProcessors = () => [
+    ...(sentry.enabled ? [new SentrySpanProcessor()] : []),
+    ...(otlpEndpoint
+      ? [
+          new SimpleSpanProcessor(
+            new OTLPTraceExporter({
+              url: otlpEndpoint.endsWith('/v1/traces') ? otlpEndpoint : `${otlpEndpoint}/v1/traces`,
+              ...(otelHeaders ? { headers: otelHeaders } : {})
+            })
+          )
+        ]
+      : []),
+    // Dual export in dev: Jaeger (above) for the trace-waterfall UI, motel
+    // (github.com/kitlangton/motel) for terminal/agent-queryable local
+    // telemetry. Span export failures are caught by OTel's own SDK and never
+    // throw into the request path, so this is safe to leave unconditional
+    // within the dev/local gate even when the motel server isn't running.
+    ...(['dev', 'local'].includes(config.app.stage)
+      ? [new SimpleSpanProcessor(new OTLPTraceExporter({ url: MOTEL_TRACES_URL }))]
+      : [])
+  ]
 
   if (sentry.client) {
     propagation.setGlobalPropagator(new SentryPropagator())
   }
 
-  return NodeSdk.layer(() => ({
+  const tracerConfig = sentry.client ? { sampler: new SentrySampler(sentry.client) } : undefined
+  const globalProviderLive = Layer.effectDiscard(
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        const provider = new NodeTracerProvider({
+          spanProcessors: makeSpanProcessors(),
+          ...(tracerConfig ? { sampler: tracerConfig.sampler } : {})
+        })
+        provider.register()
+        return provider
+      }),
+      (provider) =>
+        Effect.promise(async () => {
+          await provider.forceFlush()
+          await provider.shutdown()
+          trace.disable()
+        }).pipe(Effect.ignore)
+    )
+  )
+  const effectTracingLive = NodeSdk.layer(() => ({
     resource: {
       serviceName: 'goosebumps-fm-api',
       serviceVersion: process.env.npm_package_version || '1.0.0',
@@ -67,7 +87,9 @@ export const OtlpLive = Effect.gen(function* () {
         'deployment.environment': config.app.nodeEnv
       }
     },
-    spanProcessor: [...sentryProcessors, ...otlpProcessors, ...motelProcessors],
-    ...(sentry.client ? { tracerConfig: { sampler: new SentrySampler(sentry.client) } } : {})
+    spanProcessor: makeSpanProcessors(),
+    ...(tracerConfig ? { tracerConfig } : {})
   }))
+
+  return Layer.merge(effectTracingLive, globalProviderLive)
 }).pipe(Layer.unwrap)


### PR DESCRIPTION
## What changed

- registers a global OpenTelemetry provider for instrumentation outside Effect services
- uses independent processor instances for Sentry and optional local OTLP exporters
- keeps Effect application spans on the existing scoped provider
- enables the global async context manager that Effect’s OpenTelemetry bridge already uses
- cleanly flushes/shuts down the global provider with the application layer
- upgrades the runtime test to the production topology: scoped Effect parent provider + registered DB child provider, asserting identical trace lineage

## Production evidence

`v2.76.3` reached ECS steady state and indexed its complete trace batch, but database attributes were absent. `@effect/opentelemetry` source confirms `NodeSdk.layer` constructs a scoped `NodeTracerProvider` and never calls `register()`, so the module-level database tracer remained the global no-op proxy.

Related to #234. Production Sentry verification remains the closure gate.

## Performance

Unsampled/background queries still bypass SQL parsing and span creation. Sampled DB queries pay one summary parse and one span. Registering the context manager activates behavior the Effect bridge is explicitly designed to use.

## Validation

- focused telemetry tests: 14 passed
- `bun precommit`
- `git diff --check`