### PR TITLE
feat(bluesky): normalize music import signals

### DIFF
--- a/apps/vps/src/errors.ts
+++ b/apps/vps/src/errors.ts
@@ -58,6 +58,15 @@ export class CryptoError extends Data.TaggedError('CryptoError')<{
   readonly operation: 'encrypt' | 'decrypt' | 'keyResolve'
 }> {}
 
+export class BlueskyProviderError extends Data.TaggedError('BlueskyProviderError')<{
+  readonly message: string
+  readonly operation: 'resolveIdentity' | 'login'
+}> {}
+
+export class IdentityResolutionError extends Data.TaggedError('IdentityResolutionError')<{
+  readonly message: string
+}> {}
+
 export class ReminderProcessingError extends Data.TaggedError('ReminderProcessingError')<{
   readonly message: string
   readonly reminderId: string

--- a/apps/vps/src/runtime/services.ts
+++ b/apps/vps/src/runtime/services.ts
@@ -7,6 +7,7 @@ export { DatabaseService, DatabaseServiceLayer } from '@/services/database.servi
 
 import { AudioServiceLayer } from '@/services/audio.service'
 import { ConfigServiceLayer } from '@/services/config.service'
+import { BlueskyClientLayer } from '@/services/bluesky-client.service'
 import { BlueskyImportServiceLayer } from '@/services/bluesky-importer.service'
 import { CryptoServiceLayer } from '@/services/crypto.service'
 import { EmailServiceLayer } from '@/services/email.service'
@@ -38,6 +39,7 @@ const UploadAssetDepsLive = Layer.mergeAll(ConfigServiceLayer, UploadAssetServic
 
 const BaseServicesLayer = Layer.mergeAll(
   ConfigServiceLayer,
+  BlueskyClientLayer,
   BlueskyImportServiceLayer,
   CryptoServiceLayer.pipe(Layer.provide(ConfigServiceLayer)),
   DatabaseServiceLayer,

--- a/apps/vps/src/runtime/services.ts
+++ b/apps/vps/src/runtime/services.ts
@@ -7,6 +7,7 @@ export { DatabaseService, DatabaseServiceLayer } from '@/services/database.servi
 
 import { AudioServiceLayer } from '@/services/audio.service'
 import { ConfigServiceLayer } from '@/services/config.service'
+import { BlueskyImportServiceLayer } from '@/services/bluesky-importer.service'
 import { CryptoServiceLayer } from '@/services/crypto.service'
 import { EmailServiceLayer } from '@/services/email.service'
 import { FavoriteServiceLayer } from '@/services/favorite.service'
@@ -37,6 +38,7 @@ const UploadAssetDepsLive = Layer.mergeAll(ConfigServiceLayer, UploadAssetServic
 
 const BaseServicesLayer = Layer.mergeAll(
   ConfigServiceLayer,
+  BlueskyImportServiceLayer,
   CryptoServiceLayer.pipe(Layer.provide(ConfigServiceLayer)),
   DatabaseServiceLayer,
   EmailServiceLayer,

--- a/apps/vps/src/services/bluesky-client.service.test.ts
+++ b/apps/vps/src/services/bluesky-client.service.test.ts
@@ -1,0 +1,73 @@
+import { Effect, Redacted } from 'effect'
+import { describe, expect, test } from 'vitest'
+import { IdentityResolutionError } from '@/errors'
+import { makeBlueskyClient } from './bluesky-client.service'
+
+const responses = new Map<string, unknown>([
+  ['resolve', { did: 'did:plc:author' }],
+  [
+    'did',
+    {
+      service: [
+        {
+          id: '#atproto_pds',
+          type: 'AtprotoPersonalDataServer',
+          serviceEndpoint: 'https://pds.example.test'
+        }
+      ]
+    }
+  ],
+  [
+    'session',
+    {
+      did: 'did:plc:author',
+      handle: 'author.bsky.social',
+      accessJwt: 'access-token',
+      refreshJwt: 'refresh-token'
+    }
+  ]
+])
+
+const fakeFetch = async (input: string | URL, init?: RequestInit): Promise<Response> => {
+  const url = String(input)
+  if (url.includes('resolveHandle')) return Response.json(responses.get('resolve'))
+  if (url.includes('plc.directory')) return Response.json(responses.get('did'))
+  if (init?.body) expect(init.body).toContain('password')
+  return Response.json(responses.get('session'))
+}
+
+describe('BlueskyClient', () => {
+  test('resolves the PDS and verifies the login subject', async () => {
+    const result = await Effect.runPromise(
+      makeBlueskyClient(fakeFetch).login({
+        handle: 'author.bsky.social',
+        appPassword: Redacted.make('app-password')
+      })
+    )
+
+    expect(result.did).toBe('did:plc:author')
+    expect(result.serviceEndpoint).toBe('https://pds.example.test')
+    expect(Redacted.value(result.accessJwt)).toBe('access-token')
+  })
+
+  test('fails closed when the handle resolves to a different login identity', async () => {
+    const client = makeBlueskyClient(async (input, init) => {
+      const response = await fakeFetch(input, init)
+      if (String(input).includes('server.createSession')) {
+        return Response.json({
+          did: 'did:plc:someone-else',
+          handle: 'other.bsky.social',
+          accessJwt: 'access-token',
+          refreshJwt: 'refresh-token'
+        })
+      }
+      return response
+    })
+
+    await expect(
+      Effect.runPromise(
+        client.login({ handle: 'author.bsky.social', appPassword: Redacted.make('secret') })
+      )
+    ).rejects.toBeInstanceOf(IdentityResolutionError)
+  })
+})

--- a/apps/vps/src/services/bluesky-client.service.ts
+++ b/apps/vps/src/services/bluesky-client.service.ts
@@ -1,0 +1,145 @@
+import { Context, Effect, Layer, Redacted } from 'effect'
+import { z } from 'zod'
+import { BlueskyProviderError, IdentityResolutionError } from '@/errors'
+
+const handleSchema = z.string().trim().min(1).max(253)
+const resolveHandleResponse = z.object({ did: z.string().min(1) })
+const didDocument = z.object({
+  service: z.array(
+    z.object({
+      id: z.string(),
+      type: z.literal('AtprotoPersonalDataServer'),
+      serviceEndpoint: z.string().url()
+    })
+  )
+})
+const sessionResponse = z.object({
+  did: z.string().min(1),
+  handle: z.string().min(1),
+  accessJwt: z.string().min(1),
+  refreshJwt: z.string().min(1)
+})
+
+export type BlueskyLogin = {
+  readonly did: string
+  readonly handle: string
+  readonly serviceEndpoint: string
+  readonly accessJwt: Redacted.Redacted<string>
+  readonly refreshJwt: Redacted.Redacted<string>
+}
+
+export interface BlueskyClient {
+  readonly login: (input: {
+    readonly handle: string
+    readonly appPassword: Redacted.Redacted<string>
+  }) => Effect.Effect<BlueskyLogin, BlueskyProviderError | IdentityResolutionError>
+}
+
+export const BlueskyClient = Context.Service<BlueskyClient>('BlueskyClient')
+
+type Fetch = (input: string | URL, init?: RequestInit) => Promise<Response>
+
+const providerError = (operation: BlueskyProviderError['operation'], message: string) =>
+  new BlueskyProviderError({ operation, message })
+
+const getJson = (fetcher: Fetch, url: string, operation: BlueskyProviderError['operation']) =>
+  Effect.tryPromise({
+    try: async () => {
+      const response = await fetcher(url, { signal: AbortSignal.timeout(10_000) })
+      if (!response.ok)
+        throw providerError(operation, `Bluesky request failed (${response.status})`)
+      const payload: unknown = await response.json()
+      return payload
+    },
+    catch: (error) =>
+      error instanceof BlueskyProviderError
+        ? error
+        : providerError(operation, 'Bluesky request failed')
+  })
+
+const resolveIdentity = (fetcher: Fetch, handle: string) =>
+  Effect.gen(function* () {
+    const normalizedHandle = handleSchema.safeParse(handle)
+    if (!normalizedHandle.success) {
+      return yield* new IdentityResolutionError({ message: 'Enter a valid Bluesky handle or DID' })
+    }
+
+    const resolved = yield* getJson(
+      fetcher,
+      `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(normalizedHandle.data)}`,
+      'resolveIdentity'
+    )
+    const parsed = resolveHandleResponse.safeParse(resolved)
+    if (!parsed.success) {
+      return yield* new IdentityResolutionError({
+        message: 'Bluesky did not return a valid identity'
+      })
+    }
+
+    const didResponse = yield* Effect.tryPromise({
+      try: async () => {
+        const response = await fetcher(
+          `https://plc.directory/${encodeURIComponent(parsed.data.did)}`,
+          {
+            signal: AbortSignal.timeout(10_000)
+          }
+        )
+        if (!response.ok) throw new Error('DID document unavailable')
+        const payload: unknown = await response.json()
+        return payload
+      },
+      catch: () => new IdentityResolutionError({ message: 'Unable to resolve Bluesky service' })
+    })
+    const document = didDocument.safeParse(didResponse)
+    const service = document.success
+      ? document.data.service.find((entry) => entry.id === '#atproto_pds')
+      : undefined
+    if (!service) {
+      return yield* new IdentityResolutionError({ message: 'Bluesky identity has no PDS' })
+    }
+
+    return { did: parsed.data.did, serviceEndpoint: service.serviceEndpoint }
+  })
+
+export const makeBlueskyClient = (fetcher: Fetch = globalThis.fetch): BlueskyClient => ({
+  login: ({ handle, appPassword }) =>
+    Effect.gen(function* () {
+      const identity = yield* resolveIdentity(fetcher, handle)
+      const response = yield* Effect.tryPromise({
+        try: async () => {
+          const result = await fetcher(
+            `${identity.serviceEndpoint}/xrpc/com.atproto.server.createSession`,
+            {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ identifier: handle, password: Redacted.value(appPassword) }),
+              signal: AbortSignal.timeout(10_000)
+            }
+          )
+          if (!result.ok) throw providerError('login', 'Bluesky rejected the app password')
+          const payload: unknown = await result.json()
+          return payload
+        },
+        catch: (error) =>
+          error instanceof BlueskyProviderError
+            ? error
+            : providerError('login', 'Unable to connect to Bluesky')
+      })
+      const session = sessionResponse.safeParse(response)
+      if (!session.success || session.data.did !== identity.did) {
+        return yield* new IdentityResolutionError({
+          message: 'Bluesky identity verification failed'
+        })
+      }
+
+      return {
+        did: session.data.did,
+        handle: session.data.handle,
+        serviceEndpoint: identity.serviceEndpoint,
+        accessJwt: Redacted.make(session.data.accessJwt),
+        refreshJwt: Redacted.make(session.data.refreshJwt)
+      }
+    })
+})
+
+export const BlueskyClientLayer = Layer.succeed(BlueskyClient, makeBlueskyClient())

--- a/apps/vps/src/services/bluesky-importer.service.test.ts
+++ b/apps/vps/src/services/bluesky-importer.service.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest'
+import { normalizeBlueskyRecord } from './bluesky-importer.service'
+
+const entry = (overrides: Record<string, unknown> = {}) => ({
+  post: {
+    uri: 'at://did:plc:author/app.bsky.feed.post/3abc',
+    cid: 'bafy-cid',
+    author: { did: 'did:plc:author', handle: 'author.bsky.social' },
+    record: {
+      text: 'listen here',
+      createdAt: '2026-01-01T12:00:00.000Z',
+      facets: [
+        {
+          index: { byteStart: 7, byteEnd: 11 },
+          features: [
+            { $type: 'app.bsky.richtext.facet#link', uri: 'https://open.spotify.com/track/123' }
+          ]
+        }
+      ]
+    }
+  },
+  ...overrides
+})
+
+describe('normalizeBlueskyRecord', () => {
+  test('extracts facet links and rewrites truncated display text', () => {
+    const result = normalizeBlueskyRecord(entry(), 'did:plc:author')
+
+    expect(result).toEqual({
+      kind: 'import',
+      record: expect.objectContaining({
+        candidateUrls: ['https://open.spotify.com/track/123'],
+        normalizedContent: 'listen https://open.spotify.com/track/123',
+        publicUrl: 'https://bsky.app/profile/did:plc:author/post/3abc'
+      })
+    })
+  })
+
+  test('accepts a linkless #gbfm post', () => {
+    const input = entry()
+    input.post.record.text = 'thread opener #gbfm'
+    input.post.record.facets = [
+      {
+        index: { byteStart: 15, byteEnd: 20 },
+        features: [
+          Object.assign({ $type: 'app.bsky.richtext.facet#tag', uri: '' }, { tag: 'gbfm' })
+        ]
+      }
+    ]
+
+    const result = normalizeBlueskyRecord(input, 'did:plc:author')
+    expect(result).toMatchObject({ kind: 'import', record: { candidateUrls: [], tags: ['gbfm'] } })
+  })
+
+  test('excludes reposts, other authors, and non-music links', () => {
+    expect(normalizeBlueskyRecord({ ...entry(), reason: {} }, 'did:plc:author')).toEqual({
+      kind: 'skip',
+      reason: 'repost'
+    })
+    expect(normalizeBlueskyRecord(entry(), 'did:plc:other')).toEqual({
+      kind: 'skip',
+      reason: 'different-author'
+    })
+
+    const nonMusic = entry()
+    nonMusic.post.record.facets = [
+      {
+        index: { byteStart: 0, byteEnd: 4 },
+        features: [{ $type: 'app.bsky.richtext.facet#link', uri: 'https://example.com' }]
+      }
+    ]
+    expect(normalizeBlueskyRecord(nonMusic, 'did:plc:author')).toEqual({
+      kind: 'skip',
+      reason: 'not-qualifying'
+    })
+  })
+})

--- a/apps/vps/src/services/bluesky-importer.service.test.ts
+++ b/apps/vps/src/services/bluesky-importer.service.test.ts
@@ -1,5 +1,10 @@
+import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
-import { normalizeBlueskyRecord } from './bluesky-importer.service'
+import {
+  BlueskyImportService,
+  BlueskyImportServiceLayer,
+  normalizeBlueskyRecord
+} from './bluesky-importer.service'
 
 const entry = (overrides: Record<string, unknown> = {}) => ({
   post: {
@@ -50,6 +55,24 @@ describe('normalizeBlueskyRecord', () => {
 
     const result = normalizeBlueskyRecord(input, 'did:plc:author')
     expect(result).toMatchObject({ kind: 'import', record: { candidateUrls: [], tags: ['gbfm'] } })
+  })
+
+  test('summarizes a feed through the Effect service boundary', async () => {
+    const summary = await Effect.runPromise(
+      Effect.gen(function* () {
+        const importer = yield* BlueskyImportService
+        return yield* importer.normalizeFeed(
+          [entry(), { ...entry(), reason: {} }],
+          'did:plc:author'
+        )
+      }).pipe(Effect.provide(BlueskyImportServiceLayer))
+    )
+
+    expect(summary).toMatchObject({
+      discovered: 2,
+      qualifying: 1,
+      skipped: { repost: 1 }
+    })
   })
 
   test('excludes reposts, other authors, and non-music links', () => {

--- a/apps/vps/src/services/bluesky-importer.service.ts
+++ b/apps/vps/src/services/bluesky-importer.service.ts
@@ -1,3 +1,4 @@
+import { Context, Effect, Layer } from 'effect'
 import { z } from 'zod'
 
 const musicHosts = new Set([
@@ -42,6 +43,22 @@ export type ImportedRecord = {
 }
 
 export type ImportSkipReason = 'repost' | 'different-author' | 'malformed' | 'not-qualifying'
+
+export type ImportBatchSummary = {
+  readonly discovered: number
+  readonly qualifying: number
+  readonly records: ReadonlyArray<ImportedRecord>
+  readonly skipped: Readonly<Record<ImportSkipReason, number>>
+}
+
+export interface BlueskyImportService {
+  readonly normalizeFeed: (
+    entries: ReadonlyArray<unknown>,
+    expectedAuthorDid: string
+  ) => Effect.Effect<ImportBatchSummary>
+}
+
+export const BlueskyImportService = Context.Service<BlueskyImportService>('BlueskyImportService')
 
 export type NormalizedBlueskyRecord =
   | { readonly kind: 'import'; readonly record: ImportedRecord }
@@ -169,3 +186,37 @@ export const normalizeBlueskyRecord = (
     }
   }
 }
+
+const emptySkipped = (): Record<ImportSkipReason, number> => ({
+  repost: 0,
+  'different-author': 0,
+  malformed: 0,
+  'not-qualifying': 0
+})
+
+const normalizeFeed = (
+  entries: ReadonlyArray<unknown>,
+  expectedAuthorDid: string
+): Effect.Effect<ImportBatchSummary> =>
+  Effect.forEach(entries, (entry) =>
+    Effect.sync(() => normalizeBlueskyRecord(entry, expectedAuthorDid))
+  ).pipe(
+    Effect.map((results) => {
+      const skipped = emptySkipped()
+      const records: Array<ImportedRecord> = []
+      for (const result of results) {
+        if (result.kind === 'import') records.push(result.record)
+        else skipped[result.reason] += 1
+      }
+      return {
+        discovered: entries.length,
+        qualifying: records.length,
+        records,
+        skipped
+      }
+    })
+  )
+
+export const BlueskyImportServiceLayer = Layer.succeed(BlueskyImportService, {
+  normalizeFeed
+})

--- a/apps/vps/src/services/bluesky-importer.service.ts
+++ b/apps/vps/src/services/bluesky-importer.service.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod'
+
+const musicHosts = new Set([
+  'open.spotify.com',
+  'music.apple.com',
+  'soundcloud.com',
+  'youtube.com',
+  'youtu.be',
+  'music.youtube.com',
+  'tidal.com',
+  'deezer.com',
+  'audiomack.com'
+])
+
+const stringRecord = z.record(z.string(), z.unknown())
+const feedEntrySchema = z.object({
+  post: z.object({
+    uri: z.string().min(1),
+    cid: z.string().min(1),
+    author: z.object({ did: z.string().min(1), handle: z.string().optional() }),
+    record: z.object({
+      text: z.string(),
+      createdAt: z.string().datetime({ offset: true }),
+      facets: z.array(z.unknown()).optional(),
+      embed: z.unknown().optional()
+    })
+  }),
+  reason: z.unknown().optional()
+})
+
+export type ImportedRecord = {
+  readonly atUri: string
+  readonly cid: string
+  readonly authorDid: string
+  readonly authorHandle: string
+  readonly text: string
+  readonly normalizedContent: string
+  readonly candidateUrls: ReadonlyArray<string>
+  readonly tags: ReadonlyArray<string>
+  readonly publicUrl: string
+  readonly sourceCreatedAt: Date
+}
+
+export type ImportSkipReason = 'repost' | 'different-author' | 'malformed' | 'not-qualifying'
+
+export type NormalizedBlueskyRecord =
+  | { readonly kind: 'import'; readonly record: ImportedRecord }
+  | { readonly kind: 'skip'; readonly reason: ImportSkipReason }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const getString = (value: unknown, key: string): string | undefined => {
+  if (!isRecord(value)) return undefined
+  const candidate = value[key]
+  return typeof candidate === 'string' ? candidate : undefined
+}
+
+const isLinkHost = (value: string): boolean => {
+  try {
+    const host = new URL(value).hostname.toLowerCase()
+    return musicHosts.has(host) || host.endsWith('.bandcamp.com')
+  } catch {
+    return false
+  }
+}
+
+const publicUrlFromAtUri = (atUri: string, did: string): string => {
+  const rkey = atUri.split('/').at(-1) ?? atUri
+  return `https://bsky.app/profile/${did}/post/${rkey}`
+}
+
+const replaceFacetLinks = (
+  text: string,
+  replacements: ReadonlyArray<{
+    readonly start: number
+    readonly end: number
+    readonly uri: string
+  }>
+): string => {
+  const bytes = Buffer.from(text, 'utf8')
+  return replacements
+    .toSorted((left, right) => right.start - left.start)
+    .reduce(
+      (result, replacement) =>
+        Buffer.concat([
+          result.subarray(0, replacement.start),
+          Buffer.from(replacement.uri),
+          result.subarray(replacement.end)
+        ]),
+      bytes
+    )
+    .toString('utf8')
+}
+
+const extractSignals = (record: z.infer<typeof feedEntrySchema>['post']['record']) => {
+  const urls: Array<string> = []
+  const tags: Array<string> = []
+  const replacements: Array<{ start: number; end: number; uri: string }> = []
+
+  for (const facet of record.facets ?? []) {
+    if (!isRecord(facet)) continue
+    const index = isRecord(facet.index) ? facet.index : undefined
+    const start = index?.byteStart
+    const end = index?.byteEnd
+    if (typeof start !== 'number' || typeof end !== 'number') continue
+
+    for (const feature of Array.isArray(facet.features) ? facet.features : []) {
+      const type = getString(feature, '$type')
+      if (type?.endsWith('#link')) {
+        const uri = getString(feature, 'uri')
+        if (uri) {
+          urls.push(uri)
+          replacements.push({ start, end, uri })
+        }
+      }
+      if (type?.endsWith('#tag')) {
+        const tag = getString(feature, 'tag')
+        if (tag) tags.push(tag.toLowerCase())
+      }
+    }
+  }
+
+  const embed = isRecord(record.embed) ? record.embed : undefined
+  if (
+    embed?.$type === 'app.bsky.embed.external' ||
+    embed?.$type === 'app.bsky.embed.external#view'
+  ) {
+    const external = isRecord(embed.external) ? embed.external : undefined
+    const uri = getString(external, 'uri')
+    if (uri) urls.push(uri)
+  }
+
+  return { urls: [...new Set(urls)], tags: [...new Set(tags)], replacements }
+}
+
+export const normalizeBlueskyRecord = (
+  input: unknown,
+  expectedAuthorDid: string
+): NormalizedBlueskyRecord => {
+  if (isRecord(input) && input.reason !== undefined) return { kind: 'skip', reason: 'repost' }
+
+  const parsed = feedEntrySchema.safeParse(input)
+  if (!parsed.success) return { kind: 'skip', reason: 'malformed' }
+  if (parsed.data.post.author.did !== expectedAuthorDid) {
+    return { kind: 'skip', reason: 'different-author' }
+  }
+
+  const { post } = parsed.data
+  const signals = extractSignals(post.record)
+  const candidateUrls = signals.urls.filter((url) => isLinkHost(url))
+  const qualifies =
+    candidateUrls.length > 0 || signals.tags.some((tag) => tag.replace(/^#/, '') === 'gbfm')
+  if (!qualifies) return { kind: 'skip', reason: 'not-qualifying' }
+
+  return {
+    kind: 'import',
+    record: {
+      atUri: post.uri,
+      cid: post.cid,
+      authorDid: post.author.did,
+      authorHandle: post.author.handle ?? post.author.did,
+      text: post.record.text,
+      normalizedContent: replaceFacetLinks(post.record.text, signals.replacements),
+      candidateUrls,
+      tags: signals.tags,
+      publicUrl: publicUrlFromAtUri(post.uri, post.author.did),
+      sourceCreatedAt: new Date(post.record.createdAt)
+    }
+  }
+}


### PR DESCRIPTION
Part of #250; implements the Bluesky archive qualification contract from #253 and source identity inputs from #254.

Adds runtime-validated feed normalization, authored-post filtering, facet/embed URL extraction, #gbfm fallback qualification, Bandcamp support, and normalized Markdown output.

Validation: `bun precommit`.