### PR TITLE
fix(vps): unify OpenTelemetry provider

### DIFF
--- a/apps/vps/src/instrument.ts
+++ b/apps/vps/src/instrument.ts
@@ -35,6 +35,7 @@ if (enabled) {
     dsn,
     environment,
     release: process.env.SENTRY_RELEASE,
+    skipOpenTelemetrySetup: true,
     tracesSampler: ({ inheritOrSampleWith, name, normalizedRequest }) =>
       inheritOrSampleWith(traceSampleRate({ name, url: normalizedRequest?.url })),
     sendDefaultPii: false,

--- a/apps/vps/src/lib/database-instrumentation.test.ts
+++ b/apps/vps/src/lib/database-instrumentation.test.ts
@@ -1,6 +1,8 @@
-import { context, trace } from '@opentelemetry/api'
+import { OtelTracer, Resource } from '@effect/opentelemetry'
+import { trace } from '@opentelemetry/api'
 import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+import { Effect, Layer } from 'effect'
 import { describe, expect, test, vi } from 'vitest'
 import { instrumentDatabaseClient } from './database-instrumentation'
 
@@ -83,15 +85,14 @@ describe('instrumentDatabaseClient', () => {
   })
 
   test('emits one child span when a pool delegates asynchronously to a client', async () => {
-    const databaseExporter = new InMemorySpanExporter()
-    const databaseProvider = new NodeTracerProvider({
-      spanProcessors: [new SimpleSpanProcessor(databaseExporter)]
+    const exporter = new InMemorySpanExporter()
+    const provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)]
     })
-    databaseProvider.register()
-    const effectExporter = new InMemorySpanExporter()
-    const effectProvider = new NodeTracerProvider({
-      spanProcessors: [new SimpleSpanProcessor(effectExporter)]
-    })
+    provider.register()
+    const tracingLive = OtelTracer.layerGlobal.pipe(
+      Layer.provide(Resource.layer({ serviceName: 'database-instrumentation-test' }))
+    )
 
     try {
       const clientQuery = vi.fn(async (_queryConfig: unknown) => 'ok')
@@ -101,21 +102,16 @@ describe('instrumentDatabaseClient', () => {
         return client.query(queryConfig)
       })
       const pool = instrumentDatabaseClient({ query: poolQuery })
-      const requestSpan = effectProvider
-        .getTracer('database-instrumentation-test')
-        .startSpan('request')
+      await Effect.promise(() => pool.query('select "id" from "audio"')).pipe(
+        Effect.withSpan('request'),
+        Effect.provide(tracingLive),
+        Effect.runPromise
+      )
+      await provider.forceFlush()
 
-      await context.with(trace.setSpan(context.active(), requestSpan), async () => {
-        await pool.query('select "id" from "audio"')
-      })
-      requestSpan.end()
-      await Promise.all([databaseProvider.forceFlush(), effectProvider.forceFlush()])
-
-      const databaseSpans = databaseExporter.getFinishedSpans()
-      const databaseSpan = databaseSpans.find((span) => span.name === 'SELECT audio')
-      const finishedRequestSpan = effectExporter
-        .getFinishedSpans()
-        .find((span) => span.name === 'request')
+      const spans = exporter.getFinishedSpans()
+      const databaseSpan = spans.find((span) => span.name === 'SELECT audio')
+      const finishedRequestSpan = spans.find((span) => span.name === 'request')
 
       expect(databaseSpan?.parentSpanContext?.spanId).toBe(
         finishedRequestSpan?.spanContext().spanId
@@ -127,11 +123,11 @@ describe('instrumentDatabaseClient', () => {
         'db.collection.name': 'audio',
         'db.query.summary': 'SELECT audio'
       })
-      expect(databaseSpans.filter((span) => span.name === 'SELECT audio')).toHaveLength(1)
+      expect(spans.filter((span) => span.name === 'SELECT audio')).toHaveLength(1)
       expect(poolQuery).toHaveBeenCalledOnce()
       expect(clientQuery).toHaveBeenCalledOnce()
     } finally {
-      await Promise.all([databaseProvider.shutdown(), effectProvider.shutdown()])
+      await provider.shutdown()
       trace.disable()
     }
   })

--- a/apps/vps/src/lib/otel.ts
+++ b/apps/vps/src/lib/otel.ts
@@ -1,9 +1,9 @@
-import { NodeSdk } from '@effect/opentelemetry'
-import { propagation, trace } from '@opentelemetry/api'
+import { OtelTracer, Resource } from '@effect/opentelemetry'
+import { trace } from '@opentelemetry/api'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
-import { SentryPropagator, SentrySampler, SentrySpanProcessor } from '@sentry/opentelemetry'
+import * as Sentry from '@sentry/bun'
 import { Effect, Layer } from 'effect'
 import { ConfigService } from '@/services/config.service'
 import { SentryClientService } from '@/services/sentry-client.service'
@@ -33,8 +33,7 @@ export const OtlpLive = Effect.gen(function* () {
   const otlpEndpoint = (config.otel.endpoint || '').replace(/\/$/, '')
   const otelHeaders = parseOtelHeaders(config.otel.headers)
 
-  const makeSpanProcessors = () => [
-    ...(sentry.enabled ? [new SentrySpanProcessor()] : []),
+  const makeAdditionalSpanProcessors = () => [
     ...(otlpEndpoint
       ? [
           new SimpleSpanProcessor(
@@ -55,41 +54,44 @@ export const OtlpLive = Effect.gen(function* () {
       : [])
   ]
 
-  if (sentry.client) {
-    propagation.setGlobalPropagator(new SentryPropagator())
-  }
-
-  const tracerConfig = sentry.client ? { sampler: new SentrySampler(sentry.client) } : undefined
-  const globalProviderLive = Layer.effectDiscard(
-    Effect.acquireRelease(
-      Effect.sync(() => {
-        const provider = new NodeTracerProvider({
-          spanProcessors: makeSpanProcessors(),
-          ...(tracerConfig ? { sampler: tracerConfig.sampler } : {})
+  const sentryClient = sentry.client
+  const globalProviderLive = sentryClient
+    ? Layer.effectDiscard(
+        Effect.sync(() => {
+          Sentry.initOpenTelemetry(sentryClient, {
+            spanProcessors: makeAdditionalSpanProcessors()
+          })
         })
-        provider.register()
-        return provider
-      }),
-      (provider) =>
-        Effect.promise(async () => {
-          await provider.forceFlush()
-          await provider.shutdown()
-          trace.disable()
-        }).pipe(Effect.ignore)
-    )
-  )
-  const effectTracingLive = NodeSdk.layer(() => ({
-    resource: {
-      serviceName: 'goosebumps-fm-api',
-      serviceVersion: process.env.npm_package_version || '1.0.0',
-      serviceNamespace: 'application',
-      attributes: {
-        'deployment.environment': config.app.nodeEnv
-      }
-    },
-    spanProcessor: makeSpanProcessors(),
-    ...(tracerConfig ? { tracerConfig } : {})
-  }))
+      )
+    : Layer.effectDiscard(
+        Effect.acquireRelease(
+          Effect.sync(() => {
+            const provider = new NodeTracerProvider({
+              spanProcessors: makeAdditionalSpanProcessors()
+            })
+            provider.register()
+            return provider
+          }),
+          (provider) =>
+            Effect.promise(async () => {
+              await provider.forceFlush()
+              await provider.shutdown()
+              trace.disable()
+            }).pipe(Effect.ignore)
+        )
+      )
 
-  return Layer.merge(effectTracingLive, globalProviderLive)
+  const resourceLive = Resource.layer({
+    serviceName: 'goosebumps-fm-api',
+    serviceVersion: process.env.npm_package_version || '1.0.0',
+    attributes: {
+      'service.namespace': 'application',
+      'deployment.environment': config.app.nodeEnv
+    }
+  })
+  const effectTracingLive = OtelTracer.layerGlobal.pipe(
+    Layer.provide(Layer.merge(globalProviderLive, resourceLive))
+  )
+
+  return effectTracingLive
 }).pipe(Layer.unwrap)

--- a/apps/vps/src/services/sentry-client.service.ts
+++ b/apps/vps/src/services/sentry-client.service.ts
@@ -1,7 +1,7 @@
 import { traceSampleRate } from '@gbfm/core/observability/trace-sampling'
 import * as Sentry from '@sentry/bun'
 
-type Client = NonNullable<ReturnType<typeof Sentry.getClient>>
+type Client = Sentry.NodeClient
 
 import { Context, Effect, Layer } from 'effect'
 import { sanitizeDatabaseSpan } from '@/lib/database-telemetry'
@@ -28,7 +28,7 @@ export const SentryClientServiceLayer = Layer.effect(
       return { client: undefined, enabled: false }
     }
 
-    const existingClient = Sentry.getClient()
+    const existingClient = Sentry.getClient<Client>()
     if (existingClient) {
       return { client: existingClient, enabled: true }
     }
@@ -40,6 +40,7 @@ export const SentryClientServiceLayer = Layer.effect(
           dsn: sentry.dsn,
           environment: sentry.environment,
           release: process.env.SENTRY_RELEASE,
+          skipOpenTelemetrySetup: true,
           tracesSampler: ({ inheritOrSampleWith, name, normalizedRequest }) =>
             inheritOrSampleWith(traceSampleRate({ name, url: normalizedRequest?.url })),
           sendDefaultPii: false,


### PR DESCRIPTION
## Summary

- let Sentry initialize the single global OpenTelemetry provider after its preload client is configured with `skipOpenTelemetrySetup`
- install Effect tracing from that same global provider so HTTP, Effect, and explicit database spans share context and export
- keep OTLP/motel exporters as additional processors and retain the standalone provider path when Sentry is disabled
- replace the synthetic two-provider test with an actual Effect runtime span and assert the database span has the exact request parent

## Production evidence motivating this follow-up

Release v2.76.4 (ECS revision 199) reached steady state and served 6/6 readiness plus 20/20 profile requests successfully. Sentry ingested 20 HTTP spans and the expected Effect spans for the release, but zero `db.query` spans. The prior setup had three provider identities: Sentry's preloaded global provider, Effect's scoped provider, and a later provider registration. OpenTelemetry globals are first-registration-wins, so the last registration did not unify the runtime context.

## Validation

- `bun precommit`
- `bunx vitest run --config vitest.unit.config.ts src/lib/database-instrumentation.test.ts src/lib/database-telemetry.test.ts` (14 tests)
- production verification required after deployment; #234 remains open until Sentry shows real `db.query` spans with sanitized attributes

Related to #234
