### PR TITLE
fix(bluesky): require post-create role to import

### DIFF
--- a/apps/vps/src/http/bluesky.handlers.ts
+++ b/apps/vps/src/http/bluesky.handlers.ts
@@ -1,5 +1,6 @@
 import { Api } from '@gbfm/api/api'
 import { AuthSession } from '@gbfm/api/middleware/auth'
+import { canCreatePosts } from '@gbfm/core/roles'
 import { Effect, Redacted } from 'effect'
 import { HttpApiBuilder, HttpApiError } from 'effect/unstable/httpapi'
 import { dieOnDatabaseError as makeDieOnDatabaseError } from '@/http/handler-utils'
@@ -33,6 +34,9 @@ export const BlueskyHandlersLive = HttpApiBuilder.group(Api, 'bluesky', (handler
     .handle('connectBluesky', ({ payload }) =>
       Effect.gen(function* () {
         const { user } = yield* AuthSession
+        if (!canCreatePosts(user.role)) {
+          return yield* new HttpApiError.Forbidden()
+        }
         const service = yield* BlueskyAccountService
         const account = yield* dieOnDatabaseError(
           service
@@ -56,6 +60,9 @@ export const BlueskyHandlersLive = HttpApiBuilder.group(Api, 'bluesky', (handler
     .handle('syncBluesky', ({ params }) =>
       Effect.gen(function* () {
         const { user } = yield* AuthSession
+        if (!canCreatePosts(user.role)) {
+          return yield* new HttpApiError.Forbidden()
+        }
         const service = yield* BlueskySyncService
         const handle = yield* dieOnDatabaseError(
           service.start({ userId: user.id, accountId: params.id }).pipe(

--- a/packages/api/src/bluesky.ts
+++ b/packages/api/src/bluesky.ts
@@ -36,7 +36,7 @@ export const BlueskyGroup = HttpApiGroup.make('bluesky')
     HttpApiEndpoint.post('connectBluesky', '/api/integrations/bluesky', {
       payload: ConnectBlueskyInput,
       success: BlueskyAccount,
-      error: HttpApiError.BadRequest
+      error: [HttpApiError.BadRequest, HttpApiError.Forbidden]
     }).middleware(AuthMiddleware)
   )
   .add(
@@ -48,7 +48,7 @@ export const BlueskyGroup = HttpApiGroup.make('bluesky')
     HttpApiEndpoint.post('syncBluesky', '/api/integrations/bluesky/:id/sync', {
       params: { id: Uuid },
       success: SyncRunAccepted,
-      error: [HttpApiError.BadRequest, HttpApiError.NotFound]
+      error: [HttpApiError.BadRequest, HttpApiError.Forbidden, HttpApiError.NotFound]
     }).middleware(AuthMiddleware)
   )
   .add(


### PR DESCRIPTION
`connectBluesky` and `syncBluesky` required only a valid session, but the archive writer inserts posts directly via `db.insert` (`bluesky-archive.service.ts`), never passing through `createPost`'s `POST_CREATE_ROLES` check.

A plain `user`-role account could therefore create content by importing it, bypassing the role gate that governs creating it directly.

## Verified against a running server

| | before | after |
|---|---|---|
| plain user → connect | **400** (passed authz, failed on credentials) | **403** |
| plain user → sync | **404** (passed authz, account missing) | **403** |
| creator → connect | 400 | 400 (unchanged) |
| creator → sync | 404 | 404 (unchanged) |
| no session | 401 | 401 (unchanged) |

The before-column 400/404 is the tell: those responses mean the request had already cleared authorization and entered the import path.

## Scope

The hourly cron path is unaffected -- `run-bluesky-sync-task.ts` calls `BlueskySyncService.sync()` directly rather than going through HTTP, so already-connected accounts keep syncing.

## Open question

This makes connect+sync creator-only. If self-serve signups are ever meant to import their own archive, the role grant needs rethinking rather than this gate loosening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeWFZoUqVfxsAaJ12D93dA