### PR TITLE
fix(logging): retain app logger in request fibers

### DIFF
--- a/apps/vps/src/http/routes.ts
+++ b/apps/vps/src/http/routes.ts
@@ -147,7 +147,7 @@ export const createWebHandler = (options?: {
       // Effect.logError inside health handlers must reach the app's real
       // Pino + Sentry logger, not Effect's bare default console logger --
       // otherwise a DB outage's cause is logged nowhere on-call looks.
-      Layer.provide(AppLoggerLive)
+      Layer.provideMerge(AppLoggerLive)
     )
   )
 }

--- a/apps/vps/src/runtime/services.ts
+++ b/apps/vps/src/runtime/services.ts
@@ -87,4 +87,4 @@ const ServicesLayer = Layer.mergeAll(
   BlueskySyncLive
 )
 
-export const AppLayer = ServicesLayer.pipe(Layer.provide(AppLoggerLive))
+export const AppLayer = ServicesLayer.pipe(Layer.provideMerge(AppLoggerLive))


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>