### PR TITLE
feat(dashboard): add bluesky imports surface

### DIFF
--- a/apps/www/src/components/dashboard/DashboardLayout.tsx
+++ b/apps/www/src/components/dashboard/DashboardLayout.tsx
@@ -1,6 +1,15 @@
 import { canCreatePosts } from '@gbfm/core/roles'
 import { Link, type LinkProps, useLocation } from '@tanstack/react-router'
-import { FileText, Home, Link2, Mail, Music, Palette, User as UserIcon } from 'lucide-react'
+import {
+  DownloadCloud,
+  FileText,
+  Home,
+  Link2,
+  Mail,
+  Music,
+  Palette,
+  User as UserIcon
+} from 'lucide-react'
 import type { ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 import { useSession } from '@/lib/auth-client'
@@ -15,6 +24,7 @@ type DashboardTab = {
 const tabs: DashboardTab[] = [
   { to: '/dashboard', label: 'Home', icon: Home },
   { to: '/dashboard/content', label: 'Content', icon: FileText, requiresPostCreate: true },
+  { to: '/dashboard/imports', label: 'Imports', icon: DownloadCloud, requiresPostCreate: true },
   { to: '/dashboard/profile', label: 'Profile', icon: UserIcon },
   { to: '/dashboard/appearance', label: 'Appearance', icon: Palette },
   { to: '/dashboard/player', label: 'Player', icon: Music },

--- a/apps/www/src/components/integrations/BlueskyConnectionCard.tsx
+++ b/apps/www/src/components/integrations/BlueskyConnectionCard.tsx
@@ -1,5 +1,6 @@
 import { Button, Input } from '@gbfm/ui'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
 import { Effect } from 'effect'
 import { useEffect, useState } from 'react'
 import { BlueskyAccount as BlueskyAccountSchema } from '@gbfm/api/bluesky'
@@ -73,6 +74,7 @@ export function BlueskyConnectionCard() {
   }
   const [syncMessage, setSyncMessage] = useState<string | null>(null)
   const [syncRunId, setSyncRunId] = useState<string | null>(null)
+  const [createdCount, setCreatedCount] = useState<number | null>(null)
   const account = accounts.data?.[0]
 
   useEffect(() => {
@@ -89,6 +91,7 @@ export function BlueskyConnectionCard() {
         setSyncMessage(
           `Import complete: ${update.created} drafts created (${update.conflicted} conflicts).`
         )
+        setCreatedCount(update.created)
         queryClient.invalidateQueries({ queryKey: ['integrations', 'bluesky'] })
         events.close()
       } else if (update.status === 'failed') {
@@ -172,6 +175,11 @@ export function BlueskyConnectionCard() {
             </Button>
           </div>
           {syncMessage ? <p className='text-xs text-muted-foreground'>{syncMessage}</p> : null}
+          {createdCount && createdCount > 0 ? (
+            <Link to='/dashboard/content' className='text-xs underline'>
+              Review {createdCount} {createdCount === 1 ? 'draft' : 'drafts'} →
+            </Link>
+          ) : null}
         </div>
       ) : (
         <form

--- a/apps/www/src/components/integrations/NeedsAttentionList.tsx
+++ b/apps/www/src/components/integrations/NeedsAttentionList.tsx
@@ -1,0 +1,83 @@
+import { Badge, Button } from '@gbfm/ui'
+import { Link } from '@tanstack/react-router'
+import { ExternalLink } from 'lucide-react'
+import type { BlueskyPostSource as BlueskyPostSourceSchema } from '@gbfm/api/bluesky'
+
+type PostSource = typeof BlueskyPostSourceSchema.Type
+
+const explanation: Record<string, string> = {
+  conflict: 'Edited here and changed on Bluesky, so the import left it alone.',
+  error: 'The import could not finish this post.',
+  unavailable: 'The original post could not be read from Bluesky.'
+}
+
+export function NeedsAttentionList({
+  sources,
+  isPending,
+  dismissingId,
+  onDismiss
+}: {
+  sources: ReadonlyArray<PostSource>
+  isPending: boolean
+  dismissingId: string | null
+  onDismiss: (sourceId: string) => void
+}) {
+  if (isPending) {
+    return <p className='text-xs text-muted-foreground'>Checking for problems…</p>
+  }
+
+  if (sources.length === 0) {
+    return <p className='text-xs text-muted-foreground'>Nothing needs attention.</p>
+  }
+
+  return (
+    <ul className='space-y-3'>
+      {sources.map((source) => (
+        <li key={source.id} className='space-y-3 rounded-sm border p-4'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <Badge variant='secondary'>{source.sourceStatus}</Badge>
+            <span className='text-xs text-muted-foreground'>
+              {new Date(source.sourceCreatedAt).toLocaleDateString()}
+            </span>
+            {source.authorHandle ? (
+              <span className='text-xs text-muted-foreground'>{source.authorHandle}</span>
+            ) : null}
+          </div>
+
+          {source.sourceText ? (
+            <p className='line-clamp-3 text-sm text-foreground'>{source.sourceText}</p>
+          ) : null}
+
+          <p className='text-xs text-muted-foreground'>
+            {explanation[source.sourceStatus] ?? 'This import needs a look.'}
+          </p>
+
+          {source.lastError ? <p className='text-xs text-destructive'>{source.lastError}</p> : null}
+
+          <div className='flex flex-wrap gap-2'>
+            {source.postSlug ? (
+              <Button variant='outline' size='sm' asChild>
+                <Link to='/new/tweet' search={{ edit: source.postSlug }}>
+                  Open draft
+                </Link>
+              </Button>
+            ) : null}
+            <Button variant='outline' size='sm' asChild>
+              <a href={source.publicUrl} target='_blank' rel='noreferrer'>
+                <ExternalLink className='mr-2 size-4' />
+                View on Bluesky
+              </a>
+            </Button>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => onDismiss(source.id)}
+              disabled={dismissingId === source.id}>
+              {dismissingId === source.id ? 'Dismissing…' : 'Dismiss'}
+            </Button>
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/www/src/components/integrations/SyncRunsTable.tsx
+++ b/apps/www/src/components/integrations/SyncRunsTable.tsx
@@ -1,0 +1,70 @@
+import { Badge } from '@gbfm/ui'
+import type { BlueskySyncRun as BlueskySyncRunSchema } from '@gbfm/api/bluesky'
+
+type SyncRun = typeof BlueskySyncRunSchema.Type
+
+const statusVariant = (status: SyncRun['status']) =>
+  status === 'failed' ? 'destructive' : status === 'running' ? 'secondary' : 'default'
+
+const formatDuration = (run: SyncRun) => {
+  if (!run.finishedAt) return '—'
+  const ms = new Date(run.finishedAt).getTime() - new Date(run.startedAt).getTime()
+  if (ms < 1000) return '<1s'
+  const seconds = Math.round(ms / 1000)
+  return seconds < 60 ? `${seconds}s` : `${Math.floor(seconds / 60)}m ${seconds % 60}s`
+}
+
+export function SyncRunsTable({
+  runs,
+  isPending
+}: {
+  runs: ReadonlyArray<SyncRun>
+  isPending: boolean
+}) {
+  if (isPending) {
+    return <p className='text-xs text-muted-foreground'>Loading recent imports…</p>
+  }
+
+  if (runs.length === 0) {
+    return (
+      <p className='text-xs text-muted-foreground'>
+        No imports yet. Run a sync to pull your archive in as drafts.
+      </p>
+    )
+  }
+
+  return (
+    <div className='overflow-x-auto rounded-sm border'>
+      <table className='w-full text-base'>
+        <thead>
+          <tr className='border-b bg-muted/50'>
+            <th className='px-4 py-3 text-left font-medium'>Started</th>
+            <th className='px-4 py-3 text-left font-medium'>Status</th>
+            <th className='px-4 py-3 text-left font-medium'>Created</th>
+            <th className='px-4 py-3 text-left font-medium'>Already imported</th>
+            <th className='px-4 py-3 text-left font-medium'>Conflicts</th>
+            <th className='px-4 py-3 text-left font-medium'>Failed</th>
+            <th className='px-4 py-3 text-left font-medium'>Duration</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => (
+            <tr key={run.id} className='border-b hover:bg-muted/50'>
+              <td className='px-4 py-3 text-muted-foreground'>
+                {new Date(run.startedAt).toLocaleString()}
+              </td>
+              <td className='px-4 py-3'>
+                <Badge variant={statusVariant(run.status)}>{run.status}</Badge>
+              </td>
+              <td className='px-4 py-3 text-muted-foreground'>{run.created}</td>
+              <td className='px-4 py-3 text-muted-foreground'>{run.alreadyImported}</td>
+              <td className='px-4 py-3 text-muted-foreground'>{run.conflicted}</td>
+              <td className='px-4 py-3 text-muted-foreground'>{run.failed}</td>
+              <td className='px-4 py-3 text-muted-foreground'>{formatDuration(run)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -52,6 +52,7 @@ import { Route as EditorialSlugRouteImport } from './routes/editorial/$slug'
 import { Route as DashboardProfileRouteImport } from './routes/dashboard/profile'
 import { Route as DashboardPlayerRouteImport } from './routes/dashboard/player'
 import { Route as DashboardIntegrationsRouteImport } from './routes/dashboard/integrations'
+import { Route as DashboardImportsRouteImport } from './routes/dashboard/imports'
 import { Route as DashboardEmailRouteImport } from './routes/dashboard/email'
 import { Route as DashboardContentRouteImport } from './routes/dashboard/content'
 import { Route as DashboardAppearanceRouteImport } from './routes/dashboard/appearance'
@@ -288,6 +289,11 @@ const DashboardIntegrationsRoute = DashboardIntegrationsRouteImport.update({
   path: '/integrations',
   getParentRoute: () => DashboardRoute,
 } as any)
+const DashboardImportsRoute = DashboardImportsRouteImport.update({
+  id: '/imports',
+  path: '/imports',
+  getParentRoute: () => DashboardRoute,
+} as any)
 const DashboardEmailRoute = DashboardEmailRouteImport.update({
   id: '/email',
   path: '/email',
@@ -426,6 +432,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/appearance': typeof DashboardAppearanceRoute
   '/dashboard/content': typeof DashboardContentRoute
   '/dashboard/email': typeof DashboardEmailRoute
+  '/dashboard/imports': typeof DashboardImportsRoute
   '/dashboard/integrations': typeof DashboardIntegrationsRoute
   '/dashboard/player': typeof DashboardPlayerRoute
   '/dashboard/profile': typeof DashboardProfileRoute
@@ -486,6 +493,7 @@ export interface FileRoutesByTo {
   '/dashboard/appearance': typeof DashboardAppearanceRoute
   '/dashboard/content': typeof DashboardContentRoute
   '/dashboard/email': typeof DashboardEmailRoute
+  '/dashboard/imports': typeof DashboardImportsRoute
   '/dashboard/integrations': typeof DashboardIntegrationsRoute
   '/dashboard/player': typeof DashboardPlayerRoute
   '/dashboard/profile': typeof DashboardProfileRoute
@@ -552,6 +560,7 @@ export interface FileRoutesById {
   '/dashboard/appearance': typeof DashboardAppearanceRoute
   '/dashboard/content': typeof DashboardContentRoute
   '/dashboard/email': typeof DashboardEmailRoute
+  '/dashboard/imports': typeof DashboardImportsRoute
   '/dashboard/integrations': typeof DashboardIntegrationsRoute
   '/dashboard/player': typeof DashboardPlayerRoute
   '/dashboard/profile': typeof DashboardProfileRoute
@@ -619,6 +628,7 @@ export interface FileRouteTypes {
     | '/dashboard/appearance'
     | '/dashboard/content'
     | '/dashboard/email'
+    | '/dashboard/imports'
     | '/dashboard/integrations'
     | '/dashboard/player'
     | '/dashboard/profile'
@@ -679,6 +689,7 @@ export interface FileRouteTypes {
     | '/dashboard/appearance'
     | '/dashboard/content'
     | '/dashboard/email'
+    | '/dashboard/imports'
     | '/dashboard/integrations'
     | '/dashboard/player'
     | '/dashboard/profile'
@@ -744,6 +755,7 @@ export interface FileRouteTypes {
     | '/dashboard/appearance'
     | '/dashboard/content'
     | '/dashboard/email'
+    | '/dashboard/imports'
     | '/dashboard/integrations'
     | '/dashboard/player'
     | '/dashboard/profile'
@@ -1125,6 +1137,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardIntegrationsRouteImport
       parentRoute: typeof DashboardRoute
     }
+    '/dashboard/imports': {
+      id: '/dashboard/imports'
+      path: '/imports'
+      fullPath: '/dashboard/imports'
+      preLoaderRoute: typeof DashboardImportsRouteImport
+      parentRoute: typeof DashboardRoute
+    }
     '/dashboard/email': {
       id: '/dashboard/email'
       path: '/email'
@@ -1344,6 +1363,7 @@ interface DashboardRouteChildren {
   DashboardAppearanceRoute: typeof DashboardAppearanceRoute
   DashboardContentRoute: typeof DashboardContentRoute
   DashboardEmailRoute: typeof DashboardEmailRoute
+  DashboardImportsRoute: typeof DashboardImportsRoute
   DashboardIntegrationsRoute: typeof DashboardIntegrationsRoute
   DashboardPlayerRoute: typeof DashboardPlayerRoute
   DashboardProfileRoute: typeof DashboardProfileRoute
@@ -1354,6 +1374,7 @@ const DashboardRouteChildren: DashboardRouteChildren = {
   DashboardAppearanceRoute: DashboardAppearanceRoute,
   DashboardContentRoute: DashboardContentRoute,
   DashboardEmailRoute: DashboardEmailRoute,
+  DashboardImportsRoute: DashboardImportsRoute,
   DashboardIntegrationsRoute: DashboardIntegrationsRoute,
   DashboardPlayerRoute: DashboardPlayerRoute,
   DashboardProfileRoute: DashboardProfileRoute,

--- a/apps/www/src/routes/dashboard/imports.tsx
+++ b/apps/www/src/routes/dashboard/imports.tsx
@@ -1,0 +1,162 @@
+import type {
+  BlueskyAccount as BlueskyAccountSchema,
+  BlueskyPostSource as BlueskyPostSourceSchema,
+  BlueskySyncRun as BlueskySyncRunSchema
+} from '@gbfm/api/bluesky'
+import { canCreatePosts } from '@gbfm/core/roles'
+import { toast } from '@gbfm/ui'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { createFileRoute, Link, redirect } from '@tanstack/react-router'
+import { Effect } from 'effect'
+import { useState } from 'react'
+import { DashboardLayout } from '@/components/dashboard/DashboardLayout'
+import { BlueskyConnectionCard } from '@/components/integrations/BlueskyConnectionCard'
+import { NeedsAttentionList } from '@/components/integrations/NeedsAttentionList'
+import { SyncRunsTable } from '@/components/integrations/SyncRunsTable'
+import { getApiClient } from '@/lib/api-client'
+import { signInRedirect } from '@/lib/route-guards'
+import { captureException } from '@/services/analytics'
+
+type BlueskyAccount = typeof BlueskyAccountSchema.Type
+type SyncRun = typeof BlueskySyncRunSchema.Type
+type PostSource = typeof BlueskyPostSourceSchema.Type
+
+const ATTENTION_STATUSES = 'conflict,error,unavailable'
+
+export const Route = createFileRoute('/dashboard/imports')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.isAuthenticated) {
+      throw signInRedirect(location.href)
+    }
+    if (!canCreatePosts(context.auth.user?.role)) {
+      throw redirect({ to: '/dashboard' })
+    }
+  },
+  component: DashboardImports
+})
+
+function Section({
+  title,
+  description,
+  children
+}: {
+  title: string
+  description: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className='space-y-4'>
+      <div className='space-y-1'>
+        <h2 className='text-base font-bold tracking-widest text-muted-foreground'>{title}</h2>
+        <p className='text-xs font-medium tracking-wider text-muted-foreground'>{description}</p>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function ImportActivity({ account }: { account: BlueskyAccount }) {
+  const queryClient = useQueryClient()
+  const [dismissingId, setDismissingId] = useState<string | null>(null)
+
+  const runs = useQuery<ReadonlyArray<SyncRun>, Error>({
+    queryKey: ['integrations', 'bluesky', account.id, 'runs'],
+    queryFn: async () => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.bluesky.listBlueskySyncRuns({ params: { id: account.id }, query: { limit: 10 } })
+      )
+    }
+  })
+
+  const sources = useQuery<ReadonlyArray<PostSource>, Error>({
+    queryKey: ['integrations', 'bluesky', account.id, 'sources', ATTENTION_STATUSES],
+    queryFn: async () => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.bluesky.listBlueskySources({
+          params: { id: account.id },
+          query: { status: ATTENTION_STATUSES, limit: 50 }
+        })
+      )
+    }
+  })
+
+  const dismiss = useMutation({
+    mutationFn: async (sourceId: string) => {
+      const client = await getApiClient()
+      return Effect.runPromise(
+        client.bluesky.updateBlueskySourceStatus({
+          params: { sourceId },
+          payload: { sourceStatus: 'dismissed' }
+        })
+      )
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['integrations', 'bluesky', account.id, 'sources', ATTENTION_STATUSES]
+      })
+      toast({ title: 'Dismissed' })
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to dismiss', description: error.message, variant: 'destructive' })
+      captureException(error, { endpoint: 'bluesky.updateBlueskySourceStatus' })
+    },
+    onSettled: () => setDismissingId(null)
+  })
+
+  return (
+    <>
+      <Section title='Needs attention' description='Imports that stopped short of a clean draft.'>
+        <NeedsAttentionList
+          sources={sources.data ?? []}
+          isPending={sources.isPending}
+          dismissingId={dismissingId}
+          onDismiss={(sourceId) => {
+            setDismissingId(sourceId)
+            dismiss.mutate(sourceId)
+          }}
+        />
+      </Section>
+
+      <Section title='Recent imports' description='What each sync run pulled in.'>
+        <SyncRunsTable runs={runs.data ?? []} isPending={runs.isPending} />
+      </Section>
+    </>
+  )
+}
+
+function DashboardImports() {
+  const accounts = useQuery<ReadonlyArray<BlueskyAccount>, Error>({
+    queryKey: ['integrations', 'bluesky'],
+    queryFn: async () => {
+      const client = await getApiClient()
+      return Effect.runPromise(client.bluesky.listBlueskyAccounts())
+    }
+  })
+  const account = accounts.data?.[0]
+
+  return (
+    <DashboardLayout
+      title='Imports'
+      description='Bring your Bluesky music posts in as drafts, then review them before publishing.'>
+      <div className='space-y-12'>
+        <BlueskyConnectionCard />
+
+        {account ? (
+          <ImportActivity account={account} />
+        ) : (
+          <p className='text-xs text-muted-foreground'>
+            Connect an account above to see import history here.
+          </p>
+        )}
+
+        <Section title='Imported drafts' description='Everything imports create lands as a draft.'>
+          <Link to='/dashboard/content' className='text-sm underline'>
+            Review your drafts in Content →
+          </Link>
+        </Section>
+      </div>
+    </DashboardLayout>
+  )
+}


### PR DESCRIPTION
Imports finished into a dead end. The connection card printed "n drafts created" and stopped — nothing showed what a run actually did, and conflicts piled up with no UI at all.

## What this adds

`/dashboard/imports`, creator-gated the same way as `/dashboard/content`:

- **Bluesky connection card** (reused as-is, still mounted on `/dashboard/integrations`)
- **Needs attention** — sources in `conflict`/`error`/`unavailable`, each with a plain-language explanation, the source text, a link to the original post, **Open draft**, and **Dismiss**
- **Recent imports** — runs with created / already imported / conflicts / failed / duration
- **Post-sync handoff** — a finished sync now renders "Review n drafts →" pointing at `/dashboard/content`

Real empty states throughout, including a positive "Nothing needs attention" rather than hiding the section (its absence would itself be information).

## Verified in-browser

Against a real server with a seeded account, run, and conflicted source:

- page renders with all three sections and correct run counters (10 / 2 / 1 / 0, duration `5m 0s`)
- **Dismiss** wrote `source_status = dismissed` to postgres, the row left the list, and the empty state appeared
- zero console errors on a clean load

## Follow-ups not in this PR

- admin cross-user view of all accounts and runs (deliberately deferred)
- a music-entity repair queue — `bluesky-archive.service.ts` silently degrades unresolved links to `null`
- deleting an imported draft orphans its source row, and `at_uri` is uniquely indexed with `onConflictDoNothing`, so a resync will not recreate it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeWFZoUqVfxsAaJ12D93dA