### PR TITLE
fix(bluesky): preserve imported post dates

### DIFF
--- a/apps/vps/src/services/bluesky-archive.service.ts
+++ b/apps/vps/src/services/bluesky-archive.service.ts
@@ -109,6 +109,7 @@ const makeWrite = (musicEntities: MusicEntityService, scraper: MusicLinkScraperS
               const postValues: InsertPost = {
                 content: record.normalizedContent,
                 slug: generatePostSlug(null, record.normalizedContent),
+                createdAt: record.sourceCreatedAt,
                 draft: true,
                 tags: [...record.tags],
                 type: 'micro',

--- a/apps/vps/src/services/bluesky-importer.service.test.ts
+++ b/apps/vps/src/services/bluesky-importer.service.test.ts
@@ -36,7 +36,8 @@ describe('normalizeBlueskyRecord', () => {
       record: expect.objectContaining({
         candidateUrls: ['https://open.spotify.com/track/123'],
         normalizedContent: 'listen https://open.spotify.com/track/123',
-        publicUrl: 'https://bsky.app/profile/did:plc:author/post/3abc'
+        publicUrl: 'https://bsky.app/profile/did:plc:author/post/3abc',
+        sourceCreatedAt: new Date('2026-01-01T12:00:00.000Z')
       })
     })
   })


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>