### PR TITLE
ci: gate production deploys on telemetry invariants

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,3 +103,16 @@ jobs:
           release: ${{ steps.deployment-ref.outputs.ref }}
           set_commits: auto
           finalize: true
+
+      - name: Verify production deployment and telemetry
+        timeout-minutes: 20
+        env:
+          PRODUCTION_BASE_URL: https://vps.goosebumps.fm
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_OBSERVABILITY_TOKEN }}
+          SENTRY_ENVIRONMENT: production
+          SENTRY_ORG: goosebumps-collective
+          SENTRY_PROJECT_ID: '4511355794227200'
+          SENTRY_RELEASE: ${{ steps.deployment-ref.outputs.ref }}
+          SST_APP: gbfm
+          SST_STAGE: prod
+        run: bun run apps/vps/scripts/verify-production-deployment.ts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Verify production deployment and telemetry
         timeout-minutes: 20
         env:
+          AWS_REGION: us-east-1
           PRODUCTION_BASE_URL: https://vps.goosebumps.fm
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_OBSERVABILITY_TOKEN }}
           SENTRY_ENVIRONMENT: production

--- a/apps/vps/scripts/production-verification-live.ts
+++ b/apps/vps/scripts/production-verification-live.ts
@@ -1,0 +1,171 @@
+import { Effect, Layer, Redacted } from 'effect'
+import {
+  ProductionVerificationError,
+  ProductionVerificationPort,
+  type ProductionVerificationPort as ProductionVerificationPortShape
+} from '../src/ops/production-verification'
+
+const SENTRY_SPAN_FIELDS = [
+  'id',
+  'parent_span',
+  'span.op',
+  'description',
+  'transaction',
+  'trace',
+  'release',
+  'environment',
+  'db.system.name',
+  'db.operation.name',
+  'db.collection.name',
+  'db.query.summary',
+  'db.statement',
+  'db.query',
+  'db.query.text'
+] as const
+
+type LiveVerificationConfig = {
+  readonly awsRegion: string
+  readonly sentryOrg: string
+  readonly sentryProjectId: string
+  readonly sentryToken: Redacted.Redacted<string>
+}
+
+const dependencyFailure = (
+  phase:
+    | 'resource-discovery'
+    | 'ecs-rollout'
+    | 'health-probe'
+    | 'profile-probe'
+    | 'sentry-ingestion',
+  summary: string
+) => new ProductionVerificationError({ phase, summary })
+
+const runAwsJson = (
+  region: string,
+  phase: 'resource-discovery' | 'ecs-rollout',
+  args: ReadonlyArray<string>
+): Effect.Effect<unknown, ProductionVerificationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const process = Bun.spawn(
+        [
+          'aws',
+          ...args,
+          '--region',
+          region,
+          '--output',
+          'json',
+          '--no-cli-pager',
+          '--cli-connect-timeout',
+          '10',
+          '--cli-read-timeout',
+          '30'
+        ],
+        {
+          stdout: 'pipe',
+          stderr: 'pipe'
+        }
+      )
+      const [stdout, _stderr, exitCode] = await Promise.all([
+        new Response(process.stdout).text(),
+        new Response(process.stderr).text(),
+        process.exited
+      ])
+
+      if (exitCode !== 0) throw new Error('AWS CLI command failed')
+      const output: unknown = JSON.parse(stdout)
+      return output
+    },
+    catch: () => dependencyFailure(phase, 'AWS CLI request failed')
+  })
+
+const fetchJson = (
+  request: Request,
+  phase: 'health-probe' | 'profile-probe' | 'sentry-ingestion'
+) =>
+  Effect.tryPromise({
+    try: (signal) =>
+      fetch(request, { signal }).then(async (response) => {
+        const body: unknown = await response.json()
+        return { response, body }
+      }),
+    catch: () => dependencyFailure(phase, 'HTTP request failed')
+  }).pipe(
+    Effect.timeout('30 seconds'),
+    Effect.mapError((error) =>
+      error instanceof ProductionVerificationError
+        ? error
+        : dependencyFailure(phase, 'HTTP request timed out')
+    )
+  )
+
+/**
+ * Creates the live AWS, production HTTP, and Sentry adapter layer.
+ */
+export const makeProductionVerificationLive = (
+  config: LiveVerificationConfig
+): Layer.Layer<ProductionVerificationPort> =>
+  Layer.succeed(ProductionVerificationPort, {
+    discoverEcsResources: (app, stage) =>
+      runAwsJson(config.awsRegion, 'resource-discovery', [
+        'resourcegroupstaggingapi',
+        'get-resources',
+        '--tag-filters',
+        `Key=sst:app,Values=${app}`,
+        `Key=sst:stage,Values=${stage}`,
+        '--resource-type-filters',
+        'ecs:cluster',
+        'ecs:service'
+      ]),
+    describeEcsService: ({ clusterArn, serviceArn }) =>
+      runAwsJson(config.awsRegion, 'ecs-rollout', [
+        'ecs',
+        'describe-services',
+        '--cluster',
+        clusterArn,
+        '--services',
+        serviceArn
+      ]),
+    probe: ({ url, traceparent }) => {
+      const headers = new Headers()
+      if (traceparent !== undefined) headers.set('traceparent', traceparent)
+
+      const phase = url.pathname === '/health' ? 'health-probe' : 'profile-probe'
+      return fetchJson(new Request(url.toString(), { headers }), phase).pipe(
+        Effect.map(({ body, response }) => ({ body, status: response.status }))
+      )
+    },
+    querySpans: ({ environment, operation, release, traceId }) => {
+      const url = new URL(
+        `/api/0/organizations/${encodeURIComponent(config.sentryOrg)}/events/`,
+        'https://sentry.io'
+      )
+      url.searchParams.set('dataset', 'spans')
+      url.searchParams.set('project', config.sentryProjectId)
+      url.searchParams.set('environment', environment)
+      url.searchParams.set('statsPeriod', '1h')
+      url.searchParams.set('per_page', '100')
+      url.searchParams.set('query', `trace:${traceId} release:${release} span.op:${operation}`)
+      for (const field of SENTRY_SPAN_FIELDS) url.searchParams.append('field', field)
+
+      const request = new Request(url.toString(), {
+        headers: {
+          authorization: `Bearer ${Redacted.value(config.sentryToken)}`,
+          'cache-control': 'no-cache'
+        }
+      })
+      return fetchJson(request, 'sentry-ingestion').pipe(
+        Effect.flatMap(({ body, response }) =>
+          response.ok
+            ? Effect.succeed(body)
+            : Effect.fail(
+                dependencyFailure(
+                  'sentry-ingestion',
+                  `Sentry spans request returned HTTP ${response.status}`
+                )
+              )
+        )
+      )
+    },
+    wait: (milliseconds) => Effect.sleep(milliseconds)
+  } satisfies ProductionVerificationPortShape)

--- a/apps/vps/scripts/production-verification-live.ts
+++ b/apps/vps/scripts/production-verification-live.ts
@@ -23,6 +23,7 @@ const SENTRY_SPAN_FIELDS = [
   'db.query',
   'db.query.text'
 ] as const
+const SENTRY_PAGE_SIZE = 100
 
 type LiveVerificationConfig = {
   readonly awsRegion: string
@@ -41,8 +42,26 @@ const dependencyFailure = (
   summary: string
 ) => new ProductionVerificationError({ phase, summary })
 
-const safeAwsErrorCode = (standardError: string) =>
+export const safeAwsErrorCode = (standardError: string) =>
   /An error occurred \(([A-Za-z0-9._-]+)\)/.exec(standardError)?.[1]
+
+export const sentrySpanResponseIsTruncated = (response: Response, body: unknown) => {
+  const nextPageHasResults = response.headers
+    .get('link')
+    ?.split(',')
+    .some(
+      (part) =>
+        part.includes('rel="next"') &&
+        (part.includes('results="true"') || !part.includes('results='))
+    )
+  const reachedPageLimit =
+    typeof body === 'object' &&
+    body !== null &&
+    'data' in body &&
+    Array.isArray(body.data) &&
+    body.data.length >= SENTRY_PAGE_SIZE
+  return nextPageHasResults === true || reachedPageLimit
+}
 
 class SafeAwsCliError extends Error {
   readonly code: string | undefined
@@ -172,7 +191,7 @@ export const makeProductionVerificationLive = (
       url.searchParams.set('project', config.sentryProjectId)
       url.searchParams.set('environment', environment)
       url.searchParams.set('statsPeriod', '1h')
-      url.searchParams.set('per_page', '100')
+      url.searchParams.set('per_page', String(SENTRY_PAGE_SIZE))
       url.searchParams.set('query', `trace:${traceId} release:${release} span.op:${operation}`)
       for (const field of SENTRY_SPAN_FIELDS) url.searchParams.append('field', field)
 
@@ -183,16 +202,25 @@ export const makeProductionVerificationLive = (
         }
       })
       return fetchJson(request, 'sentry-ingestion').pipe(
-        Effect.flatMap(({ body, response }) =>
-          response.ok
-            ? Effect.succeed(body)
-            : Effect.fail(
-                dependencyFailure(
-                  'sentry-ingestion',
-                  `Sentry spans request returned HTTP ${response.status}`
-                )
+        Effect.flatMap(({ body, response }) => {
+          if (!response.ok) {
+            return Effect.fail(
+              dependencyFailure(
+                'sentry-ingestion',
+                `Sentry spans request returned HTTP ${response.status}`
               )
-        )
+            )
+          }
+          if (sentrySpanResponseIsTruncated(response, body)) {
+            return Effect.fail(
+              dependencyFailure(
+                'sentry-ingestion',
+                `Sentry span query reached its ${SENTRY_PAGE_SIZE}-span page limit`
+              )
+            )
+          }
+          return Effect.succeed(body)
+        })
       )
     },
     wait: (milliseconds) => Effect.sleep(milliseconds)

--- a/apps/vps/scripts/production-verification-live.ts
+++ b/apps/vps/scripts/production-verification-live.ts
@@ -18,6 +18,7 @@ const SENTRY_SPAN_FIELDS = [
   'db.operation.name',
   'db.collection.name',
   'db.query.summary',
+  'gbfm.db.instrumentation',
   'db.statement',
   'db.query',
   'db.query.text'
@@ -40,6 +41,18 @@ const dependencyFailure = (
   summary: string
 ) => new ProductionVerificationError({ phase, summary })
 
+const safeAwsErrorCode = (standardError: string) =>
+  /An error occurred \(([A-Za-z0-9._-]+)\)/.exec(standardError)?.[1]
+
+class SafeAwsCliError extends Error {
+  readonly code: string | undefined
+
+  constructor(code: string | undefined) {
+    super('AWS CLI request failed')
+    this.code = code
+  }
+}
+
 const runAwsJson = (
   region: string,
   phase: 'resource-discovery' | 'ecs-rollout',
@@ -47,7 +60,7 @@ const runAwsJson = (
 ): Effect.Effect<unknown, ProductionVerificationError> =>
   Effect.tryPromise({
     try: async () => {
-      const process = Bun.spawn(
+      const child = Bun.spawn(
         [
           'aws',
           ...args,
@@ -66,17 +79,25 @@ const runAwsJson = (
           stderr: 'pipe'
         }
       )
-      const [stdout, _stderr, exitCode] = await Promise.all([
-        new Response(process.stdout).text(),
-        new Response(process.stderr).text(),
-        process.exited
+      const [stdout, standardError, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited
       ])
 
-      if (exitCode !== 0) throw new Error('AWS CLI command failed')
+      if (exitCode !== 0) {
+        throw new SafeAwsCliError(safeAwsErrorCode(standardError))
+      }
       const output: unknown = JSON.parse(stdout)
       return output
     },
-    catch: () => dependencyFailure(phase, 'AWS CLI request failed')
+    catch: (error) => {
+      const code = error instanceof SafeAwsCliError ? error.code : undefined
+      return dependencyFailure(
+        phase,
+        code === undefined ? 'AWS CLI request failed' : `AWS CLI request failed (${code})`
+      )
+    }
   })
 
 const fetchJson = (
@@ -125,6 +146,13 @@ export const makeProductionVerificationLive = (
         clusterArn,
         '--services',
         serviceArn
+      ]),
+    describeTaskDefinition: (taskDefinitionArn) =>
+      runAwsJson(config.awsRegion, 'ecs-rollout', [
+        'ecs',
+        'describe-task-definition',
+        '--task-definition',
+        taskDefinitionArn
       ]),
     probe: ({ url, traceparent }) => {
       const headers = new Headers()

--- a/apps/vps/scripts/verify-production-deployment.ts
+++ b/apps/vps/scripts/verify-production-deployment.ts
@@ -23,7 +23,7 @@ const Environment = Schema.Struct({
   SST_STAGE: Schema.NonEmptyString
 })
 
-const VERIFICATION_REQUEST_HEADROOM_MS = 2 * 60_000
+const VERIFICATION_REQUEST_HEADROOM_MS = 5 * 60_000
 
 const verificationTimeoutMs = (config: ProductionVerificationConfig) =>
   Math.max(0, config.ecs.attempts - 1) * config.ecs.intervalMs +

--- a/apps/vps/scripts/verify-production-deployment.ts
+++ b/apps/vps/scripts/verify-production-deployment.ts
@@ -1,0 +1,119 @@
+import { appendFile } from 'node:fs/promises'
+import { randomBytes } from 'node:crypto'
+import { Effect, Redacted, Schema } from 'effect'
+import {
+  ProductionVerificationError,
+  type ProductionVerificationConfig,
+  type ProductionVerificationReport,
+  verifyProductionDeployment
+} from '../src/ops/production-verification'
+import { makeProductionVerificationLive } from './production-verification-live'
+
+const Environment = Schema.Struct({
+  AWS_REGION: Schema.NonEmptyString,
+  PRODUCTION_BASE_URL: Schema.URLFromString,
+  SENTRY_AUTH_TOKEN: Schema.RedactedFromValue(Schema.NonEmptyString),
+  SENTRY_ENVIRONMENT: Schema.NonEmptyString,
+  SENTRY_ORG: Schema.NonEmptyString,
+  SENTRY_PROJECT_ID: Schema.NonEmptyString,
+  SENTRY_RELEASE: Schema.NonEmptyString,
+  SST_APP: Schema.NonEmptyString,
+  SST_STAGE: Schema.NonEmptyString
+})
+
+const safeFailureSummary = (error: unknown) =>
+  error instanceof ProductionVerificationError
+    ? `${error.phase}: ${error.summary}`
+    : 'configuration: unexpected production verification defect'
+
+const reportMarkdown = (report: ProductionVerificationReport) => `## Production verification
+
+| Gate | Evidence |
+| --- | --- |
+| Release | \`${report.release}\` |
+| ECS | One completed deployment, task \`${report.taskDefinition.split('/').at(-1) ?? report.taskDefinition}\` |
+| Health probe | HTTP ${report.healthStatus} |
+| Profile probe | HTTP ${report.profileStatus} |
+| Sentry trace | \`${report.traceId}\` |
+| Safe database spans | ${report.databaseSpanCount} parented \`db.query\` span(s), zero forbidden \`db\` spans |
+`
+
+const failureMarkdown = (summary: string) => `## Production verification
+
+❌ ${summary}
+`
+
+const appendSummary = (markdown: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const summaryPath = process.env.GITHUB_STEP_SUMMARY
+      if (summaryPath !== undefined && summaryPath.length > 0) {
+        await appendFile(summaryPath, markdown)
+      }
+    },
+    catch: () =>
+      new ProductionVerificationError({
+        phase: 'configuration',
+        summary: 'Could not write the GitHub Actions step summary'
+      })
+  })
+
+const program = Effect.gen(function* () {
+  const environment = yield* Schema.decodeUnknownEffect(Environment)(process.env).pipe(
+    Effect.mapError(
+      () =>
+        new ProductionVerificationError({
+          phase: 'configuration',
+          summary: 'Production verification environment is missing or invalid'
+        })
+    )
+  )
+
+  const config: ProductionVerificationConfig = {
+    app: environment.SST_APP,
+    stage: environment.SST_STAGE,
+    environment: environment.SENTRY_ENVIRONMENT,
+    release: environment.SENTRY_RELEASE,
+    baseUrl: environment.PRODUCTION_BASE_URL,
+    profilePath: '/api/profile/guidefari',
+    traceId: randomBytes(16).toString('hex'),
+    parentSpanId: randomBytes(8).toString('hex'),
+    ecs: {
+      attempts: 40,
+      intervalMs: 15_000
+    },
+    sentry: {
+      attempts: 20,
+      intervalMs: 15_000
+    }
+  }
+
+  const report = yield* verifyProductionDeployment(config).pipe(
+    Effect.provide(
+      makeProductionVerificationLive({
+        awsRegion: environment.AWS_REGION,
+        sentryOrg: environment.SENTRY_ORG,
+        sentryProjectId: environment.SENTRY_PROJECT_ID,
+        sentryToken: environment.SENTRY_AUTH_TOKEN
+      })
+    )
+  )
+
+  yield* Effect.logInfo('Production verification passed', {
+    release: report.release,
+    taskDefinition: report.taskDefinition,
+    traceId: report.traceId,
+    databaseSpanCount: report.databaseSpanCount
+  })
+  yield* appendSummary(reportMarkdown(report))
+  return report
+})
+
+try {
+  await Effect.runPromise(program)
+} catch (error: unknown) {
+  const summary = safeFailureSummary(error)
+  console.error(`Production verification failed: ${summary}`)
+  await Effect.runPromise(appendSummary(failureMarkdown(summary))).catch(() => undefined)
+  process.exitCode = 1
+}

--- a/apps/vps/scripts/verify-production-deployment.ts
+++ b/apps/vps/scripts/verify-production-deployment.ts
@@ -23,6 +23,14 @@ const Environment = Schema.Struct({
   SST_STAGE: Schema.NonEmptyString
 })
 
+const VERIFICATION_REQUEST_HEADROOM_MS = 2 * 60_000
+
+const verificationTimeoutMs = (config: ProductionVerificationConfig) =>
+  Math.max(0, config.ecs.attempts - 1) * config.ecs.intervalMs +
+  Math.max(0, config.sentry.ingestionAttempts - 1) * config.sentry.intervalMs +
+  Math.max(0, config.sentry.settlementAttempts - 1) * config.sentry.intervalMs +
+  VERIFICATION_REQUEST_HEADROOM_MS
+
 const reportMarkdown = (report: ProductionVerificationReport) => `## Production verification
 
 | Gate | Evidence |
@@ -77,14 +85,16 @@ const program = Effect.gen(function* () {
     traceId: randomBytes(16).toString('hex'),
     parentSpanId: randomBytes(8).toString('hex'),
     ecs: {
-      attempts: 40,
+      attempts: 28,
       intervalMs: 15_000
     },
     sentry: {
-      attempts: 20,
-      intervalMs: 15_000
+      ingestionAttempts: 16,
+      intervalMs: 15_000,
+      settlementAttempts: 8
     }
   }
+  const timeoutMs = verificationTimeoutMs(config)
 
   const report = yield* verifyProductionDeployment(config).pipe(
     Effect.provide(
@@ -95,13 +105,13 @@ const program = Effect.gen(function* () {
         sentryToken: environment.SENTRY_AUTH_TOKEN
       })
     ),
-    Effect.timeout('18 minutes'),
+    Effect.timeout(timeoutMs),
     Effect.mapError((error) =>
       error instanceof ProductionVerificationError
         ? error
         : new ProductionVerificationError({
             phase: 'verification-timeout',
-            summary: 'Production verification exceeded its 18-minute internal timeout'
+            summary: `Production verification exceeded its ${timeoutMs}ms internal timeout`
           })
     )
   )

--- a/apps/vps/scripts/verify-production-deployment.ts
+++ b/apps/vps/scripts/verify-production-deployment.ts
@@ -1,10 +1,12 @@
 import { appendFile } from 'node:fs/promises'
 import { randomBytes } from 'node:crypto'
-import { Effect, Redacted, Schema } from 'effect'
+import { PUBLIC_PROFILE_PATH } from '@gbfm/api/profile'
+import { Cause, Effect, Exit, Schema } from 'effect'
 import {
   ProductionVerificationError,
   type ProductionVerificationConfig,
   type ProductionVerificationReport,
+  summarizeProductionVerificationFailure,
   verifyProductionDeployment
 } from '../src/ops/production-verification'
 import { makeProductionVerificationLive } from './production-verification-live'
@@ -20,11 +22,6 @@ const Environment = Schema.Struct({
   SST_APP: Schema.NonEmptyString,
   SST_STAGE: Schema.NonEmptyString
 })
-
-const safeFailureSummary = (error: unknown) =>
-  error instanceof ProductionVerificationError
-    ? `${error.phase}: ${error.summary}`
-    : 'configuration: unexpected production verification defect'
 
 const reportMarkdown = (report: ProductionVerificationReport) => `## Production verification
 
@@ -75,7 +72,8 @@ const program = Effect.gen(function* () {
     environment: environment.SENTRY_ENVIRONMENT,
     release: environment.SENTRY_RELEASE,
     baseUrl: environment.PRODUCTION_BASE_URL,
-    profilePath: '/api/profile/guidefari',
+    profilePath: PUBLIC_PROFILE_PATH.replace(':username', 'guidefari'),
+    profileTransaction: `GET ${PUBLIC_PROFILE_PATH}`,
     traceId: randomBytes(16).toString('hex'),
     parentSpanId: randomBytes(8).toString('hex'),
     ecs: {
@@ -96,6 +94,15 @@ const program = Effect.gen(function* () {
         sentryProjectId: environment.SENTRY_PROJECT_ID,
         sentryToken: environment.SENTRY_AUTH_TOKEN
       })
+    ),
+    Effect.timeout('18 minutes'),
+    Effect.mapError((error) =>
+      error instanceof ProductionVerificationError
+        ? error
+        : new ProductionVerificationError({
+            phase: 'verification-timeout',
+            summary: 'Production verification exceeded its 18-minute internal timeout'
+          })
     )
   )
 
@@ -109,11 +116,15 @@ const program = Effect.gen(function* () {
   return report
 })
 
-try {
-  await Effect.runPromise(program)
-} catch (error: unknown) {
-  const summary = safeFailureSummary(error)
+const reportFailure = async (error: unknown) => {
+  const summary = summarizeProductionVerificationFailure(error)
   console.error(`Production verification failed: ${summary}`)
   await Effect.runPromise(appendSummary(failureMarkdown(summary))).catch(() => undefined)
   process.exitCode = 1
+}
+
+const exit = await Effect.runPromiseExit(program)
+if (Exit.isFailure(exit)) {
+  const failure = exit.cause.reasons.find(Cause.isFailReason)
+  await reportFailure(failure?.error)
 }

--- a/apps/vps/src/lib/database-instrumentation.test.ts
+++ b/apps/vps/src/lib/database-instrumentation.test.ts
@@ -35,6 +35,7 @@ describe('instrumentDatabaseClient', () => {
         name: 'SELECT audio',
         op: 'db.query',
         attributes: {
+          'gbfm.db.instrumentation': 'manual',
           'db.system.name': 'postgresql',
           'db.operation.name': 'SELECT',
           'db.collection.name': 'audio',
@@ -117,6 +118,7 @@ describe('instrumentDatabaseClient', () => {
         finishedRequestSpan?.spanContext().spanId
       )
       expect(databaseSpan?.attributes).toMatchObject({
+        'gbfm.db.instrumentation': 'manual',
         'sentry.op': 'db.query',
         'db.system.name': 'postgresql',
         'db.operation.name': 'SELECT',

--- a/apps/vps/src/lib/database-instrumentation.ts
+++ b/apps/vps/src/lib/database-instrumentation.ts
@@ -103,6 +103,7 @@ export function instrumentDatabaseClient<T extends QueryableClient>(
         name: summary.description,
         op: 'db.query',
         attributes: {
+          'gbfm.db.instrumentation': 'manual',
           'db.system.name': 'postgresql',
           'db.operation.name': summary.operation,
           'db.collection.name': summary.table,

--- a/apps/vps/src/lib/database-telemetry.test.ts
+++ b/apps/vps/src/lib/database-telemetry.test.ts
@@ -24,6 +24,7 @@ describe('sanitizeDatabaseSpan', () => {
       description: 'select "audio"."id" from "audio" where "creatorId" = $1',
       data: {
         'db.system': 'postgresql',
+        'gbfm.db.instrumentation': 'manual',
         'db.statement': 'select "audio"."id" from "audio" where "creatorId" = $1',
         'db.query.text': 'select "audio"."id" from "audio" where "creatorId" = $1',
         'db.query.parameters': 'secret-user-id',
@@ -38,6 +39,7 @@ describe('sanitizeDatabaseSpan', () => {
       description: 'SELECT audio',
       data: {
         'db.system': 'postgresql',
+        'gbfm.db.instrumentation': 'manual',
         'server.address': 'database.internal',
         'sentry.op': 'db.query',
         'db.system.name': 'postgresql',

--- a/apps/vps/src/lib/database-telemetry.ts
+++ b/apps/vps/src/lib/database-telemetry.ts
@@ -4,6 +4,7 @@ const SAFE_DATABASE_ATTRIBUTE_KEYS = new Set([
   'db.system.name',
   'db.namespace',
   'db.name',
+  'gbfm.db.instrumentation',
   'server.address',
   'server.port'
 ])

--- a/apps/vps/src/ops/production-verification-live.test.ts
+++ b/apps/vps/src/ops/production-verification-live.test.ts
@@ -1,0 +1,36 @@
+import {
+  safeAwsErrorCode,
+  sentrySpanResponseIsTruncated
+} from '../../scripts/production-verification-live'
+import { describe, expect, test } from 'vitest'
+
+describe('production verification live boundaries', () => {
+  test('extracts only a bounded AWS error code', () => {
+    expect(
+      safeAwsErrorCode(
+        'An error occurred (AccessDeniedException) when calling GetResources: account details'
+      )
+    ).toBe('AccessDeniedException')
+    expect(safeAwsErrorCode('arbitrary stderr with arn:aws:iam::123456789012:role/private')).toBe(
+      undefined
+    )
+  })
+
+  test('fails closed when Sentry reports another page', () => {
+    const response = new Response(null, {
+      headers: {
+        link: '<https://sentry.io/next>; rel="next"; results="true"; cursor="opaque"'
+      }
+    })
+
+    expect(sentrySpanResponseIsTruncated(response, { data: [{ id: 'span-1' }] })).toBe(true)
+  })
+
+  test('fails closed when a full Sentry page has ambiguous pagination metadata', () => {
+    const response = new Response()
+    const data = Array.from({ length: 100 }, (_, index) => ({ id: `span-${index}` }))
+
+    expect(sentrySpanResponseIsTruncated(response, { data })).toBe(true)
+    expect(sentrySpanResponseIsTruncated(response, { data: data.slice(0, 99) })).toBe(false)
+  })
+})

--- a/apps/vps/src/ops/production-verification.test.ts
+++ b/apps/vps/src/ops/production-verification.test.ts
@@ -258,9 +258,11 @@ describe('verifyProductionDeployment', () => {
               : [
                   {
                     ...service,
-                    deployments: service.deployments.map((deployment, index) =>
-                      index === 1 ? { ...deployment, failedTasks: 2 } : deployment
-                    )
+                    deployments: service.deployments
+                      .map((deployment, index) =>
+                        index === 1 ? { ...deployment, failedTasks: 2 } : deployment
+                      )
+                      .toReversed()
                   }
                 ]
         },

--- a/apps/vps/src/ops/production-verification.test.ts
+++ b/apps/vps/src/ops/production-verification.test.ts
@@ -23,7 +23,7 @@ const config: ProductionVerificationConfig = {
   traceId,
   parentSpanId,
   ecs: { attempts: 2, intervalMs: 1 },
-  sentry: { attempts: 2, intervalMs: 1 }
+  sentry: { attempts: 4, intervalMs: 1 }
 }
 
 const resources = {
@@ -290,6 +290,29 @@ describe('verifyProductionDeployment', () => {
     ).rejects.toMatchObject({
       phase: 'sentry-privacy',
       summary: expect.stringContaining('automatic or privacy-unsafe')
+    })
+  })
+
+  test('waits for custom span attributes to finish indexing before validation', async () => {
+    const indexingSpan = {
+      ...databaseSpan,
+      'gbfm.db.instrumentation': null
+    }
+    const testLayer = makeTestLayer({
+      expectedSpanResponses: [
+        { data: [indexingSpan] },
+        { data: [indexingSpan] },
+        { data: [databaseSpan] },
+        { data: [databaseSpan] },
+        { data: [databaseSpan] }
+      ]
+    })
+
+    await expect(
+      Effect.runPromise(verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer)))
+    ).resolves.toMatchObject({
+      databaseSpanCount: 1,
+      traceId
     })
   })
 

--- a/apps/vps/src/ops/production-verification.test.ts
+++ b/apps/vps/src/ops/production-verification.test.ts
@@ -245,6 +245,36 @@ describe('verifyProductionDeployment', () => {
     })
   })
 
+  test('ignores failed-task history from the draining previous deployment', async () => {
+    const rollingService = ecsService('IN_PROGRESS')
+    const service = rollingService.services[0]
+    const testLayer = makeTestLayer({
+      ecsResponses: [
+        {
+          ...rollingService,
+          services:
+            service === undefined
+              ? []
+              : [
+                  {
+                    ...service,
+                    deployments: service.deployments.map((deployment, index) =>
+                      index === 1 ? { ...deployment, failedTasks: 2 } : deployment
+                    )
+                  }
+                ]
+        },
+        ecsService()
+      ]
+    })
+
+    await expect(
+      Effect.runPromise(verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer)))
+    ).resolves.toMatchObject({
+      taskDefinition: 'arn:aws:ecs:us-east-1:123:task-definition/gbfm_vps:202'
+    })
+  })
+
   test('fails safely when AWS returns a malformed service boundary', async () => {
     const testLayer = makeTestLayer({
       ecsResponses: [{ services: 'not-an-array', failures: [] }]

--- a/apps/vps/src/ops/production-verification.test.ts
+++ b/apps/vps/src/ops/production-verification.test.ts
@@ -23,7 +23,7 @@ const config: ProductionVerificationConfig = {
   traceId,
   parentSpanId,
   ecs: { attempts: 2, intervalMs: 1 },
-  sentry: { attempts: 4, intervalMs: 1 }
+  sentry: { ingestionAttempts: 4, intervalMs: 1, settlementAttempts: 4 }
 }
 
 const resources = {
@@ -201,6 +201,35 @@ describe('verifyProductionDeployment', () => {
       }
     ])
     expect(testLayer.waitCount()).toBeGreaterThanOrEqual(3)
+  })
+
+  test('reserves an independent convergence budget after late Sentry ingestion', async () => {
+    const lateIngestionConfig: ProductionVerificationConfig = {
+      ...config,
+      sentry: {
+        ingestionAttempts: 2,
+        intervalMs: 1,
+        settlementAttempts: 3
+      }
+    }
+    const testLayer = makeTestLayer({
+      expectedSpanResponses: [
+        { data: [] },
+        { data: [databaseSpan] },
+        { data: [databaseSpan] },
+        { data: [databaseSpan] },
+        { data: [databaseSpan] }
+      ]
+    })
+
+    await expect(
+      Effect.runPromise(
+        verifyProductionDeployment(lateIngestionConfig).pipe(Effect.provide(testLayer.layer))
+      )
+    ).resolves.toMatchObject({
+      databaseSpanCount: 1,
+      traceId
+    })
   })
 
   test('fails when ECS never reaches a single completed deployment', async () => {

--- a/apps/vps/src/ops/production-verification.test.ts
+++ b/apps/vps/src/ops/production-verification.test.ts
@@ -1,0 +1,287 @@
+import { Effect, Layer } from 'effect'
+import { describe, expect, test } from 'vitest'
+import {
+  ProductionVerificationPort,
+  type ProductionVerificationConfig,
+  type ProductionVerificationPort as ProductionVerificationPortShape,
+  verifyProductionDeployment
+} from './production-verification'
+
+const traceId = '1'.repeat(32)
+const parentSpanId = '2'.repeat(16)
+
+const config: ProductionVerificationConfig = {
+  app: 'gbfm',
+  stage: 'prod',
+  environment: 'production',
+  release: 'v2.76.7',
+  baseUrl: new URL('https://vps.goosebumps.fm'),
+  profilePath: '/api/profile/guidefari',
+  traceId,
+  parentSpanId,
+  ecs: { attempts: 2, intervalMs: 1 },
+  sentry: { attempts: 2, intervalMs: 1 }
+}
+
+const resources = {
+  ResourceTagMappingList: [
+    {
+      ResourceARN: 'arn:aws:ecs:us-east-1:123:cluster/gbfm-prod-cluster'
+    },
+    {
+      ResourceARN: 'arn:aws:ecs:us-east-1:123:service/gbfm-prod-cluster/gbfm_vps'
+    }
+  ]
+}
+
+const ecsService = (rolloutState: 'IN_PROGRESS' | 'COMPLETED' = 'COMPLETED') => ({
+  services: [
+    {
+      clusterArn: resources.ResourceTagMappingList[0]?.ResourceARN,
+      serviceArn: resources.ResourceTagMappingList[1]?.ResourceARN,
+      desiredCount: 1,
+      runningCount: rolloutState === 'COMPLETED' ? 1 : 2,
+      pendingCount: 0,
+      deployments:
+        rolloutState === 'COMPLETED'
+          ? [
+              {
+                status: 'PRIMARY',
+                rolloutState,
+                runningCount: 1,
+                pendingCount: 0,
+                failedTasks: 0,
+                taskDefinition: 'arn:aws:ecs:us-east-1:123:task-definition/gbfm_vps:202'
+              }
+            ]
+          : [
+              {
+                status: 'PRIMARY',
+                rolloutState,
+                runningCount: 1,
+                pendingCount: 0,
+                failedTasks: 0,
+                taskDefinition: 'arn:aws:ecs:us-east-1:123:task-definition/gbfm_vps:202'
+              },
+              {
+                status: 'ACTIVE',
+                rolloutState: 'COMPLETED',
+                runningCount: 1,
+                pendingCount: 0,
+                failedTasks: 0,
+                taskDefinition: 'arn:aws:ecs:us-east-1:123:task-definition/gbfm_vps:201'
+              }
+            ]
+    }
+  ],
+  failures: []
+})
+
+const profile = {
+  id: 'profile-1',
+  name: 'Guide Fari',
+  username: 'guidefari',
+  image: null,
+  bio: null,
+  socialLinks: [],
+  createdAt: '2026-07-31T00:00:00.000Z',
+  content: {
+    mixes: [],
+    shows: [],
+    editorials: [],
+    tweets: []
+  }
+}
+
+const databaseSpan = {
+  id: 'span-1',
+  parent_span: 'parent-span',
+  'span.op': 'db.query',
+  description: null,
+  transaction: 'GET /api/profile/:username',
+  trace: traceId,
+  release: config.release,
+  environment: config.environment,
+  'db.system.name': 'postgresql',
+  'db.operation.name': 'SELECT',
+  'db.collection.name': 'user',
+  'db.query.summary': 'SELECT user',
+  'db.statement': null,
+  'db.query': null,
+  'db.query.text': null
+}
+
+type TestOverrides = {
+  readonly ecsResponses?: ReadonlyArray<unknown>
+  readonly expectedSpanResponses?: ReadonlyArray<unknown>
+  readonly forbiddenSpanResponse?: unknown
+}
+
+const makeTestLayer = (overrides: TestOverrides = {}) => {
+  const ecsResponses = [...(overrides.ecsResponses ?? [ecsService()])]
+  const expectedSpanResponses = [...(overrides.expectedSpanResponses ?? [{ data: [databaseSpan] }])]
+  const probes: Array<{ readonly url: string; readonly traceparent?: string }> = []
+  let waits = 0
+
+  const take = (values: Array<unknown>, fallback: unknown) => values.shift() ?? fallback
+
+  const port: ProductionVerificationPortShape = {
+    discoverEcsResources: () => Effect.succeed(resources),
+    describeEcsService: () => Effect.succeed(take(ecsResponses, ecsService())),
+    probe: ({ traceparent, url }) => {
+      probes.push({ url: url.toString(), traceparent })
+      return Effect.succeed({
+        status: 200,
+        body: url.pathname === '/health' ? { dbConnected: true } : profile
+      })
+    },
+    querySpans: ({ operation }) =>
+      Effect.succeed(
+        operation === 'db.query'
+          ? take(expectedSpanResponses, { data: [] })
+          : (overrides.forbiddenSpanResponse ?? { data: [] })
+      ),
+    wait: () =>
+      Effect.sync(() => {
+        waits += 1
+      })
+  }
+
+  return {
+    layer: Layer.succeed(ProductionVerificationPort, port),
+    probes,
+    waitCount: () => waits
+  }
+}
+
+describe('verifyProductionDeployment', () => {
+  test('waits for ECS and proves functional, correlated, privacy-safe telemetry', async () => {
+    const testLayer = makeTestLayer({
+      ecsResponses: [ecsService('IN_PROGRESS'), ecsService()],
+      expectedSpanResponses: [{ data: [] }, { data: [databaseSpan] }]
+    })
+
+    const report = await Effect.runPromise(
+      verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer))
+    )
+
+    expect(report).toEqual({
+      release: config.release,
+      clusterArn: resources.ResourceTagMappingList[0]?.ResourceARN,
+      serviceArn: resources.ResourceTagMappingList[1]?.ResourceARN,
+      taskDefinition: 'arn:aws:ecs:us-east-1:123:task-definition/gbfm_vps:202',
+      traceId,
+      databaseSpanCount: 1,
+      healthStatus: 200,
+      profileStatus: 200
+    })
+    expect(testLayer.probes).toEqual([
+      { url: 'https://vps.goosebumps.fm/health', traceparent: undefined },
+      {
+        url: 'https://vps.goosebumps.fm/api/profile/guidefari',
+        traceparent: `00-${traceId}-${parentSpanId}-01`
+      }
+    ])
+    expect(testLayer.waitCount()).toBe(3)
+  })
+
+  test('fails when ECS never reaches a single completed deployment', async () => {
+    const testLayer = makeTestLayer({
+      ecsResponses: [ecsService('IN_PROGRESS'), ecsService('IN_PROGRESS')]
+    })
+
+    await expect(
+      Effect.runPromise(verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer)))
+    ).rejects.toMatchObject({
+      phase: 'ecs-rollout',
+      summary: expect.stringContaining('did not reach steady state')
+    })
+  })
+
+  test('fails safely when AWS returns a malformed service boundary', async () => {
+    const testLayer = makeTestLayer({
+      ecsResponses: [{ services: 'not-an-array', failures: [] }]
+    })
+
+    await expect(
+      Effect.runPromise(verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer)))
+    ).rejects.toMatchObject({
+      phase: 'ecs-rollout',
+      summary: 'AWS returned an invalid ECS service response'
+    })
+  })
+
+  test('fails when the verification trace never reaches Sentry', async () => {
+    const testLayer = makeTestLayer({
+      expectedSpanResponses: [{ data: [] }, { data: [] }]
+    })
+
+    await expect(
+      Effect.runPromise(verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer)))
+    ).rejects.toMatchObject({
+      phase: 'sentry-ingestion',
+      summary: expect.stringContaining('No database spans arrived')
+    })
+  })
+
+  test('fails safely when Sentry returns a malformed span boundary', async () => {
+    const testLayer = makeTestLayer({
+      expectedSpanResponses: [{ data: [{ id: 'incomplete-span' }] }]
+    })
+
+    await expect(
+      Effect.runPromise(verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer)))
+    ).rejects.toMatchObject({
+      phase: 'sentry-ingestion',
+      summary: 'Sentry returned an invalid spans response'
+    })
+  })
+
+  test.each([
+    {
+      name: 'missing parent correlation',
+      span: { ...databaseSpan, parent_span: null }
+    },
+    {
+      name: 'raw SQL attribute',
+      span: {
+        ...databaseSpan,
+        'db.statement': 'select * from user where id = $1'
+      }
+    },
+    {
+      name: 'wrong release',
+      span: { ...databaseSpan, release: 'v-old' }
+    },
+    {
+      name: 'SQL-shaped description',
+      span: { ...databaseSpan, description: 'select * from user where id = $1' }
+    }
+  ])('fails privacy and correlation for $name', async ({ span }) => {
+    const testLayer = makeTestLayer({
+      expectedSpanResponses: [{ data: [span] }]
+    })
+
+    await expect(
+      Effect.runPromise(verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer)))
+    ).rejects.toMatchObject({
+      phase: 'sentry-privacy',
+      summary: expect.stringContaining('unsafe database span')
+    })
+  })
+
+  test('fails when Sentry emits an automatic database span', async () => {
+    const testLayer = makeTestLayer({
+      forbiddenSpanResponse: {
+        data: [{ ...databaseSpan, 'span.op': 'db' }]
+      }
+    })
+
+    await expect(
+      Effect.runPromise(verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer)))
+    ).rejects.toMatchObject({
+      phase: 'sentry-privacy',
+      summary: expect.stringContaining('forbidden automatic database span')
+    })
+  })
+})

--- a/apps/vps/src/ops/production-verification.test.ts
+++ b/apps/vps/src/ops/production-verification.test.ts
@@ -1,9 +1,11 @@
-import { Effect, Layer } from 'effect'
+import { Cause, Effect, Exit, Layer } from 'effect'
 import { describe, expect, test } from 'vitest'
 import {
   ProductionVerificationPort,
+  ProductionVerificationError,
   type ProductionVerificationConfig,
   type ProductionVerificationPort as ProductionVerificationPortShape,
+  summarizeProductionVerificationFailure,
   verifyProductionDeployment
 } from './production-verification'
 
@@ -17,6 +19,7 @@ const config: ProductionVerificationConfig = {
   release: 'v2.76.7',
   baseUrl: new URL('https://vps.goosebumps.fm'),
   profilePath: '/api/profile/guidefari',
+  profileTransaction: 'GET /api/profile/:username',
   traceId,
   parentSpanId,
   ecs: { attempts: 2, intervalMs: 1 },
@@ -106,13 +109,25 @@ const databaseSpan = {
   'db.operation.name': 'SELECT',
   'db.collection.name': 'user',
   'db.query.summary': 'SELECT user',
+  'gbfm.db.instrumentation': 'manual',
   'db.statement': null,
   'db.query': null,
   'db.query.text': null
 }
 
+const taskDefinition = (release = config.release) => ({
+  taskDefinition: {
+    containerDefinitions: [
+      {
+        environment: [{ name: 'SENTRY_RELEASE', value: release }]
+      }
+    ]
+  }
+})
+
 type TestOverrides = {
   readonly ecsResponses?: ReadonlyArray<unknown>
+  readonly taskDefinitionResponse?: unknown
   readonly expectedSpanResponses?: ReadonlyArray<unknown>
   readonly forbiddenSpanResponse?: unknown
 }
@@ -123,11 +138,14 @@ const makeTestLayer = (overrides: TestOverrides = {}) => {
   const probes: Array<{ readonly url: string; readonly traceparent?: string }> = []
   let waits = 0
 
-  const take = (values: Array<unknown>, fallback: unknown) => values.shift() ?? fallback
+  const take = (values: Array<unknown>, fallback: unknown) =>
+    values.length > 1 ? (values.shift() ?? fallback) : (values[0] ?? fallback)
 
   const port: ProductionVerificationPortShape = {
     discoverEcsResources: () => Effect.succeed(resources),
     describeEcsService: () => Effect.succeed(take(ecsResponses, ecsService())),
+    describeTaskDefinition: () =>
+      Effect.succeed(overrides.taskDefinitionResponse ?? taskDefinition()),
     probe: ({ traceparent, url }) => {
       probes.push({ url: url.toString(), traceparent })
       return Effect.succeed({
@@ -158,7 +176,7 @@ describe('verifyProductionDeployment', () => {
   test('waits for ECS and proves functional, correlated, privacy-safe telemetry', async () => {
     const testLayer = makeTestLayer({
       ecsResponses: [ecsService('IN_PROGRESS'), ecsService()],
-      expectedSpanResponses: [{ data: [] }, { data: [databaseSpan] }]
+      expectedSpanResponses: [{ data: [] }, { data: [databaseSpan] }, { data: [databaseSpan] }]
     })
 
     const report = await Effect.runPromise(
@@ -182,7 +200,7 @@ describe('verifyProductionDeployment', () => {
         traceparent: `00-${traceId}-${parentSpanId}-01`
       }
     ])
-    expect(testLayer.waitCount()).toBe(3)
+    expect(testLayer.waitCount()).toBeGreaterThanOrEqual(3)
   })
 
   test('fails when ECS never reaches a single completed deployment', async () => {
@@ -208,6 +226,19 @@ describe('verifyProductionDeployment', () => {
     ).rejects.toMatchObject({
       phase: 'ecs-rollout',
       summary: 'AWS returned an invalid ECS service response'
+    })
+  })
+
+  test('fails when the stable ECS task belongs to a different release', async () => {
+    const testLayer = makeTestLayer({
+      taskDefinitionResponse: taskDefinition('v-old')
+    })
+
+    await expect(
+      Effect.runPromise(verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer)))
+    ).rejects.toMatchObject({
+      phase: 'ecs-rollout',
+      summary: expect.stringContaining('does not contain the deployed Sentry release')
     })
   })
 
@@ -237,27 +268,60 @@ describe('verifyProductionDeployment', () => {
     })
   })
 
+  test('revalidates all database spans after Sentry ingestion settles', async () => {
+    const testLayer = makeTestLayer({
+      expectedSpanResponses: [
+        { data: [databaseSpan] },
+        {
+          data: [
+            databaseSpan,
+            {
+              ...databaseSpan,
+              id: 'late-automatic-span',
+              'gbfm.db.instrumentation': null
+            }
+          ]
+        }
+      ]
+    })
+
+    await expect(
+      Effect.runPromise(verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer)))
+    ).rejects.toMatchObject({
+      phase: 'sentry-privacy',
+      summary: expect.stringContaining('automatic or privacy-unsafe')
+    })
+  })
+
   test.each([
     {
       name: 'missing parent correlation',
-      span: { ...databaseSpan, parent_span: null }
+      span: { ...databaseSpan, parent_span: null },
+      phase: 'sentry-correlation',
+      summary: 'missing or mismatched trace correlation'
     },
     {
       name: 'raw SQL attribute',
       span: {
         ...databaseSpan,
         'db.statement': 'select * from user where id = $1'
-      }
+      },
+      phase: 'sentry-privacy',
+      summary: 'automatic or privacy-unsafe database span'
     },
     {
       name: 'wrong release',
-      span: { ...databaseSpan, release: 'v-old' }
+      span: { ...databaseSpan, release: 'v-old' },
+      phase: 'sentry-correlation',
+      summary: 'missing or mismatched trace correlation'
     },
     {
       name: 'SQL-shaped description',
-      span: { ...databaseSpan, description: 'select * from user where id = $1' }
+      span: { ...databaseSpan, description: 'select * from user where id = $1' },
+      phase: 'sentry-privacy',
+      summary: 'automatic or privacy-unsafe database span'
     }
-  ])('fails privacy and correlation for $name', async ({ span }) => {
+  ])('fails privacy and correlation for $name', async ({ phase, span, summary }) => {
     const testLayer = makeTestLayer({
       expectedSpanResponses: [{ data: [span] }]
     })
@@ -265,8 +329,8 @@ describe('verifyProductionDeployment', () => {
     await expect(
       Effect.runPromise(verifyProductionDeployment(config).pipe(Effect.provide(testLayer.layer)))
     ).rejects.toMatchObject({
-      phase: 'sentry-privacy',
-      summary: expect.stringContaining('unsafe database span')
+      phase,
+      summary: expect.stringContaining(summary)
     })
   })
 
@@ -283,5 +347,22 @@ describe('verifyProductionDeployment', () => {
       phase: 'sentry-privacy',
       summary: expect.stringContaining('forbidden automatic database span')
     })
+  })
+
+  test('retains a typed failure summary across the Effect promise boundary', async () => {
+    const exit = await Effect.runPromiseExit(
+      Effect.fail(
+        new ProductionVerificationError({
+          phase: 'ecs-rollout',
+          summary: 'ECS did not stabilize'
+        })
+      )
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    const failure = Exit.isFailure(exit) ? exit.cause.reasons.find(Cause.isFailReason) : undefined
+    expect(summarizeProductionVerificationFailure(failure?.error)).toBe(
+      'ecs-rollout: ECS did not stabilize'
+    )
   })
 })

--- a/apps/vps/src/ops/production-verification.ts
+++ b/apps/vps/src/ops/production-verification.ts
@@ -1,0 +1,459 @@
+import { HealthReadyResponse } from '@gbfm/api/health'
+import { PublicProfileResponse } from '@gbfm/api/profile'
+import { Context, Data, Effect, Schema } from 'effect'
+
+const TaggedResourceResponse = Schema.Struct({
+  ResourceTagMappingList: Schema.Array(
+    Schema.Struct({
+      ResourceARN: Schema.String
+    })
+  )
+})
+
+const EcsDeployment = Schema.Struct({
+  status: Schema.String,
+  rolloutState: Schema.String,
+  runningCount: Schema.Number,
+  pendingCount: Schema.Number,
+  failedTasks: Schema.Number,
+  taskDefinition: Schema.String
+})
+
+const DescribeServicesResponse = Schema.Struct({
+  services: Schema.Array(
+    Schema.Struct({
+      clusterArn: Schema.String,
+      serviceArn: Schema.String,
+      desiredCount: Schema.Number,
+      runningCount: Schema.Number,
+      pendingCount: Schema.Number,
+      deployments: Schema.Array(EcsDeployment)
+    })
+  ),
+  failures: Schema.Array(Schema.Unknown)
+})
+
+const SentrySpan = Schema.Struct({
+  id: Schema.String,
+  parent_span: Schema.NullOr(Schema.String),
+  'span.op': Schema.NullOr(Schema.String),
+  description: Schema.NullOr(Schema.String),
+  transaction: Schema.NullOr(Schema.String),
+  trace: Schema.String,
+  release: Schema.String,
+  environment: Schema.String,
+  'db.system.name': Schema.NullOr(Schema.String),
+  'db.operation.name': Schema.NullOr(Schema.String),
+  'db.collection.name': Schema.NullOr(Schema.String),
+  'db.query.summary': Schema.NullOr(Schema.String),
+  'db.statement': Schema.NullOr(Schema.String),
+  'db.query': Schema.NullOr(Schema.String),
+  'db.query.text': Schema.NullOr(Schema.String)
+})
+
+const SentrySpansResponse = Schema.Struct({
+  data: Schema.Array(SentrySpan)
+})
+
+const SAFE_DATABASE_OPERATION = /^(?:SELECT|INSERT|UPDATE|DELETE|QUERY)$/
+const SAFE_DATABASE_COLLECTION = /^(?:unknown|[A-Za-z_][\w$]*)$/
+const SAFE_DATABASE_SUMMARY = /^(?:SELECT|INSERT|UPDATE|DELETE|QUERY)(?: [A-Za-z_][\w$]*)?$/
+const PROFILE_TRANSACTION = 'GET /api/profile/:username'
+
+type VerificationPhase =
+  | 'configuration'
+  | 'resource-discovery'
+  | 'ecs-rollout'
+  | 'health-probe'
+  | 'profile-probe'
+  | 'sentry-ingestion'
+  | 'sentry-privacy'
+
+type EcsResources = {
+  readonly clusterArn: string
+  readonly serviceArn: string
+}
+
+type ProbeRequest = {
+  readonly url: URL
+  readonly traceparent?: string
+}
+
+type ProbeResponse = {
+  readonly status: number
+  readonly body: unknown
+}
+
+type SpanQuery = {
+  readonly environment: string
+  readonly operation: 'db.query' | 'db'
+  readonly release: string
+  readonly traceId: string
+}
+
+/**
+ * Safe expected failure from the production deployment verification gate.
+ */
+export class ProductionVerificationError extends Data.TaggedError('ProductionVerificationError')<{
+  readonly phase: VerificationPhase
+  readonly summary: string
+}> {}
+
+/**
+ * Runtime configuration for one production verification run.
+ */
+export type ProductionVerificationConfig = {
+  readonly app: string
+  readonly stage: string
+  readonly environment: string
+  readonly release: string
+  readonly baseUrl: URL
+  readonly profilePath: string
+  readonly traceId: string
+  readonly parentSpanId: string
+  readonly ecs: {
+    readonly attempts: number
+    readonly intervalMs: number
+  }
+  readonly sentry: {
+    readonly attempts: number
+    readonly intervalMs: number
+  }
+}
+
+/**
+ * External operations used by the deployment verifier.
+ *
+ * Implementations return unknown AWS and Sentry payloads so the verifier owns
+ * boundary parsing and cannot accidentally trust third-party response shapes.
+ */
+export interface ProductionVerificationPort {
+  readonly discoverEcsResources: (
+    app: string,
+    stage: string
+  ) => Effect.Effect<unknown, ProductionVerificationError>
+  readonly describeEcsService: (
+    resources: EcsResources
+  ) => Effect.Effect<unknown, ProductionVerificationError>
+  readonly probe: (
+    request: ProbeRequest
+  ) => Effect.Effect<ProbeResponse, ProductionVerificationError>
+  readonly querySpans: (query: SpanQuery) => Effect.Effect<unknown, ProductionVerificationError>
+  readonly wait: (milliseconds: number) => Effect.Effect<void>
+}
+
+/**
+ * Effect service seam for production AWS, HTTP, and Sentry operations.
+ */
+export const ProductionVerificationPort = Context.Service<ProductionVerificationPort>(
+  'ProductionVerificationPort'
+)
+
+/**
+ * Safe evidence emitted by a successful production verification run.
+ */
+export type ProductionVerificationReport = {
+  readonly release: string
+  readonly clusterArn: string
+  readonly serviceArn: string
+  readonly taskDefinition: string
+  readonly traceId: string
+  readonly databaseSpanCount: number
+  readonly healthStatus: number
+  readonly profileStatus: number
+}
+
+const fail = (
+  phase: VerificationPhase,
+  summary: string
+): Effect.Effect<never, ProductionVerificationError> =>
+  Effect.fail(new ProductionVerificationError({ phase, summary }))
+
+const decodeResources = (input: unknown) =>
+  Schema.decodeUnknownEffect(TaggedResourceResponse)(input).pipe(
+    Effect.mapError(
+      () =>
+        new ProductionVerificationError({
+          phase: 'resource-discovery',
+          summary: 'AWS returned an invalid tagged-resource response'
+        })
+    )
+  )
+
+const decodeEcsService = (input: unknown) =>
+  Schema.decodeUnknownEffect(DescribeServicesResponse)(input).pipe(
+    Effect.mapError(
+      () =>
+        new ProductionVerificationError({
+          phase: 'ecs-rollout',
+          summary: 'AWS returned an invalid ECS service response'
+        })
+    )
+  )
+
+const decodeSentrySpans = (input: unknown, phase: 'sentry-ingestion' | 'sentry-privacy') =>
+  Schema.decodeUnknownEffect(SentrySpansResponse)(input).pipe(
+    Effect.mapError(
+      () =>
+        new ProductionVerificationError({
+          phase,
+          summary: 'Sentry returned an invalid spans response'
+        })
+    )
+  )
+
+const parseEcsResources = (
+  input: unknown
+): Effect.Effect<EcsResources, ProductionVerificationError> =>
+  Effect.gen(function* () {
+    const response = yield* decodeResources(input)
+    const clusterArns = response.ResourceTagMappingList.flatMap(({ ResourceARN }) =>
+      ResourceARN.includes(':cluster/') ? [ResourceARN] : []
+    )
+    const serviceArns = response.ResourceTagMappingList.flatMap(({ ResourceARN }) =>
+      ResourceARN.includes(':service/') ? [ResourceARN] : []
+    )
+
+    if (clusterArns.length !== 1 || serviceArns.length !== 1) {
+      return yield* fail(
+        'resource-discovery',
+        `Expected one production ECS cluster and service, found ${clusterArns.length} cluster(s) and ${serviceArns.length} service(s)`
+      )
+    }
+
+    const clusterArn = clusterArns[0]
+    const serviceArn = serviceArns[0]
+    if (clusterArn === undefined || serviceArn === undefined) {
+      return yield* fail('resource-discovery', 'AWS resource discovery returned no usable ARN')
+    }
+
+    const clusterName = clusterArn.split('/').at(-1)
+    if (clusterName === undefined || !serviceArn.includes(`:service/${clusterName}/`)) {
+      return yield* fail(
+        'resource-discovery',
+        'The discovered ECS service does not belong to the discovered cluster'
+      )
+    }
+
+    return { clusterArn, serviceArn }
+  })
+
+const waitForStableEcsService = (
+  resources: EcsResources,
+  config: ProductionVerificationConfig['ecs']
+): Effect.Effect<string, ProductionVerificationError, ProductionVerificationPort> =>
+  Effect.gen(function* () {
+    const port = yield* ProductionVerificationPort
+    let lastState = 'unavailable'
+
+    for (let attempt = 1; attempt <= config.attempts; attempt += 1) {
+      const response = yield* port
+        .describeEcsService(resources)
+        .pipe(Effect.flatMap(decodeEcsService))
+
+      if (response.failures.length > 0 || response.services.length !== 1) {
+        return yield* fail(
+          'ecs-rollout',
+          'AWS did not return exactly one healthy ECS service result'
+        )
+      }
+
+      const service = response.services[0]
+      if (service === undefined) {
+        return yield* fail('ecs-rollout', 'AWS returned no ECS service')
+      }
+
+      const deployment = service.deployments[0]
+      const failedTasks = service.deployments.reduce(
+        (count, candidate) => count + candidate.failedTasks,
+        0
+      )
+
+      if (failedTasks > 0) {
+        return yield* fail('ecs-rollout', `ECS rollout recorded ${failedTasks} failed task(s)`)
+      }
+
+      const isStable =
+        service.desiredCount > 0 &&
+        service.runningCount === service.desiredCount &&
+        service.pendingCount === 0 &&
+        service.deployments.length === 1 &&
+        deployment?.status === 'PRIMARY' &&
+        deployment.rolloutState === 'COMPLETED' &&
+        deployment.runningCount === service.desiredCount &&
+        deployment.pendingCount === 0
+
+      if (isStable && deployment !== undefined) return deployment.taskDefinition
+
+      lastState = `desired=${service.desiredCount}, running=${service.runningCount}, pending=${service.pendingCount}, deployments=${service.deployments.length}, rollout=${deployment?.rolloutState ?? 'unknown'}`
+      if (attempt < config.attempts) yield* port.wait(config.intervalMs)
+    }
+
+    return yield* fail(
+      'ecs-rollout',
+      `ECS did not reach steady state after ${config.attempts} attempts (${lastState})`
+    )
+  })
+
+const verifyHealthProbe = (
+  baseUrl: URL
+): Effect.Effect<number, ProductionVerificationError, ProductionVerificationPort> =>
+  Effect.gen(function* () {
+    const port = yield* ProductionVerificationPort
+    const response = yield* port.probe({ url: new URL('/health', baseUrl) })
+
+    if (response.status !== 200) {
+      return yield* fail('health-probe', `Health probe returned HTTP ${response.status}`)
+    }
+
+    yield* Schema.decodeUnknownEffect(HealthReadyResponse)(response.body).pipe(
+      Effect.mapError(
+        () =>
+          new ProductionVerificationError({
+            phase: 'health-probe',
+            summary: 'Health probe returned an invalid readiness response'
+          })
+      )
+    )
+    return response.status
+  })
+
+const verifyProfileProbe = (
+  config: ProductionVerificationConfig
+): Effect.Effect<number, ProductionVerificationError, ProductionVerificationPort> =>
+  Effect.gen(function* () {
+    const port = yield* ProductionVerificationPort
+    const response = yield* port.probe({
+      url: new URL(config.profilePath, config.baseUrl),
+      traceparent: `00-${config.traceId}-${config.parentSpanId}-01`
+    })
+
+    if (response.status !== 200) {
+      return yield* fail('profile-probe', `Profile probe returned HTTP ${response.status}`)
+    }
+
+    yield* Schema.decodeUnknownEffect(PublicProfileResponse)(response.body).pipe(
+      Effect.mapError(
+        () =>
+          new ProductionVerificationError({
+            phase: 'profile-probe',
+            summary: 'Profile probe returned an invalid public-profile response'
+          })
+      )
+    )
+    return response.status
+  })
+
+const spanHasSafeDatabaseData = (
+  span: typeof SentrySpan.Type,
+  config: ProductionVerificationConfig
+) =>
+  span.parent_span !== null &&
+  span['span.op'] === 'db.query' &&
+  span.transaction === PROFILE_TRANSACTION &&
+  span.trace === config.traceId &&
+  span.release === config.release &&
+  span.environment === config.environment &&
+  span['db.system.name'] === 'postgresql' &&
+  span['db.operation.name'] !== null &&
+  SAFE_DATABASE_OPERATION.test(span['db.operation.name']) &&
+  span['db.collection.name'] !== null &&
+  SAFE_DATABASE_COLLECTION.test(span['db.collection.name']) &&
+  span['db.query.summary'] !== null &&
+  SAFE_DATABASE_SUMMARY.test(span['db.query.summary']) &&
+  (span.description === null || SAFE_DATABASE_SUMMARY.test(span.description)) &&
+  span['db.statement'] === null &&
+  span['db.query'] === null &&
+  span['db.query.text'] === null
+
+const waitForDatabaseSpans = (
+  config: ProductionVerificationConfig
+): Effect.Effect<number, ProductionVerificationError, ProductionVerificationPort> =>
+  Effect.gen(function* () {
+    const port = yield* ProductionVerificationPort
+
+    for (let attempt = 1; attempt <= config.sentry.attempts; attempt += 1) {
+      const response = yield* port
+        .querySpans({
+          environment: config.environment,
+          operation: 'db.query',
+          release: config.release,
+          traceId: config.traceId
+        })
+        .pipe(Effect.flatMap((input) => decodeSentrySpans(input, 'sentry-ingestion')))
+
+      if (response.data.length > 0) {
+        if (!response.data.every((span) => spanHasSafeDatabaseData(span, config))) {
+          return yield* fail(
+            'sentry-privacy',
+            'Sentry returned an unparented, uncorrelated, or unsafe database span'
+          )
+        }
+        return response.data.length
+      }
+
+      if (attempt < config.sentry.attempts) yield* port.wait(config.sentry.intervalMs)
+    }
+
+    return yield* fail(
+      'sentry-ingestion',
+      `No database spans arrived for the verification trace after ${config.sentry.attempts} attempts`
+    )
+  })
+
+const verifyNoAutomaticDatabaseSpans = (
+  config: ProductionVerificationConfig
+): Effect.Effect<void, ProductionVerificationError, ProductionVerificationPort> =>
+  Effect.gen(function* () {
+    const port = yield* ProductionVerificationPort
+    const response = yield* port
+      .querySpans({
+        environment: config.environment,
+        operation: 'db',
+        release: config.release,
+        traceId: config.traceId
+      })
+      .pipe(Effect.flatMap((input) => decodeSentrySpans(input, 'sentry-privacy')))
+
+    if (response.data.length > 0) {
+      return yield* fail(
+        'sentry-privacy',
+        `Sentry returned ${response.data.length} forbidden automatic database span(s)`
+      )
+    }
+  })
+
+/**
+ * Verifies ECS steady state, functional production routes, and trace-specific
+ * Sentry database telemetry and privacy invariants.
+ */
+export const verifyProductionDeployment = (
+  config: ProductionVerificationConfig
+): Effect.Effect<
+  ProductionVerificationReport,
+  ProductionVerificationError,
+  ProductionVerificationPort
+> =>
+  Effect.gen(function* () {
+    const port = yield* ProductionVerificationPort
+    const resources = yield* port
+      .discoverEcsResources(config.app, config.stage)
+      .pipe(Effect.flatMap(parseEcsResources))
+    const taskDefinition = yield* waitForStableEcsService(resources, config.ecs)
+    const healthStatus = yield* verifyHealthProbe(config.baseUrl)
+    const profileStatus = yield* verifyProfileProbe(config)
+    const databaseSpanCount = yield* waitForDatabaseSpans(config)
+    yield* port.wait(config.sentry.intervalMs)
+    yield* verifyNoAutomaticDatabaseSpans(config)
+
+    return {
+      release: config.release,
+      clusterArn: resources.clusterArn,
+      serviceArn: resources.serviceArn,
+      taskDefinition,
+      traceId: config.traceId,
+      databaseSpanCount,
+      healthStatus,
+      profileStatus
+    }
+  })

--- a/apps/vps/src/ops/production-verification.ts
+++ b/apps/vps/src/ops/production-verification.ts
@@ -74,6 +74,7 @@ const SentrySpansResponse = Schema.Struct({
 const SAFE_DATABASE_OPERATION = /^(?:SELECT|INSERT|UPDATE|DELETE|QUERY)$/
 const SAFE_DATABASE_COLLECTION = /^(?:unknown|[A-Za-z_][\w$]*)$/
 const SAFE_DATABASE_SUMMARY = /^(?:SELECT|INSERT|UPDATE|DELETE|QUERY)(?: [A-Za-z_][\w$]*)?$/
+const REQUIRED_STABLE_SENTRY_POLLS = 3
 
 type VerificationPhase =
   | 'configuration'
@@ -433,18 +434,44 @@ const spanHasSafeDatabaseData = (span: typeof SentrySpan.Type) =>
 const validateDatabaseSpans = (
   spans: ReadonlyArray<typeof SentrySpan.Type>,
   config: ProductionVerificationConfig
-): Effect.Effect<void, ProductionVerificationError> => {
+): ProductionVerificationError | undefined => {
   if (!spans.every((span) => spanHasExpectedCorrelation(span, config))) {
-    return fail(
-      'sentry-correlation',
-      'Sentry returned a database span with missing or mismatched trace correlation'
-    )
+    return new ProductionVerificationError({
+      phase: 'sentry-correlation',
+      summary: 'Sentry returned a database span with missing or mismatched trace correlation'
+    })
   }
   if (!spans.every(spanHasSafeDatabaseData)) {
-    return fail('sentry-privacy', 'Sentry returned an automatic or privacy-unsafe database span')
+    return new ProductionVerificationError({
+      phase: 'sentry-privacy',
+      summary: 'Sentry returned an automatic or privacy-unsafe database span'
+    })
   }
-  return Effect.void
 }
+
+const databaseSpanFingerprint = (spans: ReadonlyArray<typeof SentrySpan.Type>) =>
+  JSON.stringify(
+    [...spans]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((span) => ({
+        id: span.id,
+        parentSpan: span.parent_span,
+        operation: span['span.op'],
+        description: span.description,
+        transaction: span.transaction,
+        trace: span.trace,
+        release: span.release,
+        environment: span.environment,
+        databaseSystem: span['db.system.name'],
+        databaseOperation: span['db.operation.name'],
+        databaseCollection: span['db.collection.name'],
+        databaseSummary: span['db.query.summary'],
+        instrumentation: span['gbfm.db.instrumentation'],
+        statement: span['db.statement'],
+        query: span['db.query'],
+        queryText: span['db.query.text']
+      }))
+  )
 
 const queryDatabaseSpans = (
   config: ProductionVerificationConfig,
@@ -476,10 +503,7 @@ const waitForDatabaseSpans = (
     for (let attempt = 1; attempt <= config.sentry.attempts; attempt += 1) {
       const spans = yield* queryDatabaseSpans(config, 'sentry-ingestion')
 
-      if (spans.length > 0) {
-        yield* validateDatabaseSpans(spans, config)
-        return
-      }
+      if (spans.length > 0) return
 
       if (attempt < config.sentry.attempts) yield* port.wait(config.sentry.intervalMs)
     }
@@ -494,15 +518,41 @@ const verifySettledDatabaseSpans = (
   config: ProductionVerificationConfig
 ): Effect.Effect<number, ProductionVerificationError, ProductionVerificationPort> =>
   Effect.gen(function* () {
-    const spans = yield* queryDatabaseSpans(config, 'sentry-privacy')
-    if (spans.length === 0) {
-      return yield* fail(
-        'sentry-ingestion',
-        'Database spans disappeared during the Sentry settlement interval'
-      )
+    const port = yield* ProductionVerificationPort
+    let stablePolls = 0
+    let previousFingerprint: string | undefined
+    let lastViolation: ProductionVerificationError | undefined
+
+    for (let attempt = 1; attempt <= config.sentry.attempts; attempt += 1) {
+      const spans = yield* queryDatabaseSpans(config, 'sentry-privacy')
+      const violation =
+        spans.length === 0
+          ? new ProductionVerificationError({
+              phase: 'sentry-ingestion',
+              summary: 'Database spans disappeared during Sentry ingestion settlement'
+            })
+          : validateDatabaseSpans(spans, config)
+
+      if (violation === undefined) {
+        const fingerprint = databaseSpanFingerprint(spans)
+        stablePolls = fingerprint === previousFingerprint ? stablePolls + 1 : 1
+        previousFingerprint = fingerprint
+        lastViolation = undefined
+        if (stablePolls >= REQUIRED_STABLE_SENTRY_POLLS) return spans.length
+      } else {
+        stablePolls = 0
+        previousFingerprint = undefined
+        lastViolation = violation
+      }
+
+      if (attempt < config.sentry.attempts) yield* port.wait(config.sentry.intervalMs)
     }
-    yield* validateDatabaseSpans(spans, config)
-    return spans.length
+
+    if (lastViolation !== undefined) return yield* Effect.fail(lastViolation)
+    return yield* fail(
+      'sentry-ingestion',
+      `Database spans did not converge after ${config.sentry.attempts} settlement attempts`
+    )
   })
 
 const verifyNoAutomaticDatabaseSpans = (
@@ -548,7 +598,6 @@ export const verifyProductionDeployment = (
     const healthStatus = yield* verifyHealthProbe(config.baseUrl)
     const profileStatus = yield* verifyProfileProbe(config)
     yield* waitForDatabaseSpans(config)
-    yield* port.wait(config.sentry.intervalMs)
     const databaseSpanCount = yield* verifySettledDatabaseSpans(config)
     yield* verifyNoAutomaticDatabaseSpans(config)
 

--- a/apps/vps/src/ops/production-verification.ts
+++ b/apps/vps/src/ops/production-verification.ts
@@ -143,8 +143,9 @@ export type ProductionVerificationConfig = {
     readonly intervalMs: number
   }
   readonly sentry: {
-    readonly attempts: number
+    readonly ingestionAttempts: number
     readonly intervalMs: number
+    readonly settlementAttempts: number
   }
 }
 
@@ -500,17 +501,17 @@ const waitForDatabaseSpans = (
   Effect.gen(function* () {
     const port = yield* ProductionVerificationPort
 
-    for (let attempt = 1; attempt <= config.sentry.attempts; attempt += 1) {
+    for (let attempt = 1; attempt <= config.sentry.ingestionAttempts; attempt += 1) {
       const spans = yield* queryDatabaseSpans(config, 'sentry-ingestion')
 
       if (spans.length > 0) return
 
-      if (attempt < config.sentry.attempts) yield* port.wait(config.sentry.intervalMs)
+      if (attempt < config.sentry.ingestionAttempts) yield* port.wait(config.sentry.intervalMs)
     }
 
     return yield* fail(
       'sentry-ingestion',
-      `No database spans arrived for the verification trace after ${config.sentry.attempts} attempts`
+      `No database spans arrived for the verification trace after ${config.sentry.ingestionAttempts} attempts`
     )
   })
 
@@ -523,7 +524,7 @@ const verifySettledDatabaseSpans = (
     let previousFingerprint: string | undefined
     let lastViolation: ProductionVerificationError | undefined
 
-    for (let attempt = 1; attempt <= config.sentry.attempts; attempt += 1) {
+    for (let attempt = 1; attempt <= config.sentry.settlementAttempts; attempt += 1) {
       const spans = yield* queryDatabaseSpans(config, 'sentry-privacy')
       const violation =
         spans.length === 0
@@ -545,13 +546,13 @@ const verifySettledDatabaseSpans = (
         lastViolation = violation
       }
 
-      if (attempt < config.sentry.attempts) yield* port.wait(config.sentry.intervalMs)
+      if (attempt < config.sentry.settlementAttempts) yield* port.wait(config.sentry.intervalMs)
     }
 
     if (lastViolation !== undefined) return yield* Effect.fail(lastViolation)
     return yield* fail(
       'sentry-ingestion',
-      `Database spans did not converge after ${config.sentry.attempts} settlement attempts`
+      `Database spans did not converge after ${config.sentry.settlementAttempts} settlement attempts`
     )
   })
 

--- a/apps/vps/src/ops/production-verification.ts
+++ b/apps/vps/src/ops/production-verification.ts
@@ -306,10 +306,7 @@ const waitForStableEcsService = (
       }
 
       const deployment = service.deployments[0]
-      const failedTasks = service.deployments.reduce(
-        (count, candidate) => count + candidate.failedTasks,
-        0
-      )
+      const failedTasks = deployment?.failedTasks ?? 0
 
       if (failedTasks > 0) {
         return yield* fail('ecs-rollout', `ECS rollout recorded ${failedTasks} failed task(s)`)

--- a/apps/vps/src/ops/production-verification.ts
+++ b/apps/vps/src/ops/production-verification.ts
@@ -305,7 +305,7 @@ const waitForStableEcsService = (
         return yield* fail('ecs-rollout', 'AWS returned no ECS service')
       }
 
-      const deployment = service.deployments[0]
+      const deployment = service.deployments.find((candidate) => candidate.status === 'PRIMARY')
       const failedTasks = deployment?.failedTasks ?? 0
 
       if (failedTasks > 0) {

--- a/apps/vps/src/ops/production-verification.ts
+++ b/apps/vps/src/ops/production-verification.ts
@@ -33,6 +33,21 @@ const DescribeServicesResponse = Schema.Struct({
   failures: Schema.Array(Schema.Unknown)
 })
 
+const DescribeTaskDefinitionResponse = Schema.Struct({
+  taskDefinition: Schema.Struct({
+    containerDefinitions: Schema.Array(
+      Schema.Struct({
+        environment: Schema.Array(
+          Schema.Struct({
+            name: Schema.String,
+            value: Schema.String
+          })
+        )
+      })
+    )
+  })
+})
+
 const SentrySpan = Schema.Struct({
   id: Schema.String,
   parent_span: Schema.NullOr(Schema.String),
@@ -46,6 +61,7 @@ const SentrySpan = Schema.Struct({
   'db.operation.name': Schema.NullOr(Schema.String),
   'db.collection.name': Schema.NullOr(Schema.String),
   'db.query.summary': Schema.NullOr(Schema.String),
+  'gbfm.db.instrumentation': Schema.NullOr(Schema.String),
   'db.statement': Schema.NullOr(Schema.String),
   'db.query': Schema.NullOr(Schema.String),
   'db.query.text': Schema.NullOr(Schema.String)
@@ -58,7 +74,6 @@ const SentrySpansResponse = Schema.Struct({
 const SAFE_DATABASE_OPERATION = /^(?:SELECT|INSERT|UPDATE|DELETE|QUERY)$/
 const SAFE_DATABASE_COLLECTION = /^(?:unknown|[A-Za-z_][\w$]*)$/
 const SAFE_DATABASE_SUMMARY = /^(?:SELECT|INSERT|UPDATE|DELETE|QUERY)(?: [A-Za-z_][\w$]*)?$/
-const PROFILE_TRANSACTION = 'GET /api/profile/:username'
 
 type VerificationPhase =
   | 'configuration'
@@ -67,7 +82,9 @@ type VerificationPhase =
   | 'health-probe'
   | 'profile-probe'
   | 'sentry-ingestion'
+  | 'sentry-correlation'
   | 'sentry-privacy'
+  | 'verification-timeout'
 
 type EcsResources = {
   readonly clusterArn: string
@@ -100,6 +117,14 @@ export class ProductionVerificationError extends Data.TaggedError('ProductionVer
 }> {}
 
 /**
+ * Converts a typed verifier failure into a credential-safe operator summary.
+ */
+export const summarizeProductionVerificationFailure = (error: unknown) =>
+  error instanceof ProductionVerificationError
+    ? `${error.phase}: ${error.summary}`
+    : 'configuration: unexpected production verification defect'
+
+/**
  * Runtime configuration for one production verification run.
  */
 export type ProductionVerificationConfig = {
@@ -109,6 +134,7 @@ export type ProductionVerificationConfig = {
   readonly release: string
   readonly baseUrl: URL
   readonly profilePath: string
+  readonly profileTransaction: string
   readonly traceId: string
   readonly parentSpanId: string
   readonly ecs: {
@@ -134,6 +160,9 @@ export interface ProductionVerificationPort {
   ) => Effect.Effect<unknown, ProductionVerificationError>
   readonly describeEcsService: (
     resources: EcsResources
+  ) => Effect.Effect<unknown, ProductionVerificationError>
+  readonly describeTaskDefinition: (
+    taskDefinitionArn: string
   ) => Effect.Effect<unknown, ProductionVerificationError>
   readonly probe: (
     request: ProbeRequest
@@ -187,6 +216,17 @@ const decodeEcsService = (input: unknown) =>
         new ProductionVerificationError({
           phase: 'ecs-rollout',
           summary: 'AWS returned an invalid ECS service response'
+        })
+    )
+  )
+
+const decodeTaskDefinition = (input: unknown) =>
+  Schema.decodeUnknownEffect(DescribeTaskDefinitionResponse)(input).pipe(
+    Effect.mapError(
+      () =>
+        new ProductionVerificationError({
+          phase: 'ecs-rollout',
+          summary: 'AWS returned an invalid ECS task-definition response'
         })
     )
   )
@@ -283,7 +323,7 @@ const waitForStableEcsService = (
         deployment.runningCount === service.desiredCount &&
         deployment.pendingCount === 0
 
-      if (isStable && deployment !== undefined) return deployment.taskDefinition
+      if (isStable) return deployment.taskDefinition
 
       lastState = `desired=${service.desiredCount}, running=${service.runningCount}, pending=${service.pendingCount}, deployments=${service.deployments.length}, rollout=${deployment?.rolloutState ?? 'unknown'}`
       if (attempt < config.attempts) yield* port.wait(config.intervalMs)
@@ -293,6 +333,27 @@ const waitForStableEcsService = (
       'ecs-rollout',
       `ECS did not reach steady state after ${config.attempts} attempts (${lastState})`
     )
+  })
+
+const verifyTaskDefinitionRelease = (
+  taskDefinitionArn: string,
+  release: string
+): Effect.Effect<void, ProductionVerificationError, ProductionVerificationPort> =>
+  Effect.gen(function* () {
+    const port = yield* ProductionVerificationPort
+    const response = yield* port
+      .describeTaskDefinition(taskDefinitionArn)
+      .pipe(Effect.flatMap(decodeTaskDefinition))
+    const releases = response.taskDefinition.containerDefinitions.flatMap(({ environment }) =>
+      environment.flatMap(({ name, value }) => (name === 'SENTRY_RELEASE' ? [value] : []))
+    )
+
+    if (releases.length !== 1 || releases[0] !== release) {
+      return yield* fail(
+        'ecs-rollout',
+        'The stable ECS task definition does not contain the deployed Sentry release'
+      )
+    }
   })
 
 const verifyHealthProbe = (
@@ -344,17 +405,20 @@ const verifyProfileProbe = (
     return response.status
   })
 
-const spanHasSafeDatabaseData = (
+const spanHasExpectedCorrelation = (
   span: typeof SentrySpan.Type,
   config: ProductionVerificationConfig
 ) =>
   span.parent_span !== null &&
   span['span.op'] === 'db.query' &&
-  span.transaction === PROFILE_TRANSACTION &&
+  span.transaction === config.profileTransaction &&
   span.trace === config.traceId &&
   span.release === config.release &&
-  span.environment === config.environment &&
+  span.environment === config.environment
+
+const spanHasSafeDatabaseData = (span: typeof SentrySpan.Type) =>
   span['db.system.name'] === 'postgresql' &&
+  span['gbfm.db.instrumentation'] === 'manual' &&
   span['db.operation.name'] !== null &&
   SAFE_DATABASE_OPERATION.test(span['db.operation.name']) &&
   span['db.collection.name'] !== null &&
@@ -366,30 +430,55 @@ const spanHasSafeDatabaseData = (
   span['db.query'] === null &&
   span['db.query.text'] === null
 
+const validateDatabaseSpans = (
+  spans: ReadonlyArray<typeof SentrySpan.Type>,
+  config: ProductionVerificationConfig
+): Effect.Effect<void, ProductionVerificationError> => {
+  if (!spans.every((span) => spanHasExpectedCorrelation(span, config))) {
+    return fail(
+      'sentry-correlation',
+      'Sentry returned a database span with missing or mismatched trace correlation'
+    )
+  }
+  if (!spans.every(spanHasSafeDatabaseData)) {
+    return fail('sentry-privacy', 'Sentry returned an automatic or privacy-unsafe database span')
+  }
+  return Effect.void
+}
+
+const queryDatabaseSpans = (
+  config: ProductionVerificationConfig,
+  phase: 'sentry-ingestion' | 'sentry-privacy'
+): Effect.Effect<
+  ReadonlyArray<typeof SentrySpan.Type>,
+  ProductionVerificationError,
+  ProductionVerificationPort
+> =>
+  Effect.gen(function* () {
+    const port = yield* ProductionVerificationPort
+    const response = yield* port
+      .querySpans({
+        environment: config.environment,
+        operation: 'db.query',
+        release: config.release,
+        traceId: config.traceId
+      })
+      .pipe(Effect.flatMap((input) => decodeSentrySpans(input, phase)))
+    return response.data
+  })
+
 const waitForDatabaseSpans = (
   config: ProductionVerificationConfig
-): Effect.Effect<number, ProductionVerificationError, ProductionVerificationPort> =>
+): Effect.Effect<void, ProductionVerificationError, ProductionVerificationPort> =>
   Effect.gen(function* () {
     const port = yield* ProductionVerificationPort
 
     for (let attempt = 1; attempt <= config.sentry.attempts; attempt += 1) {
-      const response = yield* port
-        .querySpans({
-          environment: config.environment,
-          operation: 'db.query',
-          release: config.release,
-          traceId: config.traceId
-        })
-        .pipe(Effect.flatMap((input) => decodeSentrySpans(input, 'sentry-ingestion')))
+      const spans = yield* queryDatabaseSpans(config, 'sentry-ingestion')
 
-      if (response.data.length > 0) {
-        if (!response.data.every((span) => spanHasSafeDatabaseData(span, config))) {
-          return yield* fail(
-            'sentry-privacy',
-            'Sentry returned an unparented, uncorrelated, or unsafe database span'
-          )
-        }
-        return response.data.length
+      if (spans.length > 0) {
+        yield* validateDatabaseSpans(spans, config)
+        return
       }
 
       if (attempt < config.sentry.attempts) yield* port.wait(config.sentry.intervalMs)
@@ -399,6 +488,21 @@ const waitForDatabaseSpans = (
       'sentry-ingestion',
       `No database spans arrived for the verification trace after ${config.sentry.attempts} attempts`
     )
+  })
+
+const verifySettledDatabaseSpans = (
+  config: ProductionVerificationConfig
+): Effect.Effect<number, ProductionVerificationError, ProductionVerificationPort> =>
+  Effect.gen(function* () {
+    const spans = yield* queryDatabaseSpans(config, 'sentry-privacy')
+    if (spans.length === 0) {
+      return yield* fail(
+        'sentry-ingestion',
+        'Database spans disappeared during the Sentry settlement interval'
+      )
+    }
+    yield* validateDatabaseSpans(spans, config)
+    return spans.length
   })
 
 const verifyNoAutomaticDatabaseSpans = (
@@ -440,10 +544,12 @@ export const verifyProductionDeployment = (
       .discoverEcsResources(config.app, config.stage)
       .pipe(Effect.flatMap(parseEcsResources))
     const taskDefinition = yield* waitForStableEcsService(resources, config.ecs)
+    yield* verifyTaskDefinitionRelease(taskDefinition, config.release)
     const healthStatus = yield* verifyHealthProbe(config.baseUrl)
     const profileStatus = yield* verifyProfileProbe(config)
-    const databaseSpanCount = yield* waitForDatabaseSpans(config)
+    yield* waitForDatabaseSpans(config)
     yield* port.wait(config.sentry.intervalMs)
+    const databaseSpanCount = yield* verifySettledDatabaseSpans(config)
     yield* verifyNoAutomaticDatabaseSpans(config)
 
     return {

--- a/docs/monitoring/production-deployment-gate.md
+++ b/docs/monitoring/production-deployment-gate.md
@@ -44,6 +44,6 @@ minute 45 seconds). The gate requires three identical, fully valid span
 snapshots before the unsanitized database-span invariant is checked. A response
 that reaches Sentry's 100-span page boundary fails closed instead of validating
 a partial result. The internal timeout is derived from those three polling
-budgets plus two minutes for AWS, HTTP, and Sentry request latency; the current
-configuration is 14 minutes 15 seconds, preserving failure reporting before the
+budgets plus five minutes for AWS, HTTP, and Sentry request latency; the current
+configuration is 17 minutes 15 seconds, preserving failure reporting before the
 workflow step's 20-minute outer timeout.

--- a/docs/monitoring/production-deployment-gate.md
+++ b/docs/monitoring/production-deployment-gate.md
@@ -38,7 +38,9 @@ as `AccessDeniedException`.
 ## Timing
 
 ECS stability is polled for up to 10 minutes. Sentry ingestion is polled for up
-to 5 minutes, followed by a settlement interval that revalidates the complete
-indexed span set before the unsanitized database-span invariant is checked. An
-18-minute internal timeout preserves the failure summary before the workflow
-step's 20-minute outer timeout.
+to 5 minutes, followed by bounded settlement polling. The gate requires three
+identical, fully valid span snapshots before the unsanitized database-span
+invariant is checked. A response that reaches Sentry's 100-span page boundary
+fails closed instead of validating a partial result. An 18-minute internal
+timeout preserves the failure summary before the workflow step's 20-minute
+outer timeout.

--- a/docs/monitoring/production-deployment-gate.md
+++ b/docs/monitoring/production-deployment-gate.md
@@ -1,0 +1,39 @@
+# Production deployment gate
+
+The `Prod Deployment` workflow verifies the deployment after SST finishes. A
+deployment is successful only when all of these checks pass:
+
+1. The SST-tagged production ECS service has one completed primary deployment,
+   its desired tasks are running, and it has no pending or failed tasks.
+2. `https://vps.goosebumps.fm/health` returns a valid ready response.
+3. A traced request to `/api/profile/guidefari` returns a valid public profile.
+4. Sentry receives parented `db.query` spans for that request's unique trace and
+   exact release.
+5. Those spans contain only normalized database metadata. Raw SQL fields,
+   unparented spans, mismatched correlation fields, and automatic `span.op:db`
+   spans fail the deployment.
+
+The gate writes its evidence or safe failure summary to the GitHub Actions step
+summary. It runs only in CI after a deployment and adds no work to production
+request handling beyond its single profile probe.
+
+## Required GitHub Actions secrets
+
+- `AWS_ROLE_ARN`: the existing production deployment role. In addition to its
+  SST deployment permissions, it must allow `tag:GetResources` and
+  `ecs:DescribeServices`.
+- `SENTRY_AUTH_TOKEN`: an `org:ci` organization token used only to publish
+  release metadata.
+- `SENTRY_OBSERVABILITY_TOKEN`: a separate personal token with only `org:read`,
+  used to query Sentry Explore spans. Do not broaden or reuse the release token.
+
+The Sentry observability token is wrapped as an Effect `Redacted` value and is
+only unwrapped while constructing the authorization header. Dependency errors
+and workflow summaries never include response bodies, command stderr, or
+credentials.
+
+## Timing
+
+ECS stability is polled for up to 10 minutes. Sentry ingestion is polled for up
+to 5 minutes, followed by a settlement interval before the automatic database
+span invariant is checked. The workflow step has a 20-minute outer timeout.

--- a/docs/monitoring/production-deployment-gate.md
+++ b/docs/monitoring/production-deployment-gate.md
@@ -4,14 +4,16 @@ The `Prod Deployment` workflow verifies the deployment after SST finishes. A
 deployment is successful only when all of these checks pass:
 
 1. The SST-tagged production ECS service has one completed primary deployment,
-   its desired tasks are running, and it has no pending or failed tasks.
+   its desired tasks are running, it has no pending or failed tasks, and its
+   task definition contains the exact `SENTRY_RELEASE` being deployed.
 2. `https://vps.goosebumps.fm/health` returns a valid ready response.
 3. A traced request to `/api/profile/guidefari` returns a valid public profile.
 4. Sentry receives parented `db.query` spans for that request's unique trace and
    exact release.
-5. Those spans contain only normalized database metadata. Raw SQL fields,
-   unparented spans, mismatched correlation fields, and automatic `span.op:db`
-   spans fail the deployment.
+5. Those spans contain the manual GBFM instrumentation marker and only
+   normalized database metadata. Raw SQL fields, unparented spans, mismatched
+   correlation fields, spans without the marker, and unsanitized
+   `span.op:db` spans fail the deployment.
 
 The gate writes its evidence or safe failure summary to the GitHub Actions step
 summary. It runs only in CI after a deployment and adds no work to production
@@ -21,7 +23,7 @@ request handling beyond its single profile probe.
 
 - `AWS_ROLE_ARN`: the existing production deployment role. In addition to its
   SST deployment permissions, it must allow `tag:GetResources` and
-  `ecs:DescribeServices`.
+  `ecs:DescribeServices` and `ecs:DescribeTaskDefinition`.
 - `SENTRY_AUTH_TOKEN`: an `org:ci` organization token used only to publish
   release metadata.
 - `SENTRY_OBSERVABILITY_TOKEN`: a separate personal token with only `org:read`,
@@ -30,10 +32,13 @@ request handling beyond its single profile probe.
 The Sentry observability token is wrapped as an Effect `Redacted` value and is
 only unwrapped while constructing the authorization header. Dependency errors
 and workflow summaries never include response bodies, command stderr, or
-credentials.
+credentials. AWS CLI failures may include only the bounded AWS error code, such
+as `AccessDeniedException`.
 
 ## Timing
 
 ECS stability is polled for up to 10 minutes. Sentry ingestion is polled for up
-to 5 minutes, followed by a settlement interval before the automatic database
-span invariant is checked. The workflow step has a 20-minute outer timeout.
+to 5 minutes, followed by a settlement interval that revalidates the complete
+indexed span set before the unsanitized database-span invariant is checked. An
+18-minute internal timeout preserves the failure summary before the workflow
+step's 20-minute outer timeout.

--- a/docs/monitoring/production-deployment-gate.md
+++ b/docs/monitoring/production-deployment-gate.md
@@ -37,10 +37,13 @@ as `AccessDeniedException`.
 
 ## Timing
 
-ECS stability is polled for up to 10 minutes. Sentry ingestion is polled for up
-to 5 minutes, followed by bounded settlement polling. The gate requires three
-identical, fully valid span snapshots before the unsanitized database-span
-invariant is checked. A response that reaches Sentry's 100-span page boundary
-fails closed instead of validating a partial result. An 18-minute internal
-timeout preserves the failure summary before the workflow step's 20-minute
-outer timeout.
+ECS stability has a 28-attempt budget (up to 6 minutes 45 seconds of polling
+sleep). Sentry ingestion has its own 16-attempt budget (up to 3 minutes 45
+seconds), followed by an independent 8-attempt settlement budget (up to 1
+minute 45 seconds). The gate requires three identical, fully valid span
+snapshots before the unsanitized database-span invariant is checked. A response
+that reaches Sentry's 100-span page boundary fails closed instead of validating
+a partial result. The internal timeout is derived from those three polling
+budgets plus two minutes for AWS, HTTP, and Sentry request latency; the current
+configuration is 14 minutes 15 seconds, preserving failure reporting before the
+workflow step's 20-minute outer timeout.

--- a/packages/api/src/profile.ts
+++ b/packages/api/src/profile.ts
@@ -65,8 +65,10 @@ export const PublicProfileResponse = Schema.Struct({
 })
 export type PublicProfileResponse = typeof PublicProfileResponse.Type
 
+export const PUBLIC_PROFILE_PATH = '/api/profile/:username'
+
 export const ProfileGroup = HttpApiGroup.make('profile').add(
-  HttpApiEndpoint.get('getPublicProfile', '/api/profile/:username', {
+  HttpApiEndpoint.get('getPublicProfile', PUBLIC_PROFILE_PATH, {
     params: { username: Schema.String },
     success: PublicProfileResponse,
     error: HttpApiError.NotFound


### PR DESCRIPTION
## What changed

- wait for the SST-tagged production ECS service to reach a single healthy completed deployment
- probe `/health` and the database-backed public profile route with a unique W3C trace
- query raw Sentry spans for that exact trace, release, and environment
- reject missing correlation, unsafe database metadata, raw SQL fields, and automatic `span.op:db` spans
- publish safe verification evidence to the GitHub Actions step summary
- document timing, failure modes, AWS permissions, and separate Sentry credentials

## Why

The database telemetry incident passed static checks because the defect lived in runtime provider composition. Deployment success also did not prove that ECS had stabilized or that the deployed release emitted privacy-safe telemetry. This adds a production contract at the point where those failures become observable.

The verifier runs only after deployment in GitHub Actions. It adds no steady-state application overhead beyond one profile probe per deployment.

## Security

`SENTRY_OBSERVABILITY_TOKEN` is a separate GitHub Actions secret with only `org:read`. The release token remains limited to `org:ci`. Runtime parsing uses Effect Schema, the token is held as an Effect `Redacted` value, and dependency bodies/stderr are not logged.

## Validation

- `bun precommit`
- 33 focused production-verification and database-telemetry tests
- full GitHub build, lint, test, and typecheck checks
- live Sentry validation against backend project `4511355794227200`
- production gate passed for release `v2.76.7` in run 30615834353

## Production proof

- [x] merge after Claude review
- [x] observe the release deployment and confirm the new gate passes
- [x] attach the workflow evidence to issue #247 and close it

Closes #247.