### PR TITLE
fix(vps): prevent raw SQL telemetry

### DIFF
--- a/apps/vps/src/instrument.ts
+++ b/apps/vps/src/instrument.ts
@@ -2,7 +2,11 @@ import { isRecord } from '@gbfm/core/utils'
 import { traceSampleRate } from '@gbfm/core/observability/trace-sampling'
 import * as Sentry from '@sentry/bun'
 import { sanitizeDatabaseSpan } from '@/lib/database-telemetry'
-import { hasLocalSentryContext, shouldEnableSentry } from '@/lib/sentry'
+import {
+  hasLocalSentryContext,
+  shouldEnableSentry,
+  withoutDatabaseAutoInstrumentation
+} from '@/lib/sentry'
 
 let resource: Record<string, unknown> | undefined
 try {
@@ -36,6 +40,7 @@ if (enabled) {
     environment,
     release: process.env.SENTRY_RELEASE,
     skipOpenTelemetrySetup: true,
+    integrations: withoutDatabaseAutoInstrumentation,
     tracesSampler: ({ inheritOrSampleWith, name, normalizedRequest }) =>
       inheritOrSampleWith(traceSampleRate({ name, url: normalizedRequest?.url })),
     sendDefaultPii: false,

--- a/apps/vps/src/lib/sentry.test.ts
+++ b/apps/vps/src/lib/sentry.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+import { withoutDatabaseAutoInstrumentation } from './sentry'
+
+describe('withoutDatabaseAutoInstrumentation', () => {
+  test('removes database integrations while preserving the remaining defaults', () => {
+    const integrations = [
+      { name: 'Http' },
+      { name: 'Postgres' },
+      { name: 'PostgresJs' },
+      { name: 'OnUncaughtException' }
+    ]
+
+    expect(withoutDatabaseAutoInstrumentation(integrations)).toEqual([
+      { name: 'Http' },
+      { name: 'OnUncaughtException' }
+    ])
+  })
+})

--- a/apps/vps/src/lib/sentry.ts
+++ b/apps/vps/src/lib/sentry.ts
@@ -1,7 +1,17 @@
 import type * as Sentry from '@sentry/bun'
 
+const DATABASE_AUTO_INTEGRATIONS = new Set(['Postgres', 'PostgresJs'])
+
 const isLocalUrl = (value: unknown) =>
   typeof value === 'string' && (value.includes('127.0.0.1') || value.includes('localhost'))
+
+/**
+ * Database queries use the explicit client wrapper so raw SQL never enters telemetry.
+ * Sentry's automatic integrations would create a second span containing the statement.
+ */
+export const withoutDatabaseAutoInstrumentation = <T extends { readonly name: string }>(
+  integrations: T[]
+) => integrations.filter((integration) => !DATABASE_AUTO_INTEGRATIONS.has(integration.name))
 
 /**
  * Local/dev Sentry is opt-in only. Production sends when a DSN is configured;

--- a/apps/vps/src/services/sentry-client.service.ts
+++ b/apps/vps/src/services/sentry-client.service.ts
@@ -5,7 +5,11 @@ type Client = Sentry.NodeClient
 
 import { Context, Effect, Layer } from 'effect'
 import { sanitizeDatabaseSpan } from '@/lib/database-telemetry'
-import { hasLocalSentryContext, shouldEnableSentry } from '@/lib/sentry'
+import {
+  hasLocalSentryContext,
+  shouldEnableSentry,
+  withoutDatabaseAutoInstrumentation
+} from '@/lib/sentry'
 import { ConfigService } from './config.service'
 
 export interface SentryClientService {
@@ -41,6 +45,7 @@ export const SentryClientServiceLayer = Layer.effect(
           environment: sentry.environment,
           release: process.env.SENTRY_RELEASE,
           skipOpenTelemetrySetup: true,
+          integrations: withoutDatabaseAutoInstrumentation,
           tracesSampler: ({ inheritOrSampleWith, name, normalizedRequest }) =>
             inheritOrSampleWith(traceSampleRate({ name, url: normalizedRequest?.url })),
           sendDefaultPii: false,


### PR DESCRIPTION
## Summary

- remove Sentry's default `Postgres` and `PostgresJs` integrations in both preload and fallback initialization
- keep the explicit database wrapper as the only query span source, preserving its low-cardinality sanitized summaries
- cover the shared integration filter so future SDK defaults cannot silently reintroduce duplicate raw-query spans

## Production evidence

v2.76.5 / ECS revision 200 proved the unified provider fix works: Sentry ingested real `db.query` spans attached to `GET /api/profile/:username`, with non-null parent IDs and safe summary attributes. It also activated Sentry's default Postgres instrumentation, creating duplicate `db` spans whose descriptions contained parameterized SQL. This PR removes that competing instrumentation rather than relying on an export hook that did not sanitize those streamed spans.

## Validation

- `bun precommit`
- `bunx vitest run --config vitest.unit.config.ts src/lib/sentry.test.ts src/lib/database-instrumentation.test.ts src/lib/database-telemetry.test.ts` (15 tests)
- production gate after deploy: `db.query` spans remain; `span.op:db` and raw SQL descriptions are absent for the new release

Related to #234
