### PR TITLE
refactor(roles): share post-create role gate

### DIFF
--- a/apps/vps/src/http/post.handlers.ts
+++ b/apps/vps/src/http/post.handlers.ts
@@ -1,5 +1,6 @@
 import { Api } from '@gbfm/api/api'
 import { AuthSession } from '@gbfm/api/middleware/auth'
+import { canCreatePosts } from '@gbfm/core/roles'
 import {
   GetEditorialPostsResponse,
   GetEditorialTagsResponse,
@@ -13,8 +14,6 @@ import { dieOnDatabaseError as makeDieOnDatabaseError } from '@/http/handler-uti
 import { PostService } from '@/services/post.service'
 
 const dieOnDatabaseError = makeDieOnDatabaseError('post')
-
-const POST_CREATE_ROLES = new Set(['creator', 'editor', 'admin'])
 
 const toDateStrings = <
   T extends {
@@ -301,7 +300,7 @@ export const PostHandlersLive = HttpApiBuilder.group(Api, 'post', (handlers) =>
     .handle('createPost', ({ payload }) =>
       Effect.gen(function* () {
         const { user } = yield* AuthSession
-        if (!POST_CREATE_ROLES.has(user.role ?? '')) {
+        if (!canCreatePosts(user.role)) {
           return yield* new HttpApiError.Forbidden()
         }
 

--- a/apps/www/src/components/Layout/NavLinks.tsx
+++ b/apps/www/src/components/Layout/NavLinks.tsx
@@ -16,7 +16,7 @@ export type NavSurface = 'overlay'
 
 export type NavTier = 'primary' | 'secondary' | 'utility' | 'create'
 
-export type MinRole = 'editor' | 'admin'
+export type MinRole = 'creator' | 'editor' | 'admin'
 
 type BaseNavItem = {
   id: string

--- a/apps/www/src/components/NewTweetFab.tsx
+++ b/apps/www/src/components/NewTweetFab.tsx
@@ -1,14 +1,13 @@
+import { canCreatePosts } from '@gbfm/core/roles'
 import { Link } from '@tanstack/react-router'
 import { Pencil } from 'lucide-react'
 import { useSession } from '@/lib/auth-client'
-
-const POST_CREATE_ROLES = new Set(['creator', 'editor', 'admin'])
 
 export function NewTweetFab() {
   const { data: session } = useSession()
   const user = session?.user
 
-  if (!user || !POST_CREATE_ROLES.has(user.role ?? '')) return null
+  if (!user || !canCreatePosts(user.role)) return null
 
   return (
     <Link

--- a/apps/www/src/lib/nav-access.ts
+++ b/apps/www/src/lib/nav-access.ts
@@ -1,23 +1,8 @@
+import { hasMinRole, type Role } from '@gbfm/core/roles'
 import type { NavItem } from '@/components/Layout/NavLinks'
 
-export type Role = 'user' | 'creator' | 'editor' | 'admin'
-
-const roleRank: Record<Role, number> = {
-  user: 0,
-  creator: 1,
-  editor: 2,
-  admin: 3
-}
-
-const isRole = (value: string): value is Role => value in roleRank
-
-export function hasMinRole(
-  userRole: string | null | undefined,
-  minRole: 'editor' | 'admin'
-): boolean {
-  if (!userRole || !isRole(userRole)) return false
-  return roleRank[userRole] >= roleRank[minRole]
-}
+export { hasMinRole }
+export type { Role }
 
 type NavAccessContext = {
   isAuthenticated: boolean

--- a/apps/www/src/routes/new/-TweetCapturePage.tsx
+++ b/apps/www/src/routes/new/-TweetCapturePage.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { canCreatePosts as roleCanCreatePosts } from '@gbfm/core/roles'
 import { LINK_STATUS, type LinkStatus } from '@gbfm/core/status'
 import { normalizeSlugBase } from '@gbfm/core/utils/slug'
 import {
@@ -81,8 +82,6 @@ const entityPathByType: Record<MusicEntityType, string> = {
   track: 'tracks',
   playlist: 'playlists'
 }
-
-const POST_CREATE_ROLES = new Set(['creator', 'editor', 'admin'])
 
 function TweetComposerCard({
   title,
@@ -428,7 +427,7 @@ export function TweetCapturePage() {
   }
 
   const canSubmit = useMemo(() => Boolean(title.trim() || commentary.trim()), [title, commentary])
-  const canCreatePosts = POST_CREATE_ROLES.has(user?.role ?? '')
+  const canCreatePosts = roleCanCreatePosts(user?.role)
   const isOwnPost = Boolean(existingPost?.creators?.some((creator) => creator.id === user?.id))
   const canAccess = Boolean(
     user && (isEditMode ? user.role === 'admin' || isOwnPost : canCreatePosts)

--- a/apps/www/src/routes/new/tweet.tsx
+++ b/apps/www/src/routes/new/tweet.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { canCreatePosts } from '@gbfm/core/roles'
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { z } from 'zod'
 import { signInRedirect } from '@/lib/route-guards'
@@ -9,14 +10,12 @@ const searchSchema = z.object({
   edit: z.string().optional()
 })
 
-const POST_CREATE_ROLES = new Set(['creator', 'editor', 'admin'])
-
 export const Route = createFileRoute('/new/tweet')({
   beforeLoad: ({ context, location }) => {
     if (!context.auth.isAuthenticated) {
       throw signInRedirect(location.href)
     }
-    if (!POST_CREATE_ROLES.has(context.auth.user?.role ?? '')) {
+    if (!canCreatePosts(context.auth.user?.role)) {
       throw redirect({ to: '/' })
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
     "./api": "./src/api/index.ts",
     "./feature-flags": "./src/feature-flags/index.ts",
     "./observability/trace-sampling": "./src/observability/trace-sampling.ts",
+    "./roles": "./src/roles/index.ts",
     "./status": "./src/status/index.ts"
   },
   "scripts": {

--- a/packages/core/src/roles/index.ts
+++ b/packages/core/src/roles/index.ts
@@ -1,0 +1,20 @@
+export const ROLES = ['user', 'creator', 'editor', 'admin'] as const
+
+export type Role = (typeof ROLES)[number]
+
+const roleRank: Record<Role, number> = {
+  user: 0,
+  creator: 1,
+  editor: 2,
+  admin: 3
+}
+
+export const isRole = (value: string): value is Role => value in roleRank
+
+export function hasMinRole(userRole: string | null | undefined, minRole: Role): boolean {
+  if (!userRole || !isRole(userRole)) return false
+  return roleRank[userRole] >= roleRank[minRole]
+}
+
+export const canCreatePosts = (userRole: string | null | undefined): boolean =>
+  hasMinRole(userRole, 'creator')

--- a/packages/core/src/roles/roles.test.ts
+++ b/packages/core/src/roles/roles.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { canCreatePosts, hasMinRole } from './index'
+
+describe('hasMinRole', () => {
+  it('ranks roles from user up to admin', () => {
+    expect(hasMinRole('admin', 'editor')).toBe(true)
+    expect(hasMinRole('editor', 'editor')).toBe(true)
+    expect(hasMinRole('creator', 'editor')).toBe(false)
+    expect(hasMinRole('user', 'creator')).toBe(false)
+  })
+
+  it('treats missing and unknown roles as no access', () => {
+    expect(hasMinRole(null, 'creator')).toBe(false)
+    expect(hasMinRole(undefined, 'creator')).toBe(false)
+    expect(hasMinRole('', 'creator')).toBe(false)
+    expect(hasMinRole('superuser', 'creator')).toBe(false)
+  })
+})
+
+describe('canCreatePosts', () => {
+  it('admits exactly the roles the old POST_CREATE_ROLES set admitted', () => {
+    expect(canCreatePosts('creator')).toBe(true)
+    expect(canCreatePosts('editor')).toBe(true)
+    expect(canCreatePosts('admin')).toBe(true)
+    expect(canCreatePosts('user')).toBe(false)
+    expect(canCreatePosts(null)).toBe(false)
+  })
+})


### PR DESCRIPTION
`POST_CREATE_ROLES = new Set(['creator', 'editor', 'admin'])` was copy-pasted in four files (`post.handlers.ts`, `NewTweetFab.tsx`, `new/tweet.tsx`, `-TweetCapturePage.tsx`). Any change to who may create posts meant editing all four and hoping none were missed.

Moves the role hierarchy into `@gbfm/core/roles` so www and vps read one definition, and widens nav `MinRole` to allow creator-tier items (it previously only accepted `'editor' | 'admin'`).

## Behavior

No change. `canCreatePosts` is `hasMinRole(role, 'creator')`, which admits exactly `creator`/`editor`/`admin` and rejects `user`, missing, and unknown roles -- identical to the old `Set`. `packages/core/src/roles/roles.test.ts` pins that equivalence explicitly.

## Note

`ac`/`auth-permissions.ts` permission statements remain dead code -- all real enforcement is still `role === 'admin'` string comparison or this gate. Not touched here.

## Verification

- `packages/core`: 27 tests passing
- `apps/vps`: 356 tests passing
- `bun precommit` clean; `apps/www` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeWFZoUqVfxsAaJ12D93dA