### PR TITLE
feat(dashboard): add personal content surface

### DIFF
--- a/apps/www/src/components/Layout/NavLinks.tsx
+++ b/apps/www/src/components/Layout/NavLinks.tsx
@@ -120,6 +120,16 @@ export const navConfig: NavItem[] = [
     adminOnly: true
   },
   {
+    id: 'my-content',
+    name: 'My content',
+    slug: '/dashboard/content',
+    icon: <Newspaper className={iconSytles} />,
+    tier: 'create',
+    surfaces: ['overlay'],
+    description: 'Review and publish your mixes, editorials, and tweets.',
+    minRole: 'creator'
+  },
+  {
     id: 'create-mix',
     name: 'New mix',
     slug: '/mix-upload',

--- a/apps/www/src/components/dashboard/DashboardLayout.tsx
+++ b/apps/www/src/components/dashboard/DashboardLayout.tsx
@@ -1,5 +1,6 @@
+import { canCreatePosts } from '@gbfm/core/roles'
 import { Link, type LinkProps, useLocation } from '@tanstack/react-router'
-import { Home, Link2, Mail, Music, Palette, User as UserIcon } from 'lucide-react'
+import { FileText, Home, Link2, Mail, Music, Palette, User as UserIcon } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 import { useSession } from '@/lib/auth-client'
@@ -8,10 +9,12 @@ type DashboardTab = {
   to: LinkProps['to']
   label: string
   icon: typeof Home
+  requiresPostCreate?: boolean
 }
 
 const tabs: DashboardTab[] = [
   { to: '/dashboard', label: 'Home', icon: Home },
+  { to: '/dashboard/content', label: 'Content', icon: FileText, requiresPostCreate: true },
   { to: '/dashboard/profile', label: 'Profile', icon: UserIcon },
   { to: '/dashboard/appearance', label: 'Appearance', icon: Palette },
   { to: '/dashboard/player', label: 'Player', icon: Music },
@@ -19,14 +22,15 @@ const tabs: DashboardTab[] = [
   { to: '/dashboard/email', label: 'Email', icon: Mail }
 ]
 
-function DashboardTabs() {
+function DashboardTabs({ role }: { role: string | null | undefined }) {
   const pathname = useLocation().pathname
+  const visibleTabs = tabs.filter((tab) => !tab.requiresPostCreate || canCreatePosts(role))
 
   return (
     <nav
       aria-label='Dashboard'
       className='-mx-4 flex gap-1 overflow-x-auto border-b border-border/60 px-4 pb-px sm:mx-0 sm:px-0'>
-      {tabs.map(({ to, label, icon: Icon }) => {
+      {visibleTabs.map(({ to, label, icon: Icon }) => {
         const isActive = pathname === to
 
         return (
@@ -89,7 +93,7 @@ export function DashboardLayout({
 
   return (
     <div className='container mx-auto max-w-5xl space-y-6 px-4 py-8 font-jetbrains'>
-      <DashboardTabs />
+      <DashboardTabs role={session.user.role} />
 
       <div className='flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between'>
         <div className='max-w-3xl'>

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -53,6 +53,7 @@ import { Route as DashboardProfileRouteImport } from './routes/dashboard/profile
 import { Route as DashboardPlayerRouteImport } from './routes/dashboard/player'
 import { Route as DashboardIntegrationsRouteImport } from './routes/dashboard/integrations'
 import { Route as DashboardEmailRouteImport } from './routes/dashboard/email'
+import { Route as DashboardContentRouteImport } from './routes/dashboard/content'
 import { Route as DashboardAppearanceRouteImport } from './routes/dashboard/appearance'
 import { Route as AuthVerifyEmailRouteImport } from './routes/auth/verify-email'
 import { Route as AuthSignUpRouteImport } from './routes/auth/sign-up'
@@ -292,6 +293,11 @@ const DashboardEmailRoute = DashboardEmailRouteImport.update({
   path: '/email',
   getParentRoute: () => DashboardRoute,
 } as any)
+const DashboardContentRoute = DashboardContentRouteImport.update({
+  id: '/content',
+  path: '/content',
+  getParentRoute: () => DashboardRoute,
+} as any)
 const DashboardAppearanceRoute = DashboardAppearanceRouteImport.update({
   id: '/appearance',
   path: '/appearance',
@@ -418,6 +424,7 @@ export interface FileRoutesByFullPath {
   '/auth/sign-up': typeof AuthSignUpRoute
   '/auth/verify-email': typeof AuthVerifyEmailRoute
   '/dashboard/appearance': typeof DashboardAppearanceRoute
+  '/dashboard/content': typeof DashboardContentRoute
   '/dashboard/email': typeof DashboardEmailRoute
   '/dashboard/integrations': typeof DashboardIntegrationsRoute
   '/dashboard/player': typeof DashboardPlayerRoute
@@ -477,6 +484,7 @@ export interface FileRoutesByTo {
   '/auth/sign-up': typeof AuthSignUpRoute
   '/auth/verify-email': typeof AuthVerifyEmailRoute
   '/dashboard/appearance': typeof DashboardAppearanceRoute
+  '/dashboard/content': typeof DashboardContentRoute
   '/dashboard/email': typeof DashboardEmailRoute
   '/dashboard/integrations': typeof DashboardIntegrationsRoute
   '/dashboard/player': typeof DashboardPlayerRoute
@@ -542,6 +550,7 @@ export interface FileRoutesById {
   '/auth/sign-up': typeof AuthSignUpRoute
   '/auth/verify-email': typeof AuthVerifyEmailRoute
   '/dashboard/appearance': typeof DashboardAppearanceRoute
+  '/dashboard/content': typeof DashboardContentRoute
   '/dashboard/email': typeof DashboardEmailRoute
   '/dashboard/integrations': typeof DashboardIntegrationsRoute
   '/dashboard/player': typeof DashboardPlayerRoute
@@ -608,6 +617,7 @@ export interface FileRouteTypes {
     | '/auth/sign-up'
     | '/auth/verify-email'
     | '/dashboard/appearance'
+    | '/dashboard/content'
     | '/dashboard/email'
     | '/dashboard/integrations'
     | '/dashboard/player'
@@ -667,6 +677,7 @@ export interface FileRouteTypes {
     | '/auth/sign-up'
     | '/auth/verify-email'
     | '/dashboard/appearance'
+    | '/dashboard/content'
     | '/dashboard/email'
     | '/dashboard/integrations'
     | '/dashboard/player'
@@ -731,6 +742,7 @@ export interface FileRouteTypes {
     | '/auth/sign-up'
     | '/auth/verify-email'
     | '/dashboard/appearance'
+    | '/dashboard/content'
     | '/dashboard/email'
     | '/dashboard/integrations'
     | '/dashboard/player'
@@ -1120,6 +1132,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardEmailRouteImport
       parentRoute: typeof DashboardRoute
     }
+    '/dashboard/content': {
+      id: '/dashboard/content'
+      path: '/content'
+      fullPath: '/dashboard/content'
+      preLoaderRoute: typeof DashboardContentRouteImport
+      parentRoute: typeof DashboardRoute
+    }
     '/dashboard/appearance': {
       id: '/dashboard/appearance'
       path: '/appearance'
@@ -1323,6 +1342,7 @@ const TweetRouteRouteWithChildren = TweetRouteRoute._addFileChildren(
 
 interface DashboardRouteChildren {
   DashboardAppearanceRoute: typeof DashboardAppearanceRoute
+  DashboardContentRoute: typeof DashboardContentRoute
   DashboardEmailRoute: typeof DashboardEmailRoute
   DashboardIntegrationsRoute: typeof DashboardIntegrationsRoute
   DashboardPlayerRoute: typeof DashboardPlayerRoute
@@ -1332,6 +1352,7 @@ interface DashboardRouteChildren {
 
 const DashboardRouteChildren: DashboardRouteChildren = {
   DashboardAppearanceRoute: DashboardAppearanceRoute,
+  DashboardContentRoute: DashboardContentRoute,
   DashboardEmailRoute: DashboardEmailRoute,
   DashboardIntegrationsRoute: DashboardIntegrationsRoute,
   DashboardPlayerRoute: DashboardPlayerRoute,

--- a/apps/www/src/routes/dashboard/content.tsx
+++ b/apps/www/src/routes/dashboard/content.tsx
@@ -1,0 +1,27 @@
+import { canCreatePosts } from '@gbfm/core/roles'
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { ContentManager } from '@/components/content/ContentManager'
+import { DashboardLayout } from '@/components/dashboard/DashboardLayout'
+import { signInRedirect } from '@/lib/route-guards'
+
+export const Route = createFileRoute('/dashboard/content')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.isAuthenticated) {
+      throw signInRedirect(location.href)
+    }
+    if (!canCreatePosts(context.auth.user?.role)) {
+      throw redirect({ to: '/dashboard' })
+    }
+  },
+  component: DashboardContent
+})
+
+function DashboardContent() {
+  return (
+    <DashboardLayout
+      title='Content'
+      description='Your mixes, editorials, and tweets. Drafts stay private until you publish them.'>
+      <ContentManager scope='mine' />
+    </DashboardLayout>
+  )
+}


### PR DESCRIPTION
Bluesky imports land as drafts owned by the importer, but the only place to review them was `/admin/content` behind `role === 'admin'`. The feature read as admin-only even though the backend was built ownership-scoped from day one.

`getPostsForEdit` already takes `AuthMiddleware` rather than `requireAdmin`, and `PostService.getAllForEdit` scopes by actor (`post.service.ts:360-366`): admin sees everything, everyone else sees `postIdsForCreator(userId)`. So this is a frontend change — no new endpoint, no query change.

## What this adds

- `/dashboard/content` rendering `ContentManager` with `scope='mine'`
- A **Content** tab in the dashboard nav, filtered out below creator
- A **My content** entry in the global create menu

## Access

Creator and above, enforced in two places:
- `beforeLoad` redirects — unauthenticated to sign-in, under-privileged to `/dashboard`
- the tab is not rendered at all for lower roles

Server-side scoping is unchanged and remains the real boundary.

## Verified in-browser

| role | result |
|---|---|
| admin | page renders, **Created By** correctly absent (that's `scope='mine'`) |
| user | redirected `/dashboard/content` → `/dashboard`, Content tab absent from nav |

Both checked against a real signed-in session, not a mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeWFZoUqVfxsAaJ12D93dA