### PR TITLE
feat(bluesky): expose sync runs and source status

### DIFF
--- a/apps/vps/src/db/external-account.schema.ts
+++ b/apps/vps/src/db/external-account.schema.ts
@@ -219,3 +219,5 @@ export type SelectExternalAccountSession = InferSelectModel<typeof externalAccou
 export type InsertExternalAccountSession = InferInsertModel<typeof externalAccountSessions>
 export type SelectBlueskyPostSource = InferSelectModel<typeof blueskyPostSources>
 export type InsertBlueskyPostSource = InferInsertModel<typeof blueskyPostSources>
+export type SelectBlueskySyncRun = InferSelectModel<typeof blueskySyncRuns>
+export type BlueskySourceStatus = SelectBlueskyPostSource['sourceStatus']

--- a/apps/vps/src/http/bluesky.handlers.ts
+++ b/apps/vps/src/http/bluesky.handlers.ts
@@ -3,11 +3,74 @@ import { AuthSession } from '@gbfm/api/middleware/auth'
 import { canCreatePosts } from '@gbfm/core/roles'
 import { Effect, Redacted } from 'effect'
 import { HttpApiBuilder, HttpApiError } from 'effect/unstable/httpapi'
+import type { BlueskySourceStatus } from '@/db/external-account.schema'
 import { dieOnDatabaseError as makeDieOnDatabaseError } from '@/http/handler-utils'
 import { BlueskyAccountService } from '@/services/bluesky-account.service'
+import { BlueskyRunsService, type SourceWithPost } from '@/services/bluesky-runs.service'
 import { BlueskySyncService } from '@/services/bluesky-sync.service'
 
 const dieOnDatabaseError = makeDieOnDatabaseError('bluesky')
+
+const SOURCE_STATUSES: ReadonlySet<string> = new Set([
+  'active',
+  'edited',
+  'deleted',
+  'unavailable',
+  'error',
+  'dismissed',
+  'conflict'
+])
+
+const parseStatuses = (raw: string | undefined): ReadonlyArray<BlueskySourceStatus> | undefined => {
+  if (!raw) return undefined
+  const parsed = raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value): value is BlueskySourceStatus => SOURCE_STATUSES.has(value))
+  return parsed.length > 0 ? parsed : undefined
+}
+
+const toSourceResponse = (source: SourceWithPost) => ({
+  id: source.id,
+  postId: source.postId,
+  postSlug: source.postSlug,
+  postDraft: source.postDraft,
+  authorHandle: source.authorHandle,
+  publicUrl: source.publicUrl,
+  sourceCreatedAt: source.sourceCreatedAt.toISOString(),
+  sourceStatus: source.sourceStatus,
+  sourceText: source.sourceText,
+  locallyEdited: source.locallyEdited,
+  lastError: source.lastError
+})
+
+const toRunResponse = (run: {
+  id: string
+  status: 'running' | 'succeeded' | 'failed'
+  discovered: number
+  qualifying: number
+  created: number
+  alreadyImported: number
+  conflicted: number
+  failed: number
+  pageCount: number
+  errorCategory: string | null
+  startedAt: Date
+  finishedAt: Date | null
+}) => ({
+  id: run.id,
+  status: run.status,
+  discovered: run.discovered,
+  qualifying: run.qualifying,
+  created: run.created,
+  alreadyImported: run.alreadyImported,
+  conflicted: run.conflicted,
+  failed: run.failed,
+  pageCount: run.pageCount,
+  errorCategory: run.errorCategory,
+  startedAt: run.startedAt.toISOString(),
+  finishedAt: run.finishedAt?.toISOString() ?? null
+})
 
 const toAccountResponse = (account: {
   id: string
@@ -113,6 +176,56 @@ export const BlueskyHandlersLive = HttpApiBuilder.group(Api, 'bluesky', (handler
         yield* dieOnDatabaseError(
           service
             .disconnect(user.id, params.id)
+            .pipe(Effect.catchTag('NotFoundError', () => new HttpApiError.NotFound()))
+        )
+        return { success: true as const }
+      })
+    )
+    .handle('listBlueskySyncRuns', ({ params, query }) =>
+      Effect.gen(function* () {
+        const { user } = yield* AuthSession
+        const service = yield* BlueskyRunsService
+        const runs = yield* dieOnDatabaseError(
+          service
+            .listRuns({
+              userId: user.id,
+              accountId: params.id,
+              limit: query.limit ?? 20
+            })
+            .pipe(Effect.catchTag('NotFoundError', () => new HttpApiError.NotFound()))
+        )
+        return runs.map(toRunResponse)
+      })
+    )
+    .handle('listBlueskySources', ({ params, query }) =>
+      Effect.gen(function* () {
+        const { user } = yield* AuthSession
+        const service = yield* BlueskyRunsService
+        const sources = yield* dieOnDatabaseError(
+          service
+            .listSources({
+              userId: user.id,
+              accountId: params.id,
+              statuses: parseStatuses(query.status),
+              limit: query.limit ?? 50,
+              offset: query.offset ?? 0
+            })
+            .pipe(Effect.catchTag('NotFoundError', () => new HttpApiError.NotFound()))
+        )
+        return sources.map(toSourceResponse)
+      })
+    )
+    .handle('updateBlueskySourceStatus', ({ params, payload }) =>
+      Effect.gen(function* () {
+        const { user } = yield* AuthSession
+        const service = yield* BlueskyRunsService
+        yield* dieOnDatabaseError(
+          service
+            .setSourceStatus({
+              userId: user.id,
+              sourceId: params.sourceId,
+              sourceStatus: payload.sourceStatus
+            })
             .pipe(Effect.catchTag('NotFoundError', () => new HttpApiError.NotFound()))
         )
         return { success: true as const }

--- a/apps/vps/src/runtime/services.ts
+++ b/apps/vps/src/runtime/services.ts
@@ -11,6 +11,7 @@ import { BlueskyAccountServiceLayer } from '@/services/bluesky-account.service'
 import { BlueskyArchiveServiceLayer } from '@/services/bluesky-archive.service'
 import { BlueskyClientLayer } from '@/services/bluesky-client.service'
 import { BlueskyImportServiceLayer } from '@/services/bluesky-importer.service'
+import { BlueskyRunsServiceLayer } from '@/services/bluesky-runs.service'
 import { BlueskySyncServiceLayer } from '@/services/bluesky-sync.service'
 import { LockServiceLayer } from '@/services/lock.service'
 import { CryptoServiceLayer } from '@/services/crypto.service'
@@ -84,6 +85,7 @@ const ServicesLayer = Layer.mergeAll(
   MusicEntityLive,
   BlueskyAccountServiceLayer.pipe(Layer.provide(BaseServicesLayer)),
   BlueskyArchiveLive,
+  BlueskyRunsServiceLayer,
   BlueskySyncLive
 )
 

--- a/apps/vps/src/services/bluesky-runs.service.ts
+++ b/apps/vps/src/services/bluesky-runs.service.ts
@@ -1,0 +1,142 @@
+import { and, desc, eq, inArray } from 'drizzle-orm'
+import { Context, Effect, Layer } from 'effect'
+import { db } from '@/db'
+import {
+  type BlueskySourceStatus,
+  blueskyPostSources,
+  blueskySyncRuns,
+  externalAccounts,
+  type SelectBlueskyPostSource,
+  type SelectBlueskySyncRun
+} from '@/db/external-account.schema'
+import { postsTable } from '@/db/post.schema'
+import { DatabaseError, NotFoundError } from '@/errors'
+
+export type SourceWithPost = SelectBlueskyPostSource & {
+  readonly postSlug: string | null
+  readonly postDraft: boolean | null
+}
+
+export interface BlueskyRunsService {
+  readonly listRuns: (input: {
+    readonly userId: string
+    readonly accountId: string
+    readonly limit: number
+  }) => Effect.Effect<ReadonlyArray<SelectBlueskySyncRun>, DatabaseError | NotFoundError>
+  readonly listSources: (input: {
+    readonly userId: string
+    readonly accountId: string
+    readonly statuses?: ReadonlyArray<BlueskySourceStatus>
+    readonly limit: number
+    readonly offset: number
+  }) => Effect.Effect<ReadonlyArray<SourceWithPost>, DatabaseError | NotFoundError>
+  readonly setSourceStatus: (input: {
+    readonly userId: string
+    readonly sourceId: string
+    readonly sourceStatus: BlueskySourceStatus
+  }) => Effect.Effect<void, DatabaseError | NotFoundError>
+}
+
+export const BlueskyRunsService = Context.Service<BlueskyRunsService>('BlueskyRunsService')
+
+const databaseError = (operation: string) =>
+  new DatabaseError({ message: 'Bluesky runs database operation failed', operation })
+
+// Ownership for runs and sources is only expressible through the owning
+// external account, so every read re-checks it rather than trusting the id.
+const requireOwnedAccount = (userId: string, accountId: string) =>
+  Effect.gen(function* () {
+    const rows = yield* Effect.tryPromise({
+      try: () =>
+        db
+          .select({ id: externalAccounts.id })
+          .from(externalAccounts)
+          .where(and(eq(externalAccounts.id, accountId), eq(externalAccounts.userId, userId)))
+          .limit(1),
+      catch: () => databaseError('select')
+    })
+    if (rows.length === 0) {
+      return yield* new NotFoundError({ message: 'Bluesky account not found' })
+    }
+  })
+
+const makeService = (): BlueskyRunsService => ({
+  listRuns: ({ userId, accountId, limit }) =>
+    Effect.gen(function* () {
+      yield* requireOwnedAccount(userId, accountId)
+      return yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select()
+            .from(blueskySyncRuns)
+            .where(eq(blueskySyncRuns.externalAccountId, accountId))
+            .orderBy(desc(blueskySyncRuns.startedAt))
+            .limit(limit),
+        catch: () => databaseError('select')
+      })
+    }),
+
+  listSources: ({ userId, accountId, statuses, limit, offset }) =>
+    Effect.gen(function* () {
+      yield* requireOwnedAccount(userId, accountId)
+      const statusCondition =
+        statuses && statuses.length > 0
+          ? inArray(blueskyPostSources.sourceStatus, [...statuses])
+          : undefined
+
+      return yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select({
+              source: blueskyPostSources,
+              postSlug: postsTable.slug,
+              postDraft: postsTable.draft
+            })
+            .from(blueskyPostSources)
+            .leftJoin(postsTable, eq(postsTable.id, blueskyPostSources.postId))
+            .where(and(eq(blueskyPostSources.externalAccountId, accountId), statusCondition))
+            .orderBy(desc(blueskyPostSources.sourceCreatedAt))
+            .limit(limit)
+            .offset(offset)
+            .then((rows) =>
+              rows.map((row) => ({
+                ...row.source,
+                postSlug: row.postSlug,
+                postDraft: row.postDraft
+              }))
+            ),
+        catch: () => databaseError('select')
+      })
+    }),
+
+  setSourceStatus: ({ userId, sourceId, sourceStatus }) =>
+    Effect.gen(function* () {
+      const owned = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select({ id: blueskyPostSources.id })
+            .from(blueskyPostSources)
+            .innerJoin(
+              externalAccounts,
+              eq(externalAccounts.id, blueskyPostSources.externalAccountId)
+            )
+            .where(and(eq(blueskyPostSources.id, sourceId), eq(externalAccounts.userId, userId)))
+            .limit(1),
+        catch: () => databaseError('select')
+      })
+      if (owned.length === 0) {
+        return yield* new NotFoundError({ message: 'Bluesky source not found' })
+      }
+
+      yield* Effect.tryPromise({
+        try: () =>
+          db
+            .update(blueskyPostSources)
+            .set({ sourceStatus })
+            .where(eq(blueskyPostSources.id, sourceId)),
+        catch: () => databaseError('update')
+      })
+    })
+})
+
+export const BlueskyRunsServiceLayer = Layer.succeed(BlueskyRunsService, makeService())

--- a/packages/api/src/bluesky.ts
+++ b/packages/api/src/bluesky.ts
@@ -24,6 +24,59 @@ export const SyncRunAccepted = Schema.Struct({
   status: Schema.Literal('queued')
 })
 
+export const BlueskySyncRun = Schema.Struct({
+  id: Uuid,
+  status: Schema.Literals(['running', 'succeeded', 'failed']),
+  discovered: Schema.Number,
+  qualifying: Schema.Number,
+  created: Schema.Number,
+  alreadyImported: Schema.Number,
+  conflicted: Schema.Number,
+  failed: Schema.Number,
+  pageCount: Schema.Number,
+  errorCategory: Schema.NullOr(Schema.String),
+  startedAt: Schema.String,
+  finishedAt: Schema.NullOr(Schema.String)
+})
+
+export const BlueskySourceStatus = Schema.Literals([
+  'active',
+  'edited',
+  'deleted',
+  'unavailable',
+  'error',
+  'dismissed',
+  'conflict'
+])
+
+export const BlueskyPostSource = Schema.Struct({
+  id: Uuid,
+  postId: Schema.NullOr(Uuid),
+  postSlug: Schema.NullOr(Schema.String),
+  postDraft: Schema.NullOr(Schema.Boolean),
+  authorHandle: Schema.NullOr(Schema.String),
+  publicUrl: Schema.String,
+  sourceCreatedAt: Schema.String,
+  sourceStatus: BlueskySourceStatus,
+  sourceText: Schema.NullOr(Schema.String),
+  locallyEdited: Schema.Boolean,
+  lastError: Schema.NullOr(Schema.String)
+})
+
+const ListSourcesQuery = Schema.Struct({
+  status: Schema.optional(Schema.String),
+  limit: Schema.optional(Schema.FiniteFromString),
+  offset: Schema.optional(Schema.FiniteFromString)
+})
+
+const ListRunsQuery = Schema.Struct({
+  limit: Schema.optional(Schema.FiniteFromString)
+})
+
+const UpdateSourceStatusInput = Schema.Struct({
+  sourceStatus: Schema.Literals(['dismissed', 'active'])
+})
+
 const ScheduleBlueskyInput = Schema.Struct({ scheduled: Schema.Boolean })
 
 const ConnectBlueskyInput = Schema.Struct({
@@ -65,4 +118,32 @@ export const BlueskyGroup = HttpApiGroup.make('bluesky')
       success: Schema.Struct({ success: Schema.Literal(true) }),
       error: [HttpApiError.NotFound, HttpApiError.BadRequest]
     }).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.get('listBlueskySyncRuns', '/api/integrations/bluesky/:id/runs', {
+      params: { id: Uuid },
+      query: ListRunsQuery,
+      success: Schema.Array(BlueskySyncRun),
+      error: HttpApiError.NotFound
+    }).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.get('listBlueskySources', '/api/integrations/bluesky/:id/sources', {
+      params: { id: Uuid },
+      query: ListSourcesQuery,
+      success: Schema.Array(BlueskyPostSource),
+      error: HttpApiError.NotFound
+    }).middleware(AuthMiddleware)
+  )
+  .add(
+    HttpApiEndpoint.patch(
+      'updateBlueskySourceStatus',
+      '/api/integrations/bluesky/sources/:sourceId',
+      {
+        params: { sourceId: Uuid },
+        payload: UpdateSourceStatusInput,
+        success: Schema.Struct({ success: Schema.Literal(true) }),
+        error: HttpApiError.NotFound
+      }
+    ).middleware(AuthMiddleware)
   )


### PR DESCRIPTION
`bluesky_sync_runs` and `bluesky_post_sources` have recorded every import since the feature shipped, but **no endpoint ever read them**. Conflicts and failures accumulated invisibly — there is currently no UI anywhere that can surface a conflicted import.

## Endpoints

| endpoint | purpose |
|---|---|
| `GET /api/integrations/bluesky/:id/runs` | recent sync runs with their counters |
| `GET /api/integrations/bluesky/:id/sources?status=` | post sources, filterable by status |
| `PATCH /api/integrations/bluesky/sources/:sourceId` | set source status (dismiss a conflict) |

Sources join their post to return `postSlug` and `postDraft`, so a review queue can link straight back to the draft.

## Ownership

Runs and sources have no `userId` of their own — ownership is only expressible through the owning external account, so every read re-checks it rather than trusting the id. Unowned ids return **404**, not 403, so the endpoints don't confirm that someone else's resource exists.

## Verified against a running server

- runs returns the seeded run with correct counters (created 10, alreadyImported 2, conflicted 1, pageCount 3)
- `?status=conflict` returns the conflicted source with its joined `postSlug`; `?status=deleted` returns `[]`
- dismiss returns `{success:true}` and `source_status` becomes `dismissed` in postgres
- **a second signed-in user gets 404 on all three** (read runs, read sources, dismiss)

`apps/vps`: 356 tests passing.

## Note

`unresolved` and `skipped` exist on the runs table and are deliberately **not** returned here — `bluesky-sync.service.ts` never writes them, so they are always 0. Worth either populating or dropping in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeWFZoUqVfxsAaJ12D93dA